### PR TITLE
feat(api): address agents and skills through the request path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,13 @@ Key API endpoints:
 - `/v1/super-agents/evaluations` - Dataset and evaluation management
 - `/v1/super-agents/observability/logs` - Request logging
 
+The gateway endpoints (`/v1/chat/completions`, `/v1/completions`, `/v1/responses`,
+`/v1/embeddings`) are also mounted under
+`/v1/agents/:agent_name/skills/:skill_name/...`. That form names the agent and
+skill in the path instead of in the `sa-config` header, which makes the header
+optional. `commonVariablesMiddleware` merges the path names into the config (the
+path wins over the header) and route matching is done against the canonical path.
+
 **Hono Syntax**: Always use chained method syntax for proper type inference:
 ```typescript
 // Use this pattern:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,24 @@ Super Agents is a self-optimizing AI agent platform that automatically improves 
     # agent_response = response.choices[0].message.parsed
     # print("\nAgent Response:", agent_response)
     ```
-    
+
+    Alternatively, you can name the agent and the skill in the URL instead of in the `sa-config` header. Point the base URL at the skill and the rest of the request stays a plain OpenAI request:
+
+    ```python
+    client = OpenAI(
+        api_key="",
+        base_url="http://localhost:3000/v1/agents/calendar_event_planner/skills/generate",
+    )
+
+    response = client.beta.chat.completions.parse(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": user_message}],
+        response_format=CalendarEvent,
+    )
+    ```
+
+    This works for `/chat/completions`, `/completions`, `/responses` and `/embeddings`. Agent and skill names must be URL-encoded. The `sa-config` header is optional in this form, and is still the place for anything else you want to send (such as `system_prompt_variables`); if it also carries `agent_name` or `skill_name`, the URL wins.
+
 3. Navigate to the `generate` skill dashboard. When a skill is just created, you will see a "Warming up" message next to the skill name. This is normal and indicates that the skill is warming up. Send 5 requests or so to allow the agent to see the some sample messages, expected response structure, tools, etc. without you having to manually define those. The agent will create the appropriate prompts and evaluations by seeing the sample messages and expected response structure.
 
 4. After a few requests you will see the "Warming up" message disappear. Click on "Manage Evaluations" and double check that the "Task Completion" evaluation is checking for the right qualities. Make adjustments to it if needed. You can also check each log within the skill and see why a specific score was given to it. Setting up evaluations correctly **since the beginning** will allow an agent to find the most optimal configurations faster.

--- a/examples/openai-lib/chat-complete-api-path-scoped.ts
+++ b/examples/openai-lib/chat-complete-api-path-scoped.ts
@@ -1,0 +1,83 @@
+import OpenAI from 'openai';
+import 'dotenv/config';
+import logger from '@shared/console-logging';
+
+const AGENT_NAME = 'captain_code';
+const SKILL_NAME = 'programming';
+
+// The agent and the skill can be named in the base URL instead of in the
+// `sa-config` header. From there on this is a plain OpenAI client: no per
+// request headers needed.
+const client = new OpenAI({
+  // This is the API key to Super Agents
+  // You can use a custom key by setting it as the value of BEARER_TOKEN in your .env file (restart server after saving)
+  apiKey: process.env.BEARER_TOKEN ?? '',
+  baseURL: `http://localhost:3000/v1/agents/${encodeURIComponent(AGENT_NAME)}/skills/${encodeURIComponent(SKILL_NAME)}`,
+});
+
+const userMessage1 = 'Are semicolons optional in JavaScript?';
+logger.printWithHeader('User', userMessage1);
+
+const response1 = await client.chat.completions.create({
+  model: 'gpt-4o-mini', // The model value is ignored by Super Agents
+  messages: [
+    {
+      role: 'user',
+      content: userMessage1,
+    },
+  ],
+});
+
+const agentResponse1 = response1.choices[0].message.content;
+logger.printWithHeader('Agent', agentResponse1 || '');
+
+const userMessage2 = 'What about in Rust?';
+logger.printWithHeader('User', userMessage2);
+
+const response2 = await client.chat.completions.create({
+  model: 'gpt-4o-mini',
+  messages: [
+    {
+      role: 'user',
+      content: userMessage1,
+    },
+    {
+      role: 'assistant',
+      content: agentResponse1,
+    },
+    {
+      role: 'user',
+      content: userMessage2,
+    },
+  ],
+});
+
+logger.printWithHeader('Agent', response2.choices[0].message.content || '');
+
+// The `sa-config` header is still available for everything else, such as
+// system prompt variables. `agent_name` and `skill_name` in the header are
+// ignored when the URL already names them.
+const userMessage3 = 'What day is it today?';
+logger.printWithHeader('User', userMessage3);
+
+const response3 = await client
+  .withOptions({
+    defaultHeaders: {
+      'sa-config': JSON.stringify({
+        system_prompt_variables: {
+          datetime: new Date().toISOString(),
+        },
+      }),
+    },
+  })
+  .chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [
+      {
+        role: 'user',
+        content: userMessage3,
+      },
+    ],
+  });
+
+logger.printWithHeader('Agent', response3.choices[0].message.content || '');

--- a/packages/api/src/middlewares/logs.ts
+++ b/packages/api/src/middlewares/logs.ts
@@ -38,6 +38,7 @@ import type {
 } from '@shared/types/data/log';
 import type { Skill } from '@shared/types/data/skill';
 import type { EvaluationMethodName } from '@shared/types/evaluations';
+import { stripAgentSkillPath } from '@shared/utils/url';
 import type { MiddlewareHandler } from 'hono';
 import { getRuntimeKey } from 'hono/adapter';
 import type { Factory } from 'hono/factory';
@@ -622,7 +623,9 @@ export const logsMiddleware = (
 
     await next();
 
-    const url = new URL(c.req.url);
+    // Path-scoped requests are logged under their canonical endpoint so that
+    // they group with requests that named the agent and skill in the header.
+    const url = new URL(stripAgentSkillPath(c.req.url));
 
     if (!shouldLogRequest(url)) {
       return;

--- a/packages/api/src/middlewares/variables.test.ts
+++ b/packages/api/src/middlewares/variables.test.ts
@@ -1,0 +1,217 @@
+import { commonVariablesMiddleware } from '@api/middlewares/variables';
+import type { AppEnv } from '@api/types/hono';
+import { FunctionName } from '@shared/types/api/request';
+import type { SuperAgentsConfigPreProcessed } from '@shared/types/api/request/headers';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+interface EchoedRequest {
+  config: SuperAgentsConfigPreProcessed;
+  function_name: FunctionName;
+  url: string;
+}
+
+const CHAT_COMPLETION_BODY = {
+  model: 'gpt-4o-mini',
+  messages: [{ role: 'user', content: 'Hello' }],
+};
+
+const app = new Hono<AppEnv>()
+  .basePath('/v1')
+  .use('*', commonVariablesMiddleware)
+  .post('/agents/:agent_name/skills/:skill_name/chat/completions', (c) =>
+    c.json({
+      config: c.get('sa_config_pre_processed'),
+      function_name: c.get('sa_request_data').functionName,
+      url: c.get('sa_request_data').url,
+    }),
+  )
+  .post('/chat/completions', (c) =>
+    c.json({
+      config: c.get('sa_config_pre_processed'),
+      function_name: c.get('sa_request_data').functionName,
+      url: c.get('sa_request_data').url,
+    }),
+  );
+
+const post = (path: string, headers: Record<string, string> = {}) =>
+  app.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(CHAT_COMPLETION_BODY),
+  });
+
+const readBody = (response: Response) =>
+  response.json() as Promise<EchoedRequest>;
+
+describe('commonVariablesMiddleware', () => {
+  describe('agent and skill in the path', () => {
+    it('should not require the sa-config header', async () => {
+      const response = await post(
+        '/v1/agents/captain_code/skills/programming/chat/completions',
+      );
+
+      expect(response.status).toBe(200);
+      const body = await readBody(response);
+      expect(body.config.agent_name).toBe('captain_code');
+      expect(body.config.skill_name).toBe('programming');
+      expect(body.function_name).toBe(FunctionName.CHAT_COMPLETE);
+    });
+
+    it('should decode percent-encoded names', async () => {
+      const response = await post(
+        `/v1/agents/${encodeURIComponent('captain code')}/skills/${encodeURIComponent('programming basics')}/chat/completions`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await readBody(response);
+      expect(body.config.agent_name).toBe('captain code');
+      expect(body.config.skill_name).toBe('programming basics');
+    });
+
+    it('should keep the rest of the sa-config header', async () => {
+      const response = await post(
+        '/v1/agents/captain_code/skills/programming/chat/completions',
+        {
+          'sa-config': JSON.stringify({
+            agent_name: 'other_agent',
+            skill_name: 'other_skill',
+            app_id: 'my-app',
+            system_prompt_variables: { datetime: '2026-01-01T00:00:00.000Z' },
+          }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const body = await readBody(response);
+      // The path wins over the header.
+      expect(body.config.agent_name).toBe('captain_code');
+      expect(body.config.skill_name).toBe('programming');
+      expect(body.config.app_id).toBe('my-app');
+      expect(body.config.system_prompt_variables).toEqual({
+        datetime: '2026-01-01T00:00:00.000Z',
+      });
+    });
+
+    it('should default to auto optimization when no target is given', async () => {
+      const response = await post(
+        '/v1/agents/captain_code/skills/programming/chat/completions',
+      );
+
+      const body = await readBody(response);
+      expect(body.config.targets).toEqual([
+        expect.objectContaining({ optimization: 'auto' }),
+      ]);
+    });
+
+    it('should resolve the request data against the canonical route', async () => {
+      const response = await post(
+        '/v1/agents/captain_code/skills/programming/chat/completions',
+      );
+
+      const body = await readBody(response);
+      expect(new URL(body.url).pathname).toBe('/v1/chat/completions');
+    });
+  });
+
+  describe('unroutable paths', () => {
+    it('should answer 404 instead of 500 for an unknown endpoint', async () => {
+      const response = await post('/v1/nope', {
+        'sa-config': JSON.stringify({
+          agent_name: 'captain_code',
+          skill_name: 'programming',
+        }),
+      });
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        error: 'No API route matches POST /v1/nope',
+      });
+    });
+
+    it('should point at the scoped form when the skill segment is missing', async () => {
+      const response = await post('/v1/agents/captain_code/chat/completions');
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        error:
+          'No API route matches POST /v1/agents/captain_code/chat/completions',
+        hint: 'Expected /v1/agents/{agent_name}/skills/{skill_name}/{endpoint}',
+      });
+    });
+
+    it('should answer 404 before asking for the sa-config header', async () => {
+      // Without the route check this would report a missing config instead of a
+      // mistyped URL.
+      const response = await post('/v1/agents/captain_code/chat/completions', {
+        'sa-config': JSON.stringify({
+          agent_name: 'captain_code',
+          skill_name: 'programming',
+        }),
+      });
+
+      expect(response.status).toBe(404);
+    });
+
+    it('should answer 404 for an unknown endpoint under a valid scope', async () => {
+      const response = await post(
+        '/v1/agents/captain_code/skills/programming/nope',
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        error:
+          'No API route matches POST /v1/agents/captain_code/skills/programming/nope',
+      });
+    });
+
+    it('should answer 422 when the body does not fit the route schema', async () => {
+      const response = await app.request(
+        '/v1/agents/captain_code/skills/programming/chat/completions',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          // Missing the required `model` field.
+          body: JSON.stringify({ messages: [{ role: 'user', content: 'Hi' }] }),
+        },
+      );
+
+      expect(response.status).toBe(422);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toContain('Invalid request body');
+    });
+  });
+
+  describe('agent and skill in the header', () => {
+    it('should read the names from the sa-config header', async () => {
+      const response = await post('/v1/chat/completions', {
+        'sa-config': JSON.stringify({
+          agent_name: 'captain_code',
+          skill_name: 'programming',
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await readBody(response);
+      expect(body.config.agent_name).toBe('captain_code');
+      expect(body.config.skill_name).toBe('programming');
+    });
+
+    it('should reject a request without the sa-config header', async () => {
+      const response = await post('/v1/chat/completions');
+
+      expect(response.status).toBe(422);
+      expect(await response.json()).toEqual({
+        error: 'Missing Super Agents config',
+      });
+    });
+
+    it('should reject a header that is missing the skill name', async () => {
+      const response = await post('/v1/chat/completions', {
+        'sa-config': JSON.stringify({ agent_name: 'captain_code' }),
+      });
+
+      expect(response.status).toBe(422);
+    });
+  });
+});

--- a/packages/api/src/middlewares/variables.ts
+++ b/packages/api/src/middlewares/variables.ts
@@ -1,7 +1,12 @@
 import type { AppContext } from '@api/types/hono';
 import type { HttpMethod } from '@api/types/http';
 import { SuperAgentsConfigPreProcessed } from '@shared/types/api/request/headers';
-import { produceSuperAgentsRequestData } from '@shared/utils/sa-request-data';
+import {
+  InvalidRequestBodyError,
+  isKnownRoute,
+  produceSuperAgentsRequestData,
+} from '@shared/utils/sa-request-data';
+import { parseAgentSkillPath } from '@shared/utils/url';
 import type { Next } from 'hono';
 import { createMiddleware } from 'hono/factory';
 
@@ -16,14 +21,49 @@ export const commonVariablesMiddleware = createMiddleware(
     if (c.req.url.includes('/v1/')) {
       // Don't set variables for Super Agents API requests
       if (!c.req.url.includes('/v1/super-agents')) {
+        // The agent and skill can be named in the path
+        // (`/v1/agents/:agent_name/skills/:skill_name/chat/completions`) instead
+        // of in the `sa-config` header. When they are, the header is optional.
+        const { pathname } = new URL(c.req.url);
+        const agentSkillScope = parseAgentSkillPath(pathname);
+        const method = c.req.method as HttpMethod;
+
+        // Answer an unroutable path before asking for credentials or config, so
+        // a mistyped URL reads as a mistyped URL.
+        if (!isKnownRoute(method, c.req.url)) {
+          return c.json(
+            {
+              error: `No API route matches ${method} ${pathname}`,
+              // The scoped form is easy to mistype, so point at it whenever the
+              // path looks like an attempt at it.
+              ...(pathname.startsWith('/v1/agents/') && !agentSkillScope
+                ? {
+                    hint: 'Expected /v1/agents/{agent_name}/skills/{skill_name}/{endpoint}',
+                  }
+                : {}),
+            },
+            404,
+          );
+        }
+
         const configString = c.req.header('sa-config');
-        if (!configString) {
+        if (!configString && !agentSkillScope) {
           return c.json({ error: 'Missing Super Agents config' }, 422);
         }
-        const rawConfig = JSON.parse(configString);
+        const rawConfig = configString ? JSON.parse(configString) : {};
+
+        // The path always wins over the header so that a client pointed at a
+        // skill's base URL cannot accidentally target another skill.
+        const config = agentSkillScope
+          ? {
+              ...rawConfig,
+              agent_name: agentSkillScope.agent_name,
+              skill_name: agentSkillScope.skill_name,
+            }
+          : rawConfig;
 
         const saConfigPreProcessed = SuperAgentsConfigPreProcessed.safeParse(
-          rawConfig,
+          config,
           {
             error: (error) => `Invalid Super Agents config as ${error.message}`,
           },
@@ -43,13 +83,22 @@ export const commonVariablesMiddleware = createMiddleware(
 
         const body = await c.req.json();
 
-        const saRequestData = produceSuperAgentsRequestData(
-          c.req.method as HttpMethod,
-          c.req.url,
-          c.req.header(),
-          body,
-        );
-        c.set('sa_request_data', saRequestData);
+        try {
+          const saRequestData = produceSuperAgentsRequestData(
+            method,
+            c.req.url,
+            c.req.header(),
+            body,
+          );
+          c.set('sa_request_data', saRequestData);
+        } catch (err) {
+          // `isKnownRoute` ignores the body, so a route can still be ruled out
+          // here by the request's stream mode or by its schema.
+          if (err instanceof InvalidRequestBodyError) {
+            return c.json({ error: err.message }, 422);
+          }
+          throw err;
+        }
       }
     }
     await next();

--- a/packages/api/src/v1/app.ts
+++ b/packages/api/src/v1/app.ts
@@ -36,6 +36,9 @@ import { prettyJSON } from 'hono/pretty-json';
 
 const factory = createFactory<AppEnv>();
 
+/** Path prefix that scopes a gateway request to an agent and one of its skills. */
+const AGENT_SKILL_BASE_PATH = '/agents/:agent_name/skills/:skill_name';
+
 // Initialize model capabilities on server startup
 initializeModelCapabilities();
 
@@ -109,6 +112,14 @@ app.route('/chat', chatRouter);
 app.route('/completions', completionsRouter);
 app.route('/responses', responsesRouter);
 app.route('/embeddings', embeddingsRouter);
+
+// The same endpoints scoped to an agent and a skill through the path, so that
+// OpenAI-compatible clients can point their base URL at a single skill instead
+// of sending the names in the `sa-config` header.
+app.route(`${AGENT_SKILL_BASE_PATH}/chat`, chatRouter);
+app.route(`${AGENT_SKILL_BASE_PATH}/completions`, completionsRouter);
+app.route(`${AGENT_SKILL_BASE_PATH}/responses`, responsesRouter);
+app.route(`${AGENT_SKILL_BASE_PATH}/embeddings`, embeddingsRouter);
 const superAgentsRoute = app.route('/super-agents', superAgentsRouter);
 
 export type SuperAgentsRoute = typeof superAgentsRoute;

--- a/packages/api/src/v1/index.test.ts
+++ b/packages/api/src/v1/index.test.ts
@@ -19,5 +19,26 @@ describe('API v1 Index', () => {
       expect(indexModule.default).toBeDefined();
       expect(typeof indexModule.default.fetch).toBe('function');
     }, 30000);
+
+    it('should expose the agent and skill scoped endpoints', async () => {
+      const indexModule = await import('@api/v1/index');
+
+      const paths = new Set(
+        indexModule.default.routes.map((route) => route.path),
+      );
+
+      expect(paths).toContain(
+        '/v1/agents/:agent_name/skills/:skill_name/chat/completions',
+      );
+      expect(paths).toContain(
+        '/v1/agents/:agent_name/skills/:skill_name/completions',
+      );
+      expect(paths).toContain(
+        '/v1/agents/:agent_name/skills/:skill_name/responses',
+      );
+      expect(paths).toContain(
+        '/v1/agents/:agent_name/skills/:skill_name/embeddings',
+      );
+    }, 30000);
   });
 });

--- a/packages/api/src/v1/index.ts
+++ b/packages/api/src/v1/index.ts
@@ -37,6 +37,9 @@ import { prettyJSON } from 'hono/pretty-json';
 
 const factory = createFactory<AppEnv>();
 
+/** Path prefix that scopes a gateway request to an agent and one of its skills. */
+const AGENT_SKILL_BASE_PATH = '/agents/:agent_name/skills/:skill_name';
+
 // Lazy initialization of model capabilities (Cloudflare Workers can't do this at module load time)
 let modelCapabilitiesInitialized = false;
 
@@ -121,6 +124,14 @@ app.route('/chat', chatRouter);
 app.route('/completions', completionsRouter);
 app.route('/responses', responsesRouter);
 app.route('/embeddings', embeddingsRouter);
+
+// The same endpoints scoped to an agent and a skill through the path, so that
+// OpenAI-compatible clients can point their base URL at a single skill instead
+// of sending the names in the `sa-config` header.
+app.route(`${AGENT_SKILL_BASE_PATH}/chat`, chatRouter);
+app.route(`${AGENT_SKILL_BASE_PATH}/completions`, completionsRouter);
+app.route(`${AGENT_SKILL_BASE_PATH}/responses`, responsesRouter);
+app.route(`${AGENT_SKILL_BASE_PATH}/embeddings`, embeddingsRouter);
 const superAgentsRoute = app.route('/super-agents', superAgentsRouter);
 
 export type SuperAgentsRoute = typeof superAgentsRoute;

--- a/packages/shared/src/utils/sa-request-data.test.ts
+++ b/packages/shared/src/utils/sa-request-data.test.ts
@@ -1,6 +1,9 @@
 import { FunctionName } from '@shared/types/api/request';
 import { HttpMethod } from '@shared/types/http';
-import { produceSuperAgentsRequestData } from '@shared/utils/sa-request-data';
+import {
+  isKnownRoute,
+  produceSuperAgentsRequestData,
+} from '@shared/utils/sa-request-data';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('produceSuperAgentsRequestData', () => {
@@ -341,6 +344,90 @@ describe('produceSuperAgentsRequestData', () => {
       );
 
       expect(result.requestBody).toMatchObject(validRequestBody);
+    });
+  });
+
+  describe('agent and skill scoped paths', () => {
+    it('should match the canonical route for a scoped chat completion', () => {
+      const result = produceSuperAgentsRequestData(
+        HttpMethod.POST,
+        `${baseUrl}/v1/agents/captain_code/skills/programming/chat/completions`,
+        requestHeaders,
+        {
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'Hello' }],
+        },
+      );
+
+      expect(result.functionName).toBe(FunctionName.CHAT_COMPLETE);
+      expect(result.url).toBe(`${baseUrl}/v1/chat/completions`);
+    });
+
+    it('should match the canonical route for a scoped streaming request', () => {
+      const result = produceSuperAgentsRequestData(
+        HttpMethod.POST,
+        `${baseUrl}/v1/agents/captain_code/skills/programming/chat/completions`,
+        requestHeaders,
+        {
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'Hello' }],
+          stream: true,
+        },
+      );
+
+      expect(result.functionName).toBe(FunctionName.STREAM_CHAT_COMPLETE);
+      expect(result.stream).toBe(true);
+    });
+
+    it('should match the canonical route for scoped embeddings', () => {
+      const result = produceSuperAgentsRequestData(
+        HttpMethod.POST,
+        `${baseUrl}/v1/agents/captain_code/skills/embed/embeddings`,
+        requestHeaders,
+        {
+          model: 'text-embedding-3-small',
+          input: 'Hello',
+        },
+      );
+
+      expect(result.functionName).toBe(FunctionName.EMBED);
+      expect(result.url).toBe(`${baseUrl}/v1/embeddings`);
+    });
+  });
+
+  describe('isKnownRoute', () => {
+    it('should recognise the canonical gateway routes', () => {
+      expect(
+        isKnownRoute(HttpMethod.POST, `${baseUrl}/v1/chat/completions`),
+      ).toBe(true);
+      expect(isKnownRoute(HttpMethod.POST, `${baseUrl}/v1/embeddings`)).toBe(
+        true,
+      );
+    });
+
+    it('should recognise the agent and skill scoped routes', () => {
+      expect(
+        isKnownRoute(
+          HttpMethod.POST,
+          `${baseUrl}/v1/agents/captain_code/skills/programming/chat/completions`,
+        ),
+      ).toBe(true);
+    });
+
+    it('should reject unknown paths', () => {
+      expect(isKnownRoute(HttpMethod.POST, `${baseUrl}/v1/nope`)).toBe(false);
+      expect(
+        isKnownRoute(
+          HttpMethod.POST,
+          `${baseUrl}/v1/agents/captain_code/chat/completions`,
+        ),
+      ).toBe(false);
+    });
+
+    it('should reject a known path with the wrong method', () => {
+      expect(
+        isKnownRoute(HttpMethod.GET, `${baseUrl}/v1/chat/completions`),
+      ).toBe(false);
     });
   });
 });

--- a/packages/shared/src/utils/sa-request-data.ts
+++ b/packages/shared/src/utils/sa-request-data.ts
@@ -5,6 +5,65 @@ import {
 } from '@shared/types/api/request/body';
 import type { SuperAgentsResponseBody } from '@shared/types/api/response';
 import type { HttpMethod } from '@shared/types/http';
+import { parseAgentSkillPath } from '@shared/utils/url';
+
+/**
+ * Thrown when no known API route matches the request's method, path and stream
+ * mode. Callers should surface this as a 404 rather than a server error.
+ */
+export class UnknownRouteError extends Error {
+  constructor(method: HttpMethod, pathname: string) {
+    super(`Unknown method: ${method} for pathname: ${pathname}`);
+    this.name = 'UnknownRouteError';
+  }
+}
+
+/**
+ * Thrown when the request body does not match the schema of the matched route.
+ * Callers should surface this as a 422 rather than a server error.
+ */
+export class InvalidRequestBodyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidRequestBodyError';
+  }
+}
+
+/**
+ * Requests may name the agent and skill in the path
+ * (`/v1/agents/:agent_name/skills/:skill_name/chat/completions`). Route matching
+ * happens on the canonical path so both request styles resolve to the same
+ * function.
+ */
+function canonicalizeUrl(urlString: string): {
+  pathname: string;
+  url: string;
+} {
+  const url = new URL(urlString);
+  const agentSkillScope = parseAgentSkillPath(url.pathname);
+
+  if (!agentSkillScope) {
+    return { pathname: url.pathname, url: urlString };
+  }
+
+  url.pathname = agentSkillScope.pathname;
+  return { pathname: url.pathname, url: url.toString() };
+}
+
+/**
+ * Whether any known API route serves this method and path.
+ *
+ * This ignores the request body, so it can be checked before the body is read.
+ * A route that matches here can still be rejected by
+ * `produceSuperAgentsRequestData` when the body does not fit its schema.
+ */
+export function isKnownRoute(method: HttpMethod, urlString: string): boolean {
+  const { pathname } = canonicalizeUrl(urlString);
+
+  return functionConfigs.some(
+    (config) => config.method === method && config.route_pattern.test(pathname),
+  );
+}
 
 export function produceSuperAgentsRequestData(
   method: HttpMethod,
@@ -13,8 +72,7 @@ export function produceSuperAgentsRequestData(
   rawRequestBody: Record<string, unknown>,
   rawResponseBody?: Record<string, unknown> | null,
 ): SuperAgentsRequestData {
-  const url = new URL(urlString);
-  const pathname = url.pathname;
+  const { pathname, url: canonicalUrl } = canonicalizeUrl(urlString);
 
   if (!pathname) {
     throw new Error('No pathname found in URL');
@@ -38,7 +96,7 @@ export function produceSuperAgentsRequestData(
       const requestSchemaSafeParseResult =
         config.requestSchema.safeParse(rawRequestBody);
       if (!requestSchemaSafeParseResult.success) {
-        throw new Error(
+        throw new InvalidRequestBodyError(
           `Invalid request body: ${requestSchemaSafeParseResult.error}`,
         );
       }
@@ -65,7 +123,7 @@ export function produceSuperAgentsRequestData(
       const rawSuperAgentsRequestData = {
         route_pattern: config.route_pattern,
         method: config.method,
-        url: urlString,
+        url: canonicalUrl,
         functionName,
         requestHeaders,
         requestBody,
@@ -83,5 +141,5 @@ export function produceSuperAgentsRequestData(
     }
   }
 
-  throw new Error(`Unknown method: ${method} for pathname: ${pathname}`);
+  throw new UnknownRouteError(method, pathname);
 }

--- a/packages/shared/src/utils/url.test.ts
+++ b/packages/shared/src/utils/url.test.ts
@@ -1,4 +1,9 @@
-import { removeEndingPath, removeTrailingSlash } from '@shared/utils/url';
+import {
+  parseAgentSkillPath,
+  removeEndingPath,
+  removeTrailingSlash,
+  stripAgentSkillPath,
+} from '@shared/utils/url';
 import { describe, expect, it } from 'vitest';
 
 describe('URL Utilities', () => {
@@ -236,6 +241,86 @@ describe('URL Utilities', () => {
         'https://resource.cognitiveservices.azure.com/models/';
       const result2 = removeEndingPath(removeTrailingSlash(cognitiveUrl));
       expect(result2).toBe('https://resource.cognitiveservices.azure.com');
+    });
+  });
+
+  describe('parseAgentSkillPath', () => {
+    it('should read the agent and skill names out of a scoped path', () => {
+      expect(
+        parseAgentSkillPath(
+          '/v1/agents/my-agent/skills/my-skill/chat/completions',
+        ),
+      ).toEqual({
+        agent_name: 'my-agent',
+        skill_name: 'my-skill',
+        pathname: '/v1/chat/completions',
+      });
+    });
+
+    it('should support every gateway endpoint', () => {
+      expect(
+        parseAgentSkillPath('/v1/agents/a/skills/s/embeddings')?.pathname,
+      ).toBe('/v1/embeddings');
+      expect(
+        parseAgentSkillPath('/v1/agents/a/skills/s/responses')?.pathname,
+      ).toBe('/v1/responses');
+      expect(
+        parseAgentSkillPath('/v1/agents/a/skills/s/completions')?.pathname,
+      ).toBe('/v1/completions');
+    });
+
+    it('should decode percent-encoded names', () => {
+      expect(
+        parseAgentSkillPath(
+          '/v1/agents/captain%20code/skills/programming%2Fbasics/chat/completions',
+        ),
+      ).toEqual({
+        agent_name: 'captain code',
+        skill_name: 'programming/basics',
+        pathname: '/v1/chat/completions',
+      });
+    });
+
+    it('should keep malformed percent-encoding as-is', () => {
+      expect(
+        parseAgentSkillPath('/v1/agents/%zz/skills/my-skill/chat/completions')
+          ?.agent_name,
+      ).toBe('%zz');
+    });
+
+    it('should return null for paths that are not scoped', () => {
+      expect(parseAgentSkillPath('/v1/chat/completions')).toBeNull();
+      expect(parseAgentSkillPath('/v1/super-agents/agents')).toBeNull();
+      expect(
+        parseAgentSkillPath('/v1/agents/my-agent/chat/completions'),
+      ).toBeNull();
+      expect(
+        parseAgentSkillPath('/agents/my-agent/skills/my-skill'),
+      ).toBeNull();
+    });
+  });
+
+  describe('stripAgentSkillPath', () => {
+    it('should rewrite a scoped URL to its canonical form', () => {
+      expect(
+        stripAgentSkillPath(
+          'http://localhost:8787/v1/agents/my-agent/skills/my-skill/chat/completions',
+        ),
+      ).toBe('http://localhost:8787/v1/chat/completions');
+    });
+
+    it('should preserve the query string', () => {
+      expect(
+        stripAgentSkillPath(
+          'http://localhost:8787/v1/agents/a/skills/s/embeddings?foo=bar',
+        ),
+      ).toBe('http://localhost:8787/v1/embeddings?foo=bar');
+    });
+
+    it('should leave unscoped URLs untouched', () => {
+      expect(
+        stripAgentSkillPath('http://localhost:8787/v1/chat/completions'),
+      ).toBe('http://localhost:8787/v1/chat/completions');
     });
   });
 });

--- a/packages/shared/src/utils/url.ts
+++ b/packages/shared/src/utils/url.ts
@@ -11,3 +11,68 @@ export function removeEndingPath(url: string): string {
   }
   return url;
 }
+
+/**
+ * Matches gateway paths that name the agent and skill in the URL, for example
+ * `/v1/agents/my-agent/skills/my-skill/chat/completions`.
+ */
+const AGENT_SKILL_PATH_PATTERN =
+  /^\/v1\/agents\/([^/]+)\/skills\/([^/]+)(\/.*)?$/;
+
+export interface AgentSkillPathScope {
+  agent_name: string;
+  skill_name: string;
+  /** The path with the `/agents/:agent_name/skills/:skill_name` segment removed. */
+  pathname: string;
+}
+
+function decodePathSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    // Malformed percent-encoding: keep the raw segment so the lookup fails with
+    // an "agent not found" error instead of a decoding crash.
+    return segment;
+  }
+}
+
+/**
+ * Reads the agent and skill names out of a path-scoped gateway URL.
+ *
+ * Returns `null` when the path is not scoped, in which case the names are
+ * expected in the `sa-config` header instead.
+ */
+export function parseAgentSkillPath(
+  pathname: string,
+): AgentSkillPathScope | null {
+  const match = AGENT_SKILL_PATH_PATTERN.exec(pathname);
+  if (!match) {
+    return null;
+  }
+
+  const [, agentName, skillName, rest] = match;
+
+  return {
+    agent_name: decodePathSegment(agentName),
+    skill_name: decodePathSegment(skillName),
+    pathname: `/v1${rest ?? ''}`,
+  };
+}
+
+/**
+ * Rewrites a path-scoped gateway URL to its canonical form so that route
+ * matching and logging treat both request styles the same way.
+ *
+ * `/v1/agents/my-agent/skills/my-skill/chat/completions` -> `/v1/chat/completions`
+ */
+export function stripAgentSkillPath(urlString: string): string {
+  const url = new URL(urlString);
+  const scope = parseAgentSkillPath(url.pathname);
+
+  if (!scope) {
+    return urlString;
+  }
+
+  url.pathname = scope.pathname;
+  return url.toString();
+}


### PR DESCRIPTION
## Problem

The gateway only accepted the agent and skill in the `sa-config` header, so every call from an OpenAI-compatible client had to carry a custom header:

```ts
client.withOptions({ defaultHeaders: { 'sa-config': JSON.stringify(saConfig) } })
     .chat.completions.create({ ... })
```

That header has to be threaded through every request site, and it rules out tools that only let you configure a base URL and an API key.

## Solution

Mount the gateway endpoints under `/v1/agents/:agent_name/skills/:skill_name/...` as well. A client can now point its base URL at one skill and otherwise stay a plain OpenAI client:

```ts
const client = new OpenAI({
  apiKey: process.env.BEARER_TOKEN,
  baseURL: 'http://localhost:3000/v1/agents/captain_code/skills/programming',
});

await client.chat.completions.create({ model: 'gpt-4o-mini', messages });
```

Covers `/chat/completions`, `/completions`, `/responses` and `/embeddings`.

- **`sa-config` is optional in the path form.** When it is sent, everything else in it still applies (`system_prompt_variables`, `app_id`, `targets`, …). The path wins over `agent_name`/`skill_name` in the header, so a client pinned to a skill's base URL cannot be redirected by a stray header.
- **Route matching and log endpoints use the canonical path**, so a scoped request resolves to the same `FunctionName` and its log groups with header-scoped requests instead of appearing under a separate endpoint.
- **Both styles feed the same `getAgent`/`getSkill` lookups**, so an unknown agent or skill still answers 404 exactly as before. Auth, cache, hooks and the optimizer are untouched — no middleware ordering changed.
- Agent and skill names must be URL-encoded. Names containing `/` work through `%2F`, but some proxies normalize that in paths, so the header stays the safer route for those.

