### PR TITLE
fix(ci): drop stale optimize_ci job dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ on:
 jobs:
   build:
     name: Build
-    needs: optimize_ci
-    if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 15
     runs-on: ubuntu-latest
 
@@ -43,8 +41,6 @@ jobs:
 
   check:
     name: Check
-    needs: optimize_ci
-    if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 15
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` is rejected outright by GitHub, so **no job in it has been running on pushes to `main`**:

```
Invalid workflow file: .github/workflows/ci.yml#L1
(Line: 13, Col: 12): Job 'build' depends on unknown job 'optimize_ci'.
(Line: 46, Col: 12): Job 'check' depends on unknown job 'optimize_ci'.
```

`optimize_ci` was a [`withgraphite/graphite-ci-action`](https://github.com/withgraphite/graphite-ci-action) job that let Graphite skip redundant runs. Commit 8067674 ("Remove graphite config") deleted that job and stripped the matching `needs:`/`if:` lines from `typecheck` and `test` — but missed `build` and `check`. `ci-pull.yml` was cleaned correctly in the same commit, which is why only the push workflow broke.

## Solution

Remove the four leftover lines. `build` and `check` now run unconditionally, matching the other three jobs and `ci-pull.yml`.

## Test notes

No `needs:` entries remain in `ci.yml` and no `optimize_ci` references remain anywhere under `.github/`, so every job dependency resolves. GitHub parsing this workflow on the push after merge is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2QKsjv4dp8qGeETLWU1Gt