### PR TITLE
fix(api): reject login when ACCESS_PASSWORD is unset

### DIFF
--- a/packages/api/src/v1/reactive-agents/auth.test.ts
+++ b/packages/api/src/v1/reactive-agents/auth.test.ts
@@ -44,16 +44,19 @@ describe('Auth Router', () => {
   });
 
   describe('POST /login', () => {
-    it('accepts any password when ACCESS_PASSWORD is not set', async () => {
+    it('rejects login when ACCESS_PASSWORD is not set', async () => {
       const response = await app.request('/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ password: 'anything' }),
       });
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(400);
       const data = await response.json();
-      expect(data).toEqual({ message: 'Password verified' });
+      expect(data).toEqual({
+        error:
+          'Dashboard authentication is disabled because ACCESS_PASSWORD is not configured.',
+      });
     });
 
     it('rejects wrong password when ACCESS_PASSWORD is set', async () => {

--- a/packages/api/src/v1/reactive-agents/auth/login.ts
+++ b/packages/api/src/v1/reactive-agents/auth/login.ts
@@ -13,7 +13,7 @@ const verifyPasswordSchema = z.object({
 export const loginRouter = new Hono<AppEnv>()
   /**
    * Handles the '/reactive-agents/auth/login' API request by verifying the user's password.
-   * If ACCESS_PASSWORD is not set, authentication is disabled and any request succeeds.
+   * If ACCESS_PASSWORD is not set, login is unavailable because dashboard auth is disabled.
    */
   .post(
     zValidator('json', verifyPasswordSchema),
@@ -22,10 +22,16 @@ export const loginRouter = new Hono<AppEnv>()
       const accessPassword = c.env?.ACCESS_PASSWORD;
 
       if (!accessPassword) {
-        console.warn(
-          'ACCESS_PASSWORD is not set — dashboard authentication is disabled. Any login will be accepted.',
+        return c.json(
+          {
+            error:
+              'Dashboard authentication is disabled because ACCESS_PASSWORD is not configured.',
+          },
+          400,
         );
-      } else if (password !== accessPassword) {
+      }
+
+      if (password !== accessPassword) {
         return c.json({ error: 'Invalid password' }, 401);
       }
 


### PR DESCRIPTION
## Summary

- reject /v1/reactive-agents/auth/login with status 400 when ACCESS_PASSWORD is not configured
- keep password validation behavior unchanged when ACCESS_PASSWORD is set
- update auth router tests to match the new login behavior

## Validation

- pnpm test packages/api/src/v1/reactive-agents/auth.test.ts
- pnpm typecheck
- pnpm check