### PR TITLE
ci: build and boot both runtimes in CI

### DIFF
--- a/.github/workflows/ci-pull.yml
+++ b/.github/workflows/ci-pull.yml
@@ -132,6 +132,56 @@ jobs:
       - name: Test
         run: pnpm turbo test
 
+  worker:
+    name: Worker Runtime
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    env:
+      WRANGLER_SEND_METRICS: "false"
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10.10.0
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # `pnpm dev:api` runs on workerd, so the Workers build is exercised
+      # constantly in development but was never built or booted outside a
+      # developer's machine.
+      - name: Check Cloudflare Workers build
+        run: ./scripts/check-worker-runtime.sh
+
+  container:
+    name: Container Image
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      # The API and dashboard share one process; that static-serving path runs
+      # in neither `pnpm dev` nor the unit tests, so the image is the only
+      # place it executes.
+      - name: Smoke test the all-in-one image
+        run: ./scripts/check-container-image.sh
+
   migrations:
     name: Test Migrations
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,56 @@ jobs:
       - name: Test
         run: pnpm turbo test
 
+  worker:
+    name: Worker Runtime
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    env:
+      WRANGLER_SEND_METRICS: "false"
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10.10.0
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # `pnpm dev:api` runs on workerd, so the Workers build is exercised
+      # constantly in development but was never built or booted outside a
+      # developer's machine.
+      - name: Check Cloudflare Workers build
+        run: ./scripts/check-worker-runtime.sh
+
+  container:
+    name: Container Image
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      # The API and dashboard share one process; that static-serving path runs
+      # in neither `pnpm dev` nor the unit tests, so the image is the only
+      # place it executes.
+      - name: Smoke test the all-in-one image
+        run: ./scripts/check-container-image.sh
+
   migrations:
     name: Test Migrations
     timeout-minutes: 10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ pnpm test:watch                # Run tests in watch mode
 # In-depth integration tests (slower, more comprehensive)
 INCLUDE_IN_DEPTH=true pnpm test
 
+# Runtime checks (also run in CI; both are slow, so they are not part of `pnpm test`)
+pnpm verify:worker     # Bundle and boot the API on workerd
+pnpm verify:container  # Build the all-in-one image and smoke test it (needs Docker)
+
 # Build (uses Turborepo with caching)
 pnpm build      # Build all packages
 pnpm build:web  # Build only web package
@@ -97,6 +101,24 @@ curl "http://localhost:3000/v1/endpoint" -H "Authorization: Bearer super-agents"
 - **Framework**: Hono web framework
 - **Entry**: `src/server.ts` (Node.js) or `src/index.ts` (Cloudflare Workers)
 - **Routes**: `src/api/v1/`