### Also: unroutable paths answer 404 instead of 500

Pre-existing behavior for any unrecognized `/v1/*` path was a 500 (`produceSuperAgentsRequestData` threw `Unknown method: …`). The new URL shape makes that easy to hit by dropping the skill segment, and a 500 sends people looking in the wrong place. The route check now runs *before* the config check, so a mistyped URL reads as a mistyped URL rather than "Missing Super Agents config":

```
POST /v1/agents/captain_code/chat/completions
→ 404 {"error":"No API route matches POST /v1/agents/captain_code/chat/completions",
       "hint":"Expected /v1/agents/{agent_name}/skills/{skill_name}/{endpoint}"}
```

A body that fails the matched route's schema now answers 422 with the validation message instead of 500.

## Test notes

`pnpm typecheck`, `pnpm check` and `pnpm test` all pass (136 files, 2362 tests).

New coverage:
- `packages/shared/src/utils/url.test.ts` — path parsing, percent-decoding, malformed encoding, non-scoped paths, query preservation.
- `packages/shared/src/utils/sa-request-data.test.ts` — scoped paths resolve to the canonical route; `isKnownRoute` accepts both styles and rejects unknown paths and wrong methods.
- `packages/api/src/middlewares/variables.test.ts` (new) — header optional in the path form, path-wins-over-header precedence, auto-optimization default, and the 404/422 responses.
- `packages/api/src/v1/index.test.ts` — the four scoped routes are registered.

Also verified against the built server end to end: scoped requests to all four endpoints route through the full middleware chain with no `sa-config` header and reach the agent lookup; auth still returns 401; the previously-500 cases return 404. The agent lookup itself could not be exercised against real data — the local Supabase on this machine belongs to a different project and has no `agents` table — so a completion against a live agent is still worth a manual smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1r1Mpo1FM3PExFZi9CSNC