+
+#### The API runs on two runtimes
+
+`pnpm dev:api` runs `wrangler dev`, so **workerd is the development runtime**,
+while the Docker image runs the same code on Node through `src/server.ts`.
+Anything reachable from `src/index.ts` has to work on both. In practice:
+
+- **No module-scope I/O, timers, or randomness.** Workers reject these outright
+  — `utils/sse-event-manager.ts` starts its ping interval on first use for this
+  reason. Prefer a first-request flag over doing work at import time.
+- **Node-only packages have to stay off the Workers path.** A driver with native
+  bindings fails to bundle. Where a package ships a Workers build (`/web` entry
+  or a `workerd` export condition), use it.
+- **`node:` builtins are the quiet case.** Wrangler's unenv layer substitutes a
+  stub, so the import resolves and the Worker boots — it throws only when the
+  stub is called. Neither CI check catches this; review does.
+
+`pnpm verify:worker` bundles and boots the Worker, and runs in CI.
 
 ### Request Flow
 ```

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "typecheck": "turbo typecheck",
     "test": "vitest run",
     "test:watch": "vitest",
+    "verify:worker": "./scripts/check-worker-runtime.sh",
+    "verify:container": "./scripts/check-container-image.sh",
     "deploy:api": "pnpm --filter @super-agents/api deploy"
   },
   "dependencies": {

--- a/scripts/check-container-image.sh
+++ b/scripts/check-container-image.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Builds the all-in-one image and checks that the container serves both halves.
+#
+# The API and the dashboard share one process now, and that static-serving path
+# runs in neither `pnpm dev` (wrangler for the API, vite for the dashboard) nor
+# the unit tests. The built image is the only place it executes, so without this
+# a break in it would first appear in a published release.
+#
+# Usage: scripts/check-container-image.sh
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+image="${IMAGE_TAG:-super-agents:ci}"
+port="${CONTAINER_PROBE_PORT:-3999}"
+name="${CONTAINER_NAME:-super-agents-smoke}"
+base="http://localhost:$port"
+failures=0
+
+cleanup() {
+  docker rm -f "$name" > /dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# check <description> <expected> <actual>
+check() {
+  if [ "$2" = "$3" ]; then
+    printf '    ok   %s (%s)\n' "$1" "$3"
+  else
+    printf '    FAIL %s -- expected %s, got %s\n' "$1" "$2" "$3"
+    failures=$((failures + 1))
+  fi
+}
+
+# status <path> -> HTTP status code
+status() {
+  curl -s -o /dev/null -w '%{http_code}' -m 15 "$base$1" || echo "000"
+}
+
+# content_type <path> -> leading mime type
+content_type() {
+  curl -s -o /dev/null -w '%{content_type}' -m 15 "$base$1" | cut -d';' -f1
+}
+
+start_container() {
+  cleanup
+  docker run -d --name "$name" -p "$port:3000" "$@" "$image" > /dev/null
+
+  for _ in $(seq 1 60); do
+    if [ "$(status /health)" = "200" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "ERROR: container did not become healthy." >&2
+  docker logs "$name" >&2 || true
+  exit 1
+}
+
+echo "==> Building $image"
+docker build -t "$image" "$repo_root"
+echo
+
+echo "==> Starting container (dashboard enabled)"
+start_container
+echo "    container is up."
+echo
+
+echo "==> Dashboard"
+check "GET /health"        "200"       "$(status /health)"
+check "GET / status"       "200"       "$(status /)"
+check "GET / type"         "text/html" "$(content_type /)"
+# A client-side route has no file behind it; it must fall back to index.html.
+check "GET /agents status" "200"       "$(status /agents)"
+check "GET /agents type"   "text/html" "$(content_type /agents)"
+echo
+
+echo "==> Hashed assets"
+asset="$(curl -s -m 15 "$base/" | grep -o '/assets/[A-Za-z0-9._-]*\.js' | head -1)"
+if [ -z "$asset" ]; then
+  echo "    FAIL could not find a hashed asset referenced by index.html"
+  failures=$((failures + 1))
+else
+  check "GET $asset" "200" "$(status "$asset")"
+  cache="$(curl -s -o /dev/null -D- -m 15 "$base$asset" \
+    | tr -d '\r' | awk -F': ' 'tolower($1)=="cache-control"{print $2}')"
+  check "$asset is immutable" "public, max-age=31536000, immutable" "$cache"
+fi
+echo
+
+echo "==> API"
+# The API must answer under /v1 rather than falling through to the SPA. This
+# path is the one `commonVariablesMiddleware` skips, so it is the case that
+# would silently return index.html if the fallback were ordered wrongly.
+check "GET /v1/super-agents/nope status" "404" \
+  "$(status /v1/super-agents/nope)"
+check "GET /v1/super-agents/nope type" "application/json" \
+  "$(content_type /v1/super-agents/nope)"
+echo
+
+echo "==> Security headers"
+headers="$(curl -s -o /dev/null -D- -m 15 "$base/" | tr -d '\r' | tr 'A-Z' 'a-z')"
+for header in x-frame-options x-content-type-options x-xss-protection; do
+  if printf '%s' "$headers" | grep -q "^$header:"; then
+    printf '    ok   %s present\n' "$header"
+  else
+    printf '    FAIL %s missing\n' "$header"
+    failures=$((failures + 1))
+  fi
+done
+echo
+
+echo "==> Gateway-only mode (SERVE_DASHBOARD=false)"
+start_container -e SERVE_DASHBOARD=false
+check "GET /health" "200" "$(status /health)"
+check "GET / (dashboard off)" "404" "$(status /)"
+check "GET /v1/super-agents/nope" "404" "$(status /v1/super-agents/nope)"
+echo
+
+if [ "$failures" -gt 0 ]; then
+  echo "Container image check FAILED ($failures problem(s))." >&2
+  docker logs "$name" >&2 || true
+  exit 1
+fi
+
+echo "Container image OK."

--- a/scripts/check-worker-runtime.sh
+++ b/scripts/check-worker-runtime.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Verifies that the Cloudflare Workers build of the API still works.
+#
+# `pnpm dev:api` runs `wrangler dev`, so workerd is the runtime every developer
+# uses day to day -- but nothing built or booted it outside a developer's
+# machine. These two checks cover the failure modes that gap allows, and they
+# catch different things:
+#
+#   1. `wrangler deploy --dry-run` fails on imports that cannot be bundled.
+#      A driver package with native bindings (`@libsql/client` rather than
+#      `@libsql/client/web`, say) resolves to its Node build and stops here.
+#      It does NOT notice anything about runtime behaviour.
+#
+#   2. Booting workerd catches what bundling cannot: operations Workers forbid
+#      at module scope -- asynchronous I/O, timers, random values. A dry run
+#      exits 0 on those; workerd refuses to start.
+#
+# Neither check catches a `node:` builtin that workerd does not implement:
+# wrangler's unenv layer substitutes a stub at bundle time, so the import
+# resolves and the Worker boots. It only throws if the stub is actually called.
+#
+# Usage: scripts/check-worker-runtime.sh
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+api_dir="$repo_root/packages/api"
+
+port="${WORKER_PROBE_PORT:-8799}"
+inspector_port="${WORKER_INSPECTOR_PORT:-9399}"
+# Any path under /v1 works as a liveness probe. An unrouted one avoids needing
+# a database: reaching the API's own 404 already proves the module evaluated,
+# middleware ran and Hono dispatched.
+probe_path="${WORKER_PROBE_PATH:-/v1/}"
+boot_timeout="${WORKER_BOOT_TIMEOUT:-90}"
+
+workdir="$(mktemp -d)"
+log="$workdir/wrangler-dev.log"
+worker_pid=""
+
+cleanup() {
+  if [ -n "$worker_pid" ] && kill -0 "$worker_pid" 2>/dev/null; then
+    # wrangler spawns workerd as a child, so signal the whole group.
+    kill -- "-$worker_pid" 2>/dev/null || kill "$worker_pid" 2>/dev/null || true
+    wait "$worker_pid" 2>/dev/null || true
+  fi
+  rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+cd "$api_dir"
+
+echo "==> Bundling the Worker (wrangler deploy --dry-run)"
+pnpm exec wrangler deploy --dry-run --outdir "$workdir/dry-run"
+echo "    Worker bundles cleanly."
+echo
+
+echo "==> Booting workerd (wrangler dev) on port $port"
+setsid pnpm exec wrangler dev \
+  --port "$port" \
+  --inspector-port "$inspector_port" \
+  > "$log" 2>&1 < /dev/null &
+worker_pid=$!
+
+ready=""
+for _ in $(seq 1 "$boot_timeout"); do
+  if grep -q "Ready on" "$log" 2>/dev/null; then
+    ready=1
+    break
+  fi
+  if grep -qi "runtime failed to start\|Uncaught Error" "$log" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "$worker_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+if [ -z "$ready" ]; then
+  echo "ERROR: workerd did not start." >&2
+  echo "--- wrangler dev output ---" >&2
+  cat "$log" >&2
+  exit 1
+fi
+echo "    workerd started."
+echo
+
+echo "==> Probing GET $probe_path"
+status="$(curl -s -o "$workdir/body" -w '%{http_code}' -m 15 \
+  "http://localhost:$port$probe_path" || echo "000")"
+
+if [ "$status" = "000" ]; then
+  echo "ERROR: no HTTP response from the Worker." >&2
+  echo "--- wrangler dev output ---" >&2
+  cat "$log" >&2
+  exit 1
+fi
+
+if [ "$status" -ge 500 ]; then
+  echo "ERROR: Worker answered $status -- the runtime booted but the request failed." >&2
+  echo "--- response body ---" >&2
+  cat "$workdir/body" >&2
+  echo >&2
+  echo "--- wrangler dev output ---" >&2
+  cat "$log" >&2
+  exit 1
+fi
+
+echo "    Worker answered $status."
+echo
+echo "Worker runtime OK."


### PR DESCRIPTION
## Problem

The API targets two runtimes and CI verified neither.

`packages/api/package.json` sets `"dev": "wrangler dev"`, so **workerd is the development runtime** — every developer exercises it all day. But `pnpm turbo build` runs `packages/api/build.js`, which is the esbuild *Node* bundle, and `release.yml` publishes images without ever starting one. `grep -rn "wrangler" .github/workflows/` returned nothing.

Track 1 widened the second gap: the API and dashboard now share a process, and that static-serving path runs in neither `pnpm dev` (wrangler + vite) nor the unit tests. The built image is the only place it executes.

## What I found while building this

The design doc proposed `wrangler deploy --dry-run` as the Workers guard. Testing it showed that's only half the story, so this PR does both:

| Failure mode | `--dry-run` | boot workerd |
|---|---|---|
| Unbundleable import (native bindings — `@libsql/client` vs `@libsql/client/web`) | **exit 1** | exit 1 |
| Disallowed module-scope operation (I/O, timers, randomness) | **exit 0 — missed** | **refuses to start** |
| `node:` builtin workerd doesn't implement | exit 0 — missed | exit 0 — missed |

That third row is the interesting one. Wrangler's `unenv` layer substitutes a stub at bundle time, so `import { execSync } from 'node:child_process'` resolves, bundles, and boots — it logged `[Function: fn] { __unenv__: true }` and served requests fine. It throws only when the stub is *called*. **Neither check catches it**, so `AGENTS.md` now documents it as a review-time constraint rather than pretending CI covers it.

## Changes

- **`scripts/check-worker-runtime.sh`** — dry-run bundle, then boot workerd and probe it. `/v1/` is the probe: reaching the API's own 404 proves the module evaluated, middleware ran, and Hono dispatched, without needing a database.
- **`scripts/check-container-image.sh`** — builds the all-in-one image and asserts the dashboard serves, hashed assets carry `immutable` caching, the three security headers are present, `/v1/super-agents/nope` returns JSON 404 rather than `index.html`, and `SERVE_DASHBOARD=false` still serves the API while 404ing the dashboard.
- **Both jobs added to `ci.yml` and `ci-pull.yml`**, matching the existing duplication between them.
- **`pnpm verify:worker` / `pnpm verify:container`** aliases, documented in `AGENTS.md`. They're slow, so they're not part of `pnpm test`.
- **`AGENTS.md`** gains a "The API runs on two runtimes" section covering the module-scope rule (with `sse-event-manager.ts` as the in-repo example), Node-only packages, and the unenv stub caveat.

## Verification

The worker check was tested in all four states — a guard that can't go red isn't a guard:

| Tree state | Exit | Caught by |
|---|---|---|
| clean `main` | 0 | — (probe answered 404) |
| `setInterval` at module scope | 1 | boot — *"Disallowed operation called within global scope"* |
| `import { createClient } from '@libsql/client'` | 1 | dry-run — *"Could not resolve"* |
| restored to clean | 0 | — |

`packages/api/src/index.ts` is byte-identical to `main` (`git diff main -- packages/api/src/index.ts` is empty).

`pnpm check`, `pnpm typecheck`, `pnpm test` (136 files, 2362 tests) all pass. `pnpm verify:worker` exits 0.

**Not verified: `check-container-image.sh` has never been executed** — no Docker daemon on this machine. I validated the fragile parts against a locally-run merged server instead: the `/assets/*.js` extraction from `index.html`, the `awk` cache-control parse (matched `public, max-age=31536000, immutable` exactly), the header-presence loop, and every expected status/content-type pair. The `docker build`/`docker run` wrapper around them is unexercised, so **expect the first CI run to be where it proves itself** — and it may need a fixup.

## Notes for review

- **Cost.** The worker job is ~2 min. The container job does a full `pnpm install` + vite build + esbuild inside Docker with no layer cache, so budget ~8-12 min; `timeout-minutes: 25`. If that's too slow for every PR, the container job is the one to move to `ci.yml` only (post-merge) — say the word and I'll change it.
- **No Cloudflare credentials needed.** `--dry-run` and `wrangler dev` both run unauthenticated; confirmed locally. `WRANGLER_SEND_METRICS: "false"` keeps telemetry out of CI.
- **Probe assertion is deliberately loose** — any non-5xx HTTP response passes, rather than matching the 404 body text. Tying it to the error string would make it break on unrelated copy edits.
- These land before any libSQL work, which is the point: a driver-based connector is exactly the change row 1 of that table is waiting for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wM59ecJTFbb3gZYDDva1Z