### PR TITLE
feat(api): implement the libSQL user data and logs connectors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,18 +171,24 @@ Uses **connector pattern** for data access:
 | Backend | Location | Status |
 | --- | --- | --- |
 | Supabase / PostgREST | `packages/api/src/connectors/supabase/` | complete; what the app uses |
-| libSQL | `packages/api/src/connectors/libsql/` | schema, client, migrations, cache |
+| libSQL | `packages/api/src/connectors/libsql/` | complete; not yet selectable |
 
-The libSQL backend is **not yet selectable** — `v1/index.ts` still wires the
-Supabase connectors unconditionally. Its remaining connectors land before the
-selection is added, so a half-implemented backend is never reachable.
+The libSQL backend implements all three interfaces but is **not yet
+selectable** — `v1/index.ts` still wires the Supabase connectors
+unconditionally. Wiring it up is the remaining step.
 
 Its schema (`connectors/libsql/schema.ts`) is a translation of
 `supabase/migrations/`, not a replay: one consolidated migration describing the
 current shape. Notable differences, all deliberate:
 
 - **No stored procedures.** SQLite has none, so the five RPCs the API calls
-  become explicit transactions in the connector.
+  become explicit transactions in `connectors/libsql/user-data.ts`, and
+  `get_evaluation_scores_by_time_bucket` becomes `connectors/libsql/time-bucket.ts`.
+- **NULL stays NULL.** PostgREST serialises a NULL column as JSON `null` and
+  the Zod schemas use `.nullable()`, so row decoding preserves null rather than
+  mapping it to `undefined`.
+- **Updates re-select instead of using `RETURNING`.** SQLite computes RETURNING
+  before AFTER triggers run, so it would return a stale `updated_at`.
 - **Row-level security is dropped.** The Postgres policies grant unrestricted
   access to the service role, which is the only role the API connects as.
 - **`PRAGMA foreign_keys = ON` per connection.** SQLite leaves foreign keys
@@ -366,6 +372,9 @@ The system uses special auto-generated skills in the `super-agents` agent (defin
   - `LIBSQL_URL` - libSQL database. `file:` for an embedded SQLite file,
     `libsql://` or `https://` for a remote one. Only read by the libSQL
     connector, which is not wired up yet.
+  - Note: tests for the libSQL connector use a temp **file** database, not
+    `:memory:` — `client.transaction()` checks out a separate connection, and
+    for an in-memory database that is a separate, empty database.
   - `LIBSQL_AUTH_TOKEN` - Auth token for a remote libSQL database. Not used by `file:` databases.
   - `WEB_APP_URL` - Comma-separated origins allowed to make credentialed cross-origin
     requests. Only needed when the dashboard is hosted separately from the API; the

--- a/packages/api/src/connectors/libsql/connector.test.ts
+++ b/packages/api/src/connectors/libsql/connector.test.ts
@@ -1,0 +1,837 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AppContext } from '@api/types/hono';
+import type { Client } from '@libsql/client';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { createLibsqlClient, resetLibsqlClients } from './client';
+import { libsqlLogsStorageConnector } from './logs';
+import { migrateLibsql } from './migrate';
+import { libsqlUserDataStorageConnector as store } from './user-data';
+
+const logs = libsqlLogsStorageConnector;
+
+/**
+ * Backed by a temp file rather than `:memory:`.
+ *
+ * `client.transaction()` checks out a separate connection, and for an
+ * in-memory database that means a separate, empty database — so
+ * `updateArmAndIncrementCounters` would fail with "no such table". A file
+ * database is also what the single-container deployment actually uses.
+ */
+const tempDirs: string[] = [];
+
+const freshDatabase = async (): Promise<{ client: Client; c: AppContext }> => {
+  resetLibsqlClients();
+  const dir = mkdtempSync(join(tmpdir(), 'sa-libsql-'));
+  tempDirs.push(dir);
+  const url = `file:${join(dir, 'test.db')}`;
+
+  const client = createLibsqlClient(url);
+  await migrateLibsql(client);
+
+  const c = {
+    env: {
+      LIBSQL_URL: url,
+      AI_PROVIDER_API_KEY_ENCRYPTION_KEY: 'test-key-for-encryption-round-trip',
+    },
+  } as unknown as AppContext;
+  return { client, c };
+};
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const seedAgent = (c: AppContext) =>
+  store.createAgent(c, {
+    name: 'test-agent',
+    description: 'x'.repeat(30),
+    metadata: {},
+  });
+
+const seedSkill = (c: AppContext, agentId: string) =>
+  store.createSkill(c, {
+    agent_id: agentId,
+    name: 'test-skill',
+    description: 'y'.repeat(30),
+  } as Parameters<typeof store.createSkill>[1]);
+
+const aiProviderRequestLog = {
+  provider: 'openai',
+  function_name: 'chat_complete',
+  method: 'POST',
+  request_url: 'https://api.openai.com/v1/chat/completions',
+  status: 200,
+  request_body: { model: 'gpt-5' },
+  response_body: { id: 'chatcmpl-1' },
+  raw_request_body: '{"model":"gpt-5"}',
+  raw_response_body: '{"id":"chatcmpl-1"}',
+  cache_mode: 'disabled',
+  cache_status: 'MISS',
+};
+
+const logParams = (agentId: string, skillId: string, startTime = 1000) =>
+  ({
+    agent_id: agentId,
+    skill_id: skillId,
+    method: 'POST',
+    endpoint: '/v1/chat/completions',
+    function_name: 'chat_complete',
+    status: 200,
+    start_time: startTime,
+    end_time: startTime + 50,
+    duration: 50,
+    base_sa_config: { agent_name: 'test-agent', skill_name: 'test-skill' },
+    ai_provider: 'openai',
+    model: 'gpt-5',
+    ai_provider_request_log: aiProviderRequestLog,
+    hook_logs: [],
+    metadata: {},
+    cache_status: 'MISS',
+  }) as unknown as Parameters<typeof logs.createLog>[1];
+
+/** `SkillOptimizationArmParams` requires the full normalised range set. */
+const armParams = (modelId: string) => ({
+  model_id: modelId,
+  system_prompt: 'You are a helpful assistant.',
+  temperature_min: 0,
+  temperature_max: 1,
+  top_p_min: 0,
+  top_p_max: 1,
+  top_k_min: 0,
+  top_k_max: 1,
+  frequency_penalty_min: 0,
+  frequency_penalty_max: 1,
+  presence_penalty_min: 0,
+  presence_penalty_max: 1,
+  thinking_min: 0,
+  thinking_max: 1,
+});
+
+beforeEach(() => {
+  resetLibsqlClients();
+});
+
+describe('agents, skills and JSON columns', () => {
+  it('round-trips an agent, generating the id Postgres would default', async () => {
+    const { c } = await freshDatabase();
+
+    const created = await store.createAgent(c, {
+      name: 'my-agent',
+      description: 'd'.repeat(30),
+      metadata: { team: 'core', tags: ['a', 'b'] },
+    });
+
+    expect(created.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(created.metadata).toEqual({ team: 'core', tags: ['a', 'b'] });
+
+    const [fetched] = await store.getAgents(c, { id: created.id });
+    expect(fetched).toEqual(created);
+  });
+
+  it('filters, limits and offsets like PostgREST', async () => {
+    const { c } = await freshDatabase();
+    for (const name of ['agent-a', 'agent-b', 'agent-c']) {
+      await store.createAgent(c, {
+        name,
+        description: 'd'.repeat(30),
+        metadata: {},
+      });
+    }
+
+    expect(await store.getAgents(c, { name: 'agent-b' })).toHaveLength(1);
+    expect(await store.getAgents(c, { limit: 2 })).toHaveLength(2);
+    // Offset without a limit is legal in PostgREST but not in raw SQLite.
+    expect(await store.getAgents(c, { offset: 1 })).toHaveLength(2);
+  });
+
+  it('updates an agent and refreshes updated_at', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+
+    const updated = await store.updateAgent(c, agent.id, {
+      description: 'z'.repeat(30),
+    });
+
+    expect(updated.description).toBe('z'.repeat(30));
+    // Would be the pre-trigger value if the update used RETURNING.
+    expect(Date.parse(updated.updated_at)).toBeGreaterThanOrEqual(
+      Date.parse(agent.updated_at),
+    );
+    expect(updated.updated_at).toMatch(/Z$/);
+  });
+
+  it('cascades a delete from agent to skill', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    await seedSkill(c, agent.id);
+
+    await store.deleteAgent(c, agent.id);
+
+    expect(await store.getSkills(c, {})).toHaveLength(0);
+  });
+
+  it('round-trips the boolean and array columns on a skill', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    // `optimize` is INTEGER 0/1 in SQLite but boolean in the schema.
+    expect(skill.optimize).toBe(true);
+    expect(skill.allowed_template_variables).toEqual([]);
+
+    const updated = await store.updateSkill(c, skill.id, {
+      optimize: false,
+      allowed_template_variables: ['datetime', 'user'],
+    } as Parameters<typeof store.updateSkill>[2]);
+
+    expect(updated.optimize).toBe(false);
+    expect(updated.allowed_template_variables).toEqual(['datetime', 'user']);
+  });
+});
+
+describe('ai providers', () => {
+  it('encrypts the api key at rest and decrypts on read', async () => {
+    const { client, c } = await freshDatabase();
+
+    const created = await store.createAIProvider(c, {
+      ai_provider: 'openai',
+      name: 'default',
+      api_key: 'sk-secret-value',
+      custom_fields: {},
+    } as Parameters<typeof store.createAIProvider>[1]);
+
+    expect(created.api_key).toBe('sk-secret-value');
+
+    const raw = await client.execute('SELECT api_key FROM ai_providers');
+    expect(String(raw.rows[0].api_key)).not.toContain('sk-secret-value');
+    expect(String(raw.rows[0].api_key)).toMatch(
+      /^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/,
+    );
+
+    const fetched = await store.getAIProviderAPIKeyById(c, created.id);
+    expect(fetched?.api_key).toBe('sk-secret-value');
+  });
+
+  it('returns null for an unknown provider id', async () => {
+    const { c } = await freshDatabase();
+    expect(
+      await store.getAIProviderAPIKeyById(
+        c,
+        '00000000-0000-4000-8000-00000000dead',
+      ),
+    ).toBeNull();
+  });
+
+  it('re-encrypts on update', async () => {
+    const { c } = await freshDatabase();
+    const created = await store.createAIProvider(c, {
+      ai_provider: 'openai',
+      name: 'default',
+      api_key: 'sk-first',
+      custom_fields: {},
+    } as Parameters<typeof store.createAIProvider>[1]);
+
+    const updated = await store.updateAIProvider(c, created.id, {
+      api_key: 'sk-second',
+    } as Parameters<typeof store.updateAIProvider>[2]);
+
+    expect(updated.api_key).toBe('sk-second');
+  });
+});
+
+describe('skill-model bridge', () => {
+  const seedModel = async (c: AppContext, name: string) => {
+    const provider = await store.createAIProvider(c, {
+      ai_provider: 'openai',
+      name: `provider-${name}`,
+      api_key: null,
+      custom_fields: {},
+    } as Parameters<typeof store.createAIProvider>[1]);
+
+    return store.createModel(c, {
+      ai_provider_id: provider.id,
+      model_name: name,
+    } as Parameters<typeof store.createModel>[1]);
+  };
+
+  it('joins through the bridge in both directions', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+    const model = await seedModel(c, 'gpt-5');
+
+    await store.addModelsToSkill(c, skill.id, [model.id]);
+
+    const models = await store.getSkillModels(c, skill.id);
+    expect(models.map((m) => m.id)).toEqual([model.id]);
+
+    const skills = await store.getSkillsByModelId(c, model.id);
+    expect(skills.map((s) => s.id)).toEqual([skill.id]);
+  });
+
+  it('is idempotent when adding the same model twice', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+    const model = await seedModel(c, 'gpt-5');
+
+    await store.addModelsToSkill(c, skill.id, [model.id]);
+    await store.addModelsToSkill(c, skill.id, [model.id]);
+
+    expect(await store.getSkillModels(c, skill.id)).toHaveLength(1);
+  });
+
+  it('removes only the named models', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+    const a = await seedModel(c, 'gpt-5');
+    const b = await seedModel(c, 'claude-sonnet-5');
+
+    await store.addModelsToSkill(c, skill.id, [a.id, b.id]);
+    await store.removeModelsFromSkill(c, skill.id, [a.id]);
+
+    expect((await store.getSkillModels(c, skill.id)).map((m) => m.id)).toEqual([
+      b.id,
+    ]);
+  });
+
+  it('tolerates an empty model list', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    await expect(
+      store.addModelsToSkill(c, skill.id, []),
+    ).resolves.toBeUndefined();
+    await expect(
+      store.removeModelsFromSkill(c, skill.id, []),
+    ).resolves.toBeUndefined();
+  });
+});
+
+/** The five plpgsql functions the API actually calls, reimplemented in TS. */
+describe('atomic operations', () => {
+  it('increments the skill request counter', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    expect(skill.total_requests).toBe(0);
+    expect(
+      (await store.incrementSkillTotalRequests(c, skill.id)).total_requests,
+    ).toBe(1);
+    expect(
+      (await store.incrementSkillTotalRequests(c, skill.id)).total_requests,
+    ).toBe(2);
+  });
+
+  it('increments both cluster counters together', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+    const [cluster] = await store.createSkillOptimizationClusters(c, [
+      {
+        agent_id: agent.id,
+        skill_id: skill.id,
+        name: 'cluster-0',
+        centroid: [0.1, 0.2],
+      } as Parameters<typeof store.createSkillOptimizationClusters>[1][number],
+    ]);
+
+    // The centroid is a FLOAT[] in Postgres and JSON text here.
+    expect(cluster.centroid).toEqual([0.1, 0.2]);
+
+    const bumped = await store.incrementClusterCounters(c, cluster.id);
+    expect(bumped.total_steps).toBe(1);
+    expect(bumped.observability_total_requests).toBe(1);
+  });
+
+  it('acquires the reclustering lock only once while it is held', async () => {
+    const { client, c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    const first = await store.tryAcquireReclusteringLock(c, skill.id, 60_000);
+    expect(first).not.toBeNull();
+    expect(first?.last_clustering_at).not.toBeNull();
+
+    // Still inside the threshold, so the second caller is turned away.
+    const second = await store.tryAcquireReclusteringLock(c, skill.id, 60_000);
+    expect(second).toBeNull();
+
+    // Backdate the lock rather than passing a zero threshold: with zero, the
+    // cutoff equals the timestamp just written and the comparison is strict,
+    // so the outcome would depend on the clock ticking between the two calls.
+    await client.execute({
+      sql: 'UPDATE skills SET last_clustering_at = ? WHERE id = ?',
+      args: ['2000-01-01T00:00:00.000Z', skill.id],
+    });
+
+    const third = await store.tryAcquireReclusteringLock(c, skill.id, 60_000);
+    expect(third).not.toBeNull();
+  });
+
+  describe('updateArmAndIncrementCounters', () => {
+    const setup = async () => {
+      const { client, c } = await freshDatabase();
+      const agent = await seedAgent(c);
+      const skill = await seedSkill(c, agent.id);
+      const provider = await store.createAIProvider(c, {
+        ai_provider: 'openai',
+        name: 'arm-provider',
+        api_key: null,
+        custom_fields: {},
+      } as Parameters<typeof store.createAIProvider>[1]);
+      const model = await store.createModel(c, {
+        ai_provider_id: provider.id,
+        model_name: 'gpt-5',
+      } as Parameters<typeof store.createModel>[1]);
+      const [cluster] = await store.createSkillOptimizationClusters(c, [
+        {
+          agent_id: agent.id,
+          skill_id: skill.id,
+          name: 'cluster-0',
+          centroid: [0],
+        } as Parameters<
+          typeof store.createSkillOptimizationClusters
+        >[1][number],
+      ]);
+      const [arm] = await store.createSkillOptimizationArms(c, [
+        {
+          agent_id: agent.id,
+          skill_id: skill.id,
+          cluster_id: cluster.id,
+          name: 'arm-0',
+          params: armParams(model.id),
+        } as Parameters<typeof store.createSkillOptimizationArms>[1][number],
+      ]);
+      const [evaluation] = await store.createSkillOptimizationEvaluations(c, [
+        {
+          agent_id: agent.id,
+          skill_id: skill.id,
+          evaluation_method: 'task_completion',
+          weight: 1,
+          params: {},
+        } as Parameters<
+          typeof store.createSkillOptimizationEvaluations
+        >[1][number],
+      ]);
+      return { client, c, agent, skill, cluster, arm, evaluation };
+    };
+
+    it('creates stats on first use and moves all three counters', async () => {
+      const { c, arm, evaluation } = await setup();
+
+      const result = await store.updateArmAndIncrementCounters(c, arm.id, [
+        { evaluation_id: evaluation.id, score: 0.8 },
+      ]);
+
+      expect(result.cluster.total_steps).toBe(1);
+      expect(result.cluster.observability_total_requests).toBe(1);
+      expect(result.skill.total_requests).toBe(1);
+      expect(result.arm.id).toBe(arm.id);
+
+      const [stat] = await store.getSkillOptimizationArmStats(c, {
+        arm_id: arm.id,
+      });
+      expect(stat.n).toBe(1);
+      expect(stat.mean).toBeCloseTo(0.8, 10);
+      expect(stat.total_reward).toBeCloseTo(0.8, 10);
+      expect(stat.n2).toBeCloseTo(0.64, 10);
+    });
+
+    it('applies the incremental mean and n2 formulas across calls', async () => {
+      const { c, arm, evaluation } = await setup();
+
+      await store.updateArmAndIncrementCounters(c, arm.id, [
+        { evaluation_id: evaluation.id, score: 1.0 },
+      ]);
+      await store.updateArmAndIncrementCounters(c, arm.id, [
+        { evaluation_id: evaluation.id, score: 0.0 },
+      ]);
+
+      const [stat] = await store.getSkillOptimizationArmStats(c, {
+        arm_id: arm.id,
+      });
+      expect(stat.n).toBe(2);
+      expect(stat.total_reward).toBeCloseTo(1.0, 10);
+      expect(stat.mean).toBeCloseTo(0.5, 10);
+      // n2 accumulates squares: 1^2 + 0^2
+      expect(stat.n2).toBeCloseTo(1.0, 10);
+    });
+
+    it('updates one stat row per evaluation but bumps counters once', async () => {
+      const { c, agent, skill, arm, evaluation } = await setup();
+      const [second] = await store.createSkillOptimizationEvaluations(c, [
+        {
+          agent_id: agent.id,
+          skill_id: skill.id,
+          evaluation_method: 'latency',
+          weight: 1,
+          params: {},
+        } as Parameters<
+          typeof store.createSkillOptimizationEvaluations
+        >[1][number],
+      ]);
+
+      const result = await store.updateArmAndIncrementCounters(c, arm.id, [
+        { evaluation_id: evaluation.id, score: 1.0 },
+        { evaluation_id: second.id, score: 0.5 },
+      ]);
+
+      expect(result.cluster.total_steps).toBe(1);
+      expect(result.skill.total_requests).toBe(1);
+      expect(
+        await store.getSkillOptimizationArmStats(c, { arm_id: arm.id }),
+      ).toHaveLength(2);
+    });
+
+    it('rolls back completely when the arm does not exist', async () => {
+      const { c, skill } = await setup();
+
+      await expect(
+        store.updateArmAndIncrementCounters(
+          c,
+          '00000000-0000-4000-8000-00000000dead',
+          [{ evaluation_id: 'irrelevant', score: 1 }],
+        ),
+      ).rejects.toThrow(/not found/);
+
+      const [unchanged] = await store.getSkills(c, { id: skill.id });
+      expect(unchanged.total_requests).toBe(0);
+    });
+  });
+});
+
+describe('logs', () => {
+  it('round-trips a log through the eval-scores view', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    const created = await logs.createLog(c, logParams(agent.id, skill.id));
+    expect(created.id).toMatch(/^[0-9a-f-]{36}$/);
+
+    const [fetched] = await logs.getLogs(c, { id: created.id });
+    expect(fetched.model).toBe('gpt-5');
+    expect(fetched.base_sa_config).toEqual({
+      agent_name: 'test-agent',
+      skill_name: 'test-skill',
+    });
+  });
+
+  it('orders newest first and honours the time range', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    await logs.createLog(c, logParams(agent.id, skill.id, 1000));
+    await logs.createLog(c, logParams(agent.id, skill.id, 3000));
+    await logs.createLog(c, logParams(agent.id, skill.id, 2000));
+
+    const all = await logs.getLogs(c, {});
+    expect(all.map((l) => l.start_time)).toEqual([3000, 2000, 1000]);
+
+    // Postgres combines these into one `and=(gte,lte)` filter.
+    const ranged = await logs.getLogs(c, { after: 1500, before: 2500 });
+    expect(ranged.map((l) => l.start_time)).toEqual([2000]);
+  });
+
+  it('filters on embeddings being present', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    await logs.createLog(c, logParams(agent.id, skill.id, 1000));
+    await logs.createLog(c, {
+      ...logParams(agent.id, skill.id, 2000),
+      embedding: [0.1, 0.2, 0.3],
+    } as Parameters<typeof logs.createLog>[1]);
+
+    const withEmbedding = await logs.getLogs(c, { embedding_not_null: true });
+    expect(withEmbedding).toHaveLength(1);
+    expect(withEmbedding[0].embedding).toEqual([0.1, 0.2, 0.3]);
+  });
+
+  it('deletes a log', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+    const created = await logs.createLog(c, logParams(agent.id, skill.id));
+
+    await logs.deleteLog(c, created.id);
+    expect(await logs.getLogs(c, {})).toHaveLength(0);
+  });
+});
+
+describe('system settings', () => {
+  it('reads the singleton seeded by migration 0003', async () => {
+    const { c } = await freshDatabase();
+
+    const settings = await store.getSystemSettings(c);
+    expect(settings.id).toBeTruthy();
+    expect(settings.developer_mode).toBe(false);
+  });
+
+  it('updates the singleton without needing its id', async () => {
+    const { c } = await freshDatabase();
+
+    const updated = await store.updateSystemSettings(c, {
+      developer_mode: true,
+    } as Parameters<typeof store.updateSystemSettings>[1]);
+
+    expect(updated.developer_mode).toBe(true);
+    expect((await store.getSystemSettings(c)).developer_mode).toBe(true);
+  });
+});
+
+describe('skill events', () => {
+  it('stores metadata as JSON and reads it back', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    const event = await store.createSkillEvent(c, {
+      agent_id: agent.id,
+      skill_id: skill.id,
+      event_type: 'model_added',
+      metadata: { model_name: 'gpt-5' },
+    } as Parameters<typeof store.createSkillEvent>[1]);
+
+    expect(event.metadata).toEqual({ model_name: 'gpt-5' });
+
+    const [fetched] = await store.getSkillEvents(c, { skill_id: skill.id });
+    expect(fetched.event_type).toBe('model_added');
+  });
+});
+
+describe('evaluations', () => {
+  it('throws when updating an evaluation that does not exist', async () => {
+    const { c } = await freshDatabase();
+
+    await expect(
+      store.updateSkillOptimizationEvaluation(
+        c,
+        '00000000-0000-4000-8000-00000000dead',
+        { weight: 2 } as Parameters<
+          typeof store.updateSkillOptimizationEvaluation
+        >[2],
+      ),
+    ).rejects.toThrow('Evaluation not found');
+  });
+});
+
+/**
+ * The TypeScript replacement for `get_evaluation_scores_by_time_bucket`.
+ * Bucketing and weighting are the parts most likely to drift from the plpgsql,
+ * so they are checked against hand-computed values.
+ */
+describe('getEvaluationScoresByTimeBucket', () => {
+  const setup = async () => {
+    const { client, c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    const evaluations = await store.createSkillOptimizationEvaluations(c, [
+      {
+        agent_id: agent.id,
+        skill_id: skill.id,
+        evaluation_method: 'task_completion',
+        weight: 3,
+        params: {},
+      } as Parameters<
+        typeof store.createSkillOptimizationEvaluations
+      >[1][number],
+    ]);
+    const [latency] = await store.createSkillOptimizationEvaluations(c, [
+      {
+        agent_id: agent.id,
+        skill_id: skill.id,
+        evaluation_method: 'latency',
+        weight: 1,
+        params: {},
+      } as Parameters<
+        typeof store.createSkillOptimizationEvaluations
+      >[1][number],
+    ]);
+
+    const log = await logs.createLog(c, logParams(agent.id, skill.id));
+
+    /** Insert a run at an explicit time; `created_at` otherwise defaults to now. */
+    const addRun = async (
+      createdAt: string,
+      results: Array<{ evaluation_id: string; score: number }>,
+    ) => {
+      await client.execute({
+        sql: `INSERT INTO skill_optimization_evaluation_runs
+                (id, agent_id, skill_id, log_id, results, created_at)
+              VALUES (?, ?, ?, ?, ?, ?)`,
+        args: [
+          crypto.randomUUID(),
+          agent.id,
+          skill.id,
+          log.id,
+          JSON.stringify(results),
+          createdAt,
+        ],
+      });
+    };
+
+    return {
+      c,
+      agent,
+      skill,
+      taskCompletion: evaluations[0],
+      latency,
+      addRun,
+    };
+  };
+
+  const range = {
+    start_time: '2026-01-01T00:00:00.000Z',
+    end_time: '2026-01-02T00:00:00.000Z',
+  };
+
+  it('groups runs into fixed buckets aligned to the epoch', async () => {
+    const { c, taskCompletion, addRun } = await setup();
+
+    await addRun('2026-01-01T00:05:00.000Z', [
+      { evaluation_id: taskCompletion.id, score: 1.0 },
+    ]);
+    await addRun('2026-01-01T00:25:00.000Z', [
+      { evaluation_id: taskCompletion.id, score: 0.0 },
+    ]);
+    await addRun('2026-01-01T01:10:00.000Z', [
+      { evaluation_id: taskCompletion.id, score: 0.5 },
+    ]);
+
+    const result = await store.getEvaluationScoresByTimeBucket(c, {
+      ...range,
+      interval_minutes: 60,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].time_bucket).toBe('2026-01-01T00:00:00.000Z');
+    expect(result[0].count).toBe(2);
+    // Mean of 1.0 and 0.0 within the bucket.
+    expect(result[0].avg_score).toBeCloseTo(0.5, 10);
+    expect(result[1].time_bucket).toBe('2026-01-01T01:00:00.000Z');
+    expect(result[1].count).toBe(1);
+    expect(result[1].avg_score).toBeCloseTo(0.5, 10);
+  });
+
+  it('honours the interval', async () => {
+    const { c, taskCompletion, addRun } = await setup();
+
+    await addRun('2026-01-01T00:05:00.000Z', [
+      { evaluation_id: taskCompletion.id, score: 1.0 },
+    ]);
+    await addRun('2026-01-01T00:25:00.000Z', [
+      { evaluation_id: taskCompletion.id, score: 0.0 },
+    ]);
+
+    const hourly = await store.getEvaluationScoresByTimeBucket(c, {
+      ...range,
+      interval_minutes: 60,
+    });
+    expect(hourly).toHaveLength(1);
+
+    // At 15 minutes the same two runs land in different buckets.
+    const quarterly = await store.getEvaluationScoresByTimeBucket(c, {
+      ...range,
+      interval_minutes: 15,
+    });
+    expect(quarterly).toHaveLength(2);
+    expect(quarterly.map((r) => r.time_bucket)).toEqual([
+      '2026-01-01T00:00:00.000Z',
+      '2026-01-01T00:15:00.000Z',
+    ]);
+  });
+
+  it('weights the average by the current evaluation weights', async () => {
+    const { c, taskCompletion, latency, addRun } = await setup();
+
+    await addRun('2026-01-01T00:05:00.000Z', [
+      { evaluation_id: taskCompletion.id, score: 1.0 },
+      { evaluation_id: latency.id, score: 0.0 },
+    ]);
+
+    const result = await store.getEvaluationScoresByTimeBucket(c, {
+      ...range,
+      interval_minutes: 60,
+    });
+
+    // (1.0 * 3 + 0.0 * 1) / 4
+    expect(result[0].avg_score).toBeCloseTo(0.75, 10);
+    expect(result[0].scores_by_evaluation).toEqual({
+      task_completion: 1.0,
+      latency: 0.0,
+    });
+  });
+
+  it('reflects a weight change retroactively', async () => {
+    const { c, taskCompletion, latency, addRun } = await setup();
+
+    await addRun('2026-01-01T00:05:00.000Z', [
+      { evaluation_id: taskCompletion.id, score: 1.0 },
+      { evaluation_id: latency.id, score: 0.0 },
+    ]);
+
+    // The function recomputes from current weights rather than reusing the
+    // weighted average stored on the run.
+    await store.updateSkillOptimizationEvaluation(c, taskCompletion.id, {
+      weight: 1,
+    } as Parameters<typeof store.updateSkillOptimizationEvaluation>[2]);
+
+    const result = await store.getEvaluationScoresByTimeBucket(c, {
+      ...range,
+      interval_minutes: 60,
+    });
+
+    expect(result[0].avg_score).toBeCloseTo(0.5, 10);
+  });
+
+  it('excludes runs outside the range and filters by skill', async () => {
+    const { c, skill, taskCompletion, addRun } = await setup();
+
+    await addRun('2025-12-31T23:00:00.000Z', [
+      { evaluation_id: taskCompletion.id, score: 1.0 },
+    ]);
+    await addRun('2026-01-01T00:05:00.000Z', [
+      { evaluation_id: taskCompletion.id, score: 0.5 },
+    ]);
+
+    const result = await store.getEvaluationScoresByTimeBucket(c, {
+      ...range,
+      interval_minutes: 60,
+      skill_id: skill.id,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].avg_score).toBeCloseTo(0.5, 10);
+
+    expect(
+      await store.getEvaluationScoresByTimeBucket(c, {
+        ...range,
+        interval_minutes: 60,
+        skill_id: '00000000-0000-4000-8000-00000000dead',
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns an empty series when nothing is in range', async () => {
+    const { c } = await setup();
+
+    expect(
+      await store.getEvaluationScoresByTimeBucket(c, {
+        ...range,
+        interval_minutes: 60,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/api/src/connectors/libsql/index.ts
+++ b/packages/api/src/connectors/libsql/index.ts
@@ -5,5 +5,8 @@ export {
   getLibsqlClient,
   resetLibsqlClients,
 } from './client';
+export { libsqlLogsStorageConnector } from './logs';
 export { migrateLibsql } from './migrate';
 export { type LibsqlMigration, libsqlMigrations } from './schema';
+export { aggregateScoresByTimeBucket } from './time-bucket';
+export { libsqlUserDataStorageConnector } from './user-data';

--- a/packages/api/src/connectors/libsql/libsql.test.ts
+++ b/packages/api/src/connectors/libsql/libsql.test.ts
@@ -67,10 +67,12 @@ describe('libsql migrations', () => {
     const { client } = await freshDatabase();
 
     const applied = await client.execute(
-      'SELECT version FROM schema_migrations',
+      'SELECT version FROM schema_migrations ORDER BY version',
     );
     expect(applied.rows.map((r) => String(r.version))).toEqual([
       '0001_initial_schema',
+      '0002_feedbacks_updated_at',
+      '0003_default_system_settings',
     ]);
   });
 
@@ -116,7 +118,7 @@ describe('libsql migrations', () => {
     const applied = await client.execute(
       'SELECT COUNT(*) AS n FROM schema_migrations',
     );
-    expect(Number(applied.rows[0].n)).toBe(1);
+    expect(Number(applied.rows[0].n)).toBe(3);
   });
 });
 
@@ -191,10 +193,11 @@ describe('libsql schema semantics', () => {
   it('keeps system_settings a singleton', async () => {
     const { client } = await freshDatabase();
 
-    await client.execute({
-      sql: 'INSERT INTO system_settings (id) VALUES (?)',
-      args: ['settings-1'],
-    });
+    // Migration 0003 seeds the one permitted row.
+    const seeded = await client.execute(
+      'SELECT COUNT(*) AS n FROM system_settings',
+    );
+    expect(Number(seeded.rows[0].n)).toBe(1);
 
     await expect(
       client.execute({
@@ -218,8 +221,8 @@ describe('libsql schema semantics', () => {
 
     await expect(
       client.execute({
-        sql: 'INSERT INTO system_settings (id, judge_model_id) VALUES (?, ?)',
-        args: ['settings-1', 'model-embed'],
+        sql: 'UPDATE system_settings SET judge_model_id = ?',
+        args: ['model-embed'],
       }),
     ).rejects.toThrow(/judge_model_id must reference a text model/);
   });
@@ -510,7 +513,7 @@ describe('row mapping', () => {
     expect(fromJson(toJsonColumn({ a: [1, 2] }) as string)).toEqual({
       a: [1, 2],
     });
-    expect(fromJson(null)).toBeUndefined();
+    expect(fromJson(null)).toBeNull();
     expect(fromJson('not json', { fallback: true })).toEqual({
       fallback: true,
     });
@@ -538,7 +541,7 @@ describe('row mapping', () => {
 
     expect(row.id).toBe('x');
     expect(row.total_requests).toBe(9007199254740990);
-    expect(row.trace_id).toBeUndefined();
+    expect(row.trace_id).toBeNull();
     expect(row.metadata).toEqual({ a: 1 });
     expect(row.optimize).toBe(true);
   });

--- a/packages/api/src/connectors/libsql/logs.ts
+++ b/packages/api/src/connectors/libsql/logs.ts
@@ -1,0 +1,121 @@
+import type { LogsStorageConnector } from '@api/types/connector';
+import type { AppContext } from '@api/types/hono';
+import {
+  Log,
+  type LogCreateParams,
+  type LogsQueryParams,
+} from '@shared/types/data/log';
+import { v4 as uuidv4 } from 'uuid';
+import { z } from 'zod';
+import { getLibsqlClient } from './client';
+import { insertInto, parseRows } from './query';
+import { asColumns, toJsonColumn } from './rows';
+
+/**
+ * Reads go through `logs_with_eval_scores`, which carries the computed
+ * `avg_eval_score` and `eval_run_count`, exactly as the Supabase connector
+ * does. Writes go to the `logs` table itself.
+ */
+export const libsqlLogsStorageConnector: LogsStorageConnector = {
+  getLogs: async (
+    c: AppContext,
+    queryParams: LogsQueryParams,
+  ): Promise<Log[]> => {
+    const conditions: string[] = [];
+    const args: (string | number)[] = [];
+
+    const eq = (column: string, value: string | number | undefined) => {
+      if (value !== undefined) {
+        conditions.push(`${column} = ?`);
+        args.push(value);
+      }
+    };
+
+    eq('agent_id', queryParams.agent_id);
+    eq('skill_id', queryParams.skill_id);
+    eq('cluster_id', queryParams.cluster_id);
+    eq('arm_id', queryParams.arm_id);
+    eq('app_id', queryParams.app_id);
+    eq('id', queryParams.id);
+    eq('method', queryParams.method);
+    eq('endpoint', queryParams.endpoint);
+    eq('function_name', queryParams.function_name);
+    eq('status', queryParams.status);
+    eq('cache_status', queryParams.cache_status);
+
+    if (queryParams.embedding_not_null) {
+      conditions.push('embedding IS NOT NULL');
+    }
+    if (queryParams.after !== undefined) {
+      conditions.push('start_time >= ?');
+      args.push(queryParams.after);
+    }
+    if (queryParams.before !== undefined) {
+      conditions.push('start_time <= ?');
+      args.push(queryParams.before);
+    }
+
+    let sql = 'SELECT * FROM logs_with_eval_scores';
+    if (conditions.length > 0) {
+      sql += ` WHERE ${conditions.join(' AND ')}`;
+    }
+    sql += ' ORDER BY start_time DESC';
+
+    if (queryParams.limit !== undefined) {
+      sql += ' LIMIT ?';
+      args.push(queryParams.limit);
+    }
+    if (queryParams.offset !== undefined) {
+      if (queryParams.limit === undefined) {
+        sql += ' LIMIT -1';
+      }
+      sql += ' OFFSET ?';
+      args.push(queryParams.offset);
+    }
+
+    const result = await getLibsqlClient(c).execute({ sql, args });
+    return parseRows('logs_with_eval_scores', result.rows, z.array(Log));
+  },
+
+  createLog: async (
+    c: AppContext,
+    createParams: LogCreateParams,
+  ): Promise<Log> => {
+    const {
+      base_sa_config,
+      ai_provider_request_log,
+      hook_logs,
+      metadata,
+      embedding,
+      user_metadata,
+      ...rest
+    } = createParams as LogCreateParams & Record<string, unknown>;
+
+    const rows = await insertInto(
+      getLibsqlClient(c),
+      'logs',
+      {
+        ...asColumns(rest),
+        id: uuidv4(),
+        base_sa_config: toJsonColumn(base_sa_config),
+        ai_provider_request_log: toJsonColumn(ai_provider_request_log),
+        hook_logs: toJsonColumn(hook_logs ?? []),
+        metadata: toJsonColumn(metadata ?? {}),
+        embedding:
+          embedding === undefined ? undefined : toJsonColumn(embedding),
+        user_metadata:
+          user_metadata === undefined ? undefined : toJsonColumn(user_metadata),
+      },
+      z.array(Log),
+    );
+
+    return rows[0];
+  },
+
+  deleteLog: async (c: AppContext, id: string): Promise<void> => {
+    await getLibsqlClient(c).execute({
+      sql: 'DELETE FROM logs WHERE id = ?',
+      args: [id],
+    });
+  },
+};

--- a/packages/api/src/connectors/libsql/query.ts
+++ b/packages/api/src/connectors/libsql/query.ts
@@ -1,0 +1,200 @@
+import type { Client, InValue, Row, Transaction } from '@libsql/client';
+import type { z } from 'zod';
+import { normaliseRow } from './rows';
+
+/**
+ * The query layer the connector methods sit on.
+ *
+ * PostgREST turns `{ agent_id: 'eq.x', limit: '10', order: 'name.asc' }` into
+ * SQL on the server. These helpers do the same job in-process, which is why the
+ * connector methods below read almost identically to their Supabase
+ * counterparts: they build the same filter objects, and only the executor
+ * differs.
+ */
+
+/** Columns stored as JSON text. Everything Postgres declared `JSONB`, plus the array columns. */
+const JSON_COLUMNS: Record<string, string[]> = {
+  agents: ['metadata'],
+  skills: ['metadata', 'allowed_template_variables'],
+  skill_optimization_clusters: ['centroid'],
+  tools: ['raw_data'],
+  logs: [
+    'base_sa_config',
+    'ai_provider_request_log',
+    'hook_logs',
+    'metadata',
+    'embedding',
+    'user_metadata',
+  ],
+  improved_responses: ['original_response_body', 'improved_response_body'],
+  ai_providers: ['custom_fields'],
+  skill_optimization_arms: ['params'],
+  skill_optimization_evaluations: ['params'],
+  skill_optimization_evaluation_runs: ['results'],
+  skill_events: ['metadata'],
+};
+
+// The view is `SELECT l.*` plus two computed columns, so it decodes like logs.
+JSON_COLUMNS.logs_with_eval_scores = JSON_COLUMNS.logs;
+
+/** Columns stored as INTEGER 0/1 that the schemas expect as booleans. */
+const BOOL_COLUMNS: Record<string, string[]> = {
+  skills: ['optimize'],
+  system_settings: ['developer_mode'],
+};
+
+/** Executes statements; a `Transaction` satisfies this as well as a `Client`. */
+type Executor = Pick<Client, 'execute'> | Pick<Transaction, 'execute'>;
+
+export interface Filters {
+  [column: string]: InValue | undefined;
+}
+
+export interface SelectOptions {
+  /** e.g. `'name asc'`, `'start_time desc'`. Applied verbatim, never user input. */
+  orderBy?: string;
+  limit?: number;
+  offset?: number;
+}
+
+const whereClause = (filters: Filters): { sql: string; args: InValue[] } => {
+  const entries = Object.entries(filters).filter(
+    ([, value]) => value !== undefined,
+  ) as [string, InValue][];
+
+  if (entries.length === 0) {
+    return { sql: '', args: [] };
+  }
+
+  return {
+    sql: ` WHERE ${entries.map(([column]) => `${column} = ?`).join(' AND ')}`,
+    args: entries.map(([, value]) => value),
+  };
+};
+
+/** Decode a table's rows and validate them against the schema they belong to. */
+export const parseRows = <T extends z.ZodType>(
+  table: string,
+  rows: Row[],
+  schema: T,
+): z.infer<T> => {
+  const decoded = rows.map((row) =>
+    normaliseRow(row, {
+      json: JSON_COLUMNS[table],
+      bool: BOOL_COLUMNS[table],
+    }),
+  );
+
+  const parsed = schema.safeParse(decoded);
+  if (!parsed.success) {
+    throw new Error(
+      `Failed to parse rows from libSQL table ${table}: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+};
+
+export const selectFrom = async <T extends z.ZodType>(
+  executor: Executor,
+  table: string,
+  filters: Filters,
+  schema: T,
+  options: SelectOptions = {},
+): Promise<z.infer<T>> => {
+  const where = whereClause(filters);
+  const args: InValue[] = [...where.args];
+
+  let sql = `SELECT * FROM ${table}${where.sql}`;
+  if (options.orderBy) {
+    sql += ` ORDER BY ${options.orderBy}`;
+  }
+  if (options.limit !== undefined) {
+    sql += ' LIMIT ?';
+    args.push(options.limit);
+  }
+  if (options.offset !== undefined) {
+    // SQLite rejects OFFSET without LIMIT, so supply the no-op limit Postgres
+    // implies. PostgREST allows offset alone.
+    if (options.limit === undefined) {
+      sql += ' LIMIT -1';
+    }
+    sql += ' OFFSET ?';
+    args.push(options.offset);
+  }
+
+  const result = await executor.execute({ sql, args });
+  return parseRows(table, result.rows, schema);
+};
+
+/**
+ * Insert one row and return it as stored, so that defaults and trigger-written
+ * columns come back the way PostgREST's `return=representation` provides them.
+ */
+export const insertInto = async <T extends z.ZodType>(
+  executor: Executor,
+  table: string,
+  values: Record<string, InValue | undefined>,
+  schema: T,
+): Promise<z.infer<T>> => {
+  const entries = Object.entries(values).filter(
+    ([, value]) => value !== undefined,
+  ) as [string, InValue][];
+
+  const columns = entries.map(([column]) => column);
+  const result = await executor.execute({
+    sql: `INSERT INTO ${table} (${columns.join(', ')})
+          VALUES (${columns.map(() => '?').join(', ')})
+          RETURNING *`,
+    args: entries.map(([, value]) => value),
+  });
+
+  return parseRows(table, result.rows, schema);
+};
+
+export const updateIn = async <T extends z.ZodType>(
+  executor: Executor,
+  table: string,
+  filters: Filters,
+  values: Record<string, InValue | undefined>,
+  schema: T,
+): Promise<z.infer<T>> => {
+  const entries = Object.entries(values).filter(
+    ([, value]) => value !== undefined,
+  ) as [string, InValue][];
+
+  if (entries.length === 0) {
+    // Nothing to change; report the current state, as a no-op PATCH would.
+    return selectFrom(executor, table, filters, schema);
+  }
+
+  const where = whereClause(filters);
+  await executor.execute({
+    sql: `UPDATE ${table} SET ${entries.map(([c]) => `${c} = ?`).join(', ')}${where.sql}`,
+    args: [...entries.map(([, value]) => value), ...where.args],
+  });
+
+  /**
+   * Read the row back rather than using `UPDATE ... RETURNING *`.
+   *
+   * SQLite computes RETURNING before AFTER triggers fire, so it would hand back
+   * the `updated_at` from before the trigger rewrote it. Postgres uses a BEFORE
+   * trigger, where RETURNING already sees the new value. Re-selecting is what
+   * makes the two backends agree.
+   *
+   * Safe because every filter here is an equality on a column the update never
+   * touches (`id`, or a bridge table's keys).
+   */
+  return selectFrom(executor, table, filters, schema);
+};
+
+export const deleteFrom = async (
+  executor: Executor,
+  table: string,
+  filters: Filters,
+): Promise<void> => {
+  const where = whereClause(filters);
+  await executor.execute({
+    sql: `DELETE FROM ${table}${where.sql}`,
+    args: where.args,
+  });
+};

--- a/packages/api/src/connectors/libsql/rows.ts
+++ b/packages/api/src/connectors/libsql/rows.ts
@@ -35,15 +35,12 @@ export const toBoolColumn = (value: boolean | undefined | null): InValue => {
 // --------------------------------------------------------------- from SQLite
 
 /**
- * Parse a JSON column.
- *
- * Returns `fallback` for NULL so that a nullable JSON column reads as
- * `undefined` rather than `null`, matching what the Zod schemas accept for
- * optional fields.
+ * Parse a JSON column. NULL stays `null`, which is what PostgREST returns for
+ * a NULL `jsonb` column and therefore what the Zod schemas expect.
  */
 export const fromJson = <T>(value: unknown, fallback?: T): T | undefined => {
   if (value === null || value === undefined) {
-    return fallback;
+    return fallback === undefined ? (null as T) : fallback;
   }
   if (typeof value !== 'string') {
     // libSQL can hand back an already-decoded value for some drivers.
@@ -60,11 +57,12 @@ export const fromBool = (value: unknown): boolean =>
   value === 1 || value === true;
 
 /**
- * Normalise a raw row: `bigint` to `number`, and NULL to `undefined`.
+ * Normalise a raw row: `bigint` to `number`, everything else as stored.
  *
- * The Zod schemas mark absent fields `.optional()` rather than `.nullable()`,
- * so a NULL column has to arrive as `undefined` or parsing fails. Columns that
- * need JSON or boolean decoding are named by the caller.
+ * NULL is deliberately preserved rather than mapped to `undefined`: PostgREST
+ * serialises a NULL column as JSON `null`, so the Zod schemas are written with
+ * `.nullable()` and would reject `undefined`. Columns that need JSON or boolean
+ * decoding are named by the caller.
  */
 export const normaliseRow = (
   row: Row,
@@ -80,12 +78,11 @@ export const normaliseRow = (
       continue;
     }
     if (bool.has(key)) {
-      out[key] =
-        value === null || value === undefined ? undefined : fromBool(value);
+      out[key] = value === null || value === undefined ? null : fromBool(value);
       continue;
     }
     if (value === null || value === undefined) {
-      out[key] = undefined;
+      out[key] = null;
       continue;
     }
     out[key] = typeof value === 'bigint' ? Number(value) : value;
@@ -142,4 +139,38 @@ export const buildUpdate = (
     sql: `UPDATE ${table} SET ${assignments.join(', ')} WHERE ${where.column} = ?`,
     args: [...entries.map(([, value]) => value), where.value],
   };
+};
+
+/**
+ * Coerce a plain object into bindable column values.
+ *
+ * Used where a create or update object is spread into a statement: strings and
+ * numbers pass through, booleans become 0/1, and anything structural is
+ * stringified for the JSON TEXT column it belongs to. `undefined` survives so
+ * the query builders can drop the column and let its default apply.
+ */
+export const asColumns = (
+  values: Record<string, unknown>,
+): Record<string, InValue | undefined> => {
+  const out: Record<string, InValue | undefined> = {};
+
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) {
+      out[key] = undefined;
+    } else if (value === null) {
+      out[key] = null;
+    } else if (typeof value === 'boolean') {
+      out[key] = value ? 1 : 0;
+    } else if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'bigint'
+    ) {
+      out[key] = value;
+    } else {
+      out[key] = JSON.stringify(value);
+    }
+  }
+
+  return out;
 };

--- a/packages/api/src/connectors/libsql/schema.ts
+++ b/packages/api/src/connectors/libsql/schema.ts
@@ -517,4 +517,42 @@ const initialSchema: LibsqlMigration = {
   ],
 };
 
-export const libsqlMigrations: LibsqlMigration[] = [initialSchema];
+/**
+ * Mirrors `supabase/migrations/20260826000000_feedbacks_updated_at.sql`.
+ *
+ * `Feedback` is `.strict()` and requires `updated_at`, and
+ * `FeedbackCreateParams` generates one on every create, but the table never had
+ * the column on either backend. Appended rather than folded into the initial
+ * schema so the two backends' migration histories stay in step.
+ */
+const feedbacksUpdatedAt: LibsqlMigration = {
+  version: '0002_feedbacks_updated_at',
+  statements: [
+    `ALTER TABLE feedbacks
+      ADD COLUMN updated_at TEXT NOT NULL DEFAULT (${NOW_ISO})`,
+    updatedAtTrigger('feedbacks'),
+  ],
+};
+
+/**
+ * The Postgres initial migration seeds the singleton settings row, and
+ * `getSystemSettings` returns `settings[0]` assuming it is there. The initial
+ * libSQL migration created the table but not the row.
+ *
+ * The id is fixed rather than generated: the row is a singleton whose id is
+ * never referenced by anything, and a constant keeps the migration
+ * deterministic (SQLite has no uuid function).
+ */
+const defaultSystemSettings: LibsqlMigration = {
+  version: '0003_default_system_settings',
+  statements: [
+    `INSERT OR IGNORE INTO system_settings (id, singleton)
+     VALUES ('00000000-0000-4000-8000-000000000001', 1)`,
+  ],
+};
+
+export const libsqlMigrations: LibsqlMigration[] = [
+  initialSchema,
+  feedbacksUpdatedAt,
+  defaultSystemSettings,
+];

--- a/packages/api/src/connectors/libsql/time-bucket.ts
+++ b/packages/api/src/connectors/libsql/time-bucket.ts
@@ -1,0 +1,164 @@
+import type { Client } from '@libsql/client';
+import type {
+  EvaluationScoresByTimeBucketParams,
+  EvaluationScoresByTimeBucketResult,
+} from '@shared/types/data/evaluation-runs-with-scores';
+
+/**
+ * Replaces the `get_evaluation_scores_by_time_bucket` plpgsql function.
+ *
+ * SQLite has no stored procedures, so the SQL fetches the per-run scores from
+ * `evaluation_runs_with_scores` and the bucketing and weighting happen here.
+ * Doing the arithmetic in TypeScript rather than in a single dense query also
+ * keeps it readable against the plpgsql it replaces.
+ *
+ * The Postgres function's semantics that matter, and are reproduced here:
+ *
+ * - Buckets are aligned to the epoch at `interval_minutes`, so a series is
+ *   stable across calls rather than relative to the range requested.
+ * - `avg_score` is recomputed from the **current** evaluation weights rather
+ *   than reusing the weighted average stored per run, so re-weighting an
+ *   evaluation retroactively changes the chart.
+ * - An evaluation method with no matching row weighs 1.0 (`COALESCE(e.weight, 1.0)`).
+ * - `scores_by_evaluation` holds the per-method mean within the bucket.
+ * - `count` is the number of runs in the bucket, not the number of scores.
+ * - Results are ordered by bucket ascending.
+ */
+export const aggregateScoresByTimeBucket = async (
+  client: Client,
+  params: EvaluationScoresByTimeBucketParams,
+): Promise<EvaluationScoresByTimeBucketResult[]> => {
+  const conditions = ['er.created_at >= ?', 'er.created_at <= ?'];
+  const args: (string | number)[] = [params.start_time, params.end_time];
+
+  if (params.agent_id) {
+    conditions.push('er.agent_id = ?');
+    args.push(params.agent_id);
+  }
+  if (params.skill_id) {
+    conditions.push('er.skill_id = ?');
+    args.push(params.skill_id);
+  }
+  if (params.cluster_id) {
+    conditions.push('er.cluster_id = ?');
+    args.push(params.cluster_id);
+  }
+
+  const result = await client.execute({
+    sql: `SELECT er.agent_id, er.skill_id, er.cluster_id, er.created_at,
+                 er.scores_by_evaluation
+          FROM evaluation_runs_with_scores er
+          WHERE ${conditions.join(' AND ')}`,
+    args,
+  });
+
+  const intervalMs = params.interval_minutes * 60 * 1000;
+
+  interface Bucket {
+    time_bucket: string;
+    agent_id: string;
+    skill_id: string;
+    cluster_id: string | null;
+    /** Per evaluation method: every score seen in this bucket. */
+    scores: Map<string, number[]>;
+    count: number;
+  }
+
+  const buckets = new Map<string, Bucket>();
+
+  for (const row of result.rows) {
+    const createdAt = Date.parse(String(row.created_at));
+    if (Number.isNaN(createdAt)) {
+      continue;
+    }
+
+    const bucketStart = Math.floor(createdAt / intervalMs) * intervalMs;
+    const timeBucket = new Date(bucketStart).toISOString();
+    const clusterId =
+      row.cluster_id === null || row.cluster_id === undefined
+        ? null
+        : String(row.cluster_id);
+
+    const key = `${timeBucket}|${row.agent_id}|${row.skill_id}|${clusterId ?? ''}`;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        time_bucket: timeBucket,
+        agent_id: String(row.agent_id),
+        skill_id: String(row.skill_id),
+        cluster_id: clusterId,
+        scores: new Map(),
+        count: 0,
+      };
+      buckets.set(key, bucket);
+    }
+
+    bucket.count += 1;
+
+    // NULL when the run's results referenced no known evaluation.
+    if (row.scores_by_evaluation === null) {
+      continue;
+    }
+
+    const scores = JSON.parse(String(row.scores_by_evaluation)) as Record<
+      string,
+      number
+    >;
+    for (const [method, score] of Object.entries(scores)) {
+      const seen = bucket.scores.get(method);
+      if (seen) {
+        seen.push(score);
+      } else {
+        bucket.scores.set(method, [score]);
+      }
+    }
+  }
+
+  if (buckets.size === 0) {
+    return [];
+  }
+
+  // Current weights, keyed by skill and method, matching the function's join on
+  // `e.skill_id = ... AND e.evaluation_method = ...`.
+  const weightRows = await client.execute(
+    'SELECT skill_id, evaluation_method, weight FROM skill_optimization_evaluations',
+  );
+  const weights = new Map<string, number>();
+  for (const row of weightRows.rows) {
+    weights.set(`${row.skill_id}|${row.evaluation_method}`, Number(row.weight));
+  }
+
+  const results: EvaluationScoresByTimeBucketResult[] = [];
+
+  for (const bucket of buckets.values()) {
+    const scoresByEvaluation: Record<string, number> = {};
+    let weightedSum = 0;
+    let weightTotal = 0;
+
+    for (const [method, scores] of bucket.scores) {
+      const mean = scores.reduce((sum, s) => sum + s, 0) / scores.length;
+      scoresByEvaluation[method] = mean;
+
+      const weight = weights.get(`${bucket.skill_id}|${method}`) ?? 1.0;
+      weightedSum += mean * weight;
+      weightTotal += weight;
+    }
+
+    results.push({
+      time_bucket: bucket.time_bucket,
+      agent_id: bucket.agent_id,
+      skill_id: bucket.skill_id,
+      cluster_id: bucket.cluster_id,
+      avg_score: weightTotal === 0 ? null : weightedSum / weightTotal,
+      scores_by_evaluation:
+        Object.keys(scoresByEvaluation).length === 0
+          ? null
+          : scoresByEvaluation,
+      count: bucket.count,
+    });
+  }
+
+  results.sort((a, b) => a.time_bucket.localeCompare(b.time_bucket));
+
+  return results;
+};

--- a/packages/api/src/connectors/libsql/user-data.ts
+++ b/packages/api/src/connectors/libsql/user-data.ts
@@ -1,0 +1,1219 @@
+import type { UserDataStorageConnector } from '@api/types/connector';
+import type { AppContext } from '@api/types/hono';
+import { decryptAPIKey, encryptAPIKey } from '@api/utils/api-key-encryption';
+import { emitSSEEvent } from '@api/utils/sse-event-manager';
+import {
+  Agent as AgentSchema,
+  type Feedback,
+  type FeedbackCreateParams,
+  type FeedbackQueryParams,
+  Feedback as FeedbackSchema,
+  type ImprovedResponse,
+  type ImprovedResponseQueryParams,
+  ImprovedResponse as ImprovedResponseSchema,
+  type ImprovedResponseUpdateParams,
+  type Model,
+  type ModelCreateParams,
+  type ModelQueryParams,
+  Model as ModelSchema,
+  type ModelUpdateParams,
+  type Skill,
+  type SkillCreateParams,
+  type SkillEvent,
+  type SkillEventCreateParams,
+  type SkillEventQueryParams,
+  SkillEvent as SkillEventSchema,
+  type SkillOptimizationArm,
+  type SkillOptimizationArmCreateParams,
+  type SkillOptimizationArmQueryParams,
+  SkillOptimizationArm as SkillOptimizationArmSchema,
+  type SkillOptimizationArmUpdateParams,
+  type SkillOptimizationCluster,
+  type SkillOptimizationClusterCreateParams,
+  type SkillOptimizationClusterQueryParams,
+  SkillOptimizationCluster as SkillOptimizationClusterSchema,
+  type SkillOptimizationClusterUpdateParams,
+  type SkillOptimizationEvaluation,
+  type SkillOptimizationEvaluationCreateParams,
+  type SkillOptimizationEvaluationQueryParams,
+  type SkillOptimizationEvaluationRun,
+  type SkillOptimizationEvaluationRunCreateParams,
+  type SkillOptimizationEvaluationRunQueryParams,
+  SkillOptimizationEvaluationRun as SkillOptimizationEvaluationRunSchema,
+  SkillOptimizationEvaluation as SkillOptimizationEvaluationSchema,
+  type SkillOptimizationEvaluationUpdateParams,
+  type SkillQueryParams,
+  Skill as SkillSchema,
+  type SkillUpdateParams,
+  type SystemSettings,
+  SystemSettings as SystemSettingsSchema,
+  type SystemSettingsUpdateParams,
+  type Tool,
+  type ToolCreateParams,
+  type ToolQueryParams,
+  Tool as ToolSchema,
+} from '@shared/types/data';
+import type {
+  Agent,
+  AgentCreateParams,
+  AgentQueryParams,
+  AgentUpdateParams,
+} from '@shared/types/data/agent';
+import type {
+  AIProviderConfig,
+  AIProviderConfigCreateParams,
+  AIProviderConfigQueryParams,
+  AIProviderConfigUpdateParams,
+} from '@shared/types/data/ai-provider';
+import { AIProviderConfig as AIProviderConfigSchema } from '@shared/types/data/ai-provider';
+import type { EvaluationScoresByTimeBucketParams } from '@shared/types/data/evaluation-runs-with-scores';
+import type {
+  SkillOptimizationArmStat,
+  SkillOptimizationArmStatQueryParams,
+} from '@shared/types/data/skill-optimization-arm-stats';
+import { SkillOptimizationArmStat as SkillOptimizationArmStatSchema } from '@shared/types/data/skill-optimization-arm-stats';
+import { v4 as uuidv4 } from 'uuid';
+import { z } from 'zod';
+import { getLibsqlClient } from './client';
+import {
+  deleteFrom,
+  insertInto,
+  parseRows,
+  selectFrom,
+  updateIn,
+} from './query';
+import { asColumns, toJsonColumn } from './rows';
+import { aggregateScoresByTimeBucket } from './time-bucket';
+
+/**
+ * libSQL implementation of `UserDataStorageConnector`.
+ *
+ * Deliberately shaped like `connectors/supabase/supabase.ts` method for method,
+ * so the two can be diffed when behaviour is in question. The differences are
+ * confined to three places:
+ *
+ * 1. **Ids.** Postgres defaults `id` to `uuid_generate_v4()`. SQLite has no
+ *    uuid function, so creates that do not carry an id generate one here.
+ * 2. **JSON columns.** Objects and arrays are stringified going in; `query.ts`
+ *    decodes them coming out.
+ * 3. **Stored procedures.** The five RPCs the API calls become explicit
+ *    transactions at the bottom of this file.
+ */
+
+/** Postgres generates ids column-side; SQLite needs them supplied. */
+const withId = <T extends { id?: string }>(row: T): T & { id: string } => ({
+  ...row,
+  id: row.id ?? uuidv4(),
+});
+
+export const libsqlUserDataStorageConnector: UserDataStorageConnector = {
+  // ------------------------------------------------------------- Feedback
+  getFeedback: async (
+    c: AppContext,
+    queryParams: FeedbackQueryParams,
+  ): Promise<Feedback[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'feedbacks',
+      { id: queryParams.id, log_id: queryParams.log_id },
+      z.array(FeedbackSchema),
+      { limit: queryParams.limit, offset: queryParams.offset },
+    ),
+
+  createFeedback: async (
+    c: AppContext,
+    feedback: FeedbackCreateParams,
+  ): Promise<Feedback> => {
+    const rows = await insertInto(
+      getLibsqlClient(c),
+      'feedbacks',
+      withId(feedback),
+      z.array(FeedbackSchema),
+    );
+    return rows[0];
+  },
+
+  deleteFeedback: async (c: AppContext, id: string): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'feedbacks', { id });
+  },
+
+  // ----------------------------------------------------- Improved Response
+  getImprovedResponse: async (
+    c: AppContext,
+    params: ImprovedResponseQueryParams,
+  ): Promise<ImprovedResponse[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'improved_responses',
+      {
+        id: params.id,
+        agent_id: params.agent_id,
+        skill_id: params.skill_id,
+        log_id: params.log_id,
+      },
+      z.array(ImprovedResponseSchema),
+    ),
+
+  createImprovedResponse: async (
+    c: AppContext,
+    improvedResponse: ImprovedResponse,
+  ): Promise<ImprovedResponse> => {
+    const rows = await insertInto(
+      getLibsqlClient(c),
+      'improved_responses',
+      {
+        ...withId(improvedResponse),
+        original_response_body: toJsonColumn(
+          improvedResponse.original_response_body,
+        ),
+        improved_response_body: toJsonColumn(
+          improvedResponse.improved_response_body,
+        ),
+      },
+      z.array(ImprovedResponseSchema),
+    );
+    return rows[0];
+  },
+
+  updateImprovedResponse: async (
+    c: AppContext,
+    id: string,
+    update: ImprovedResponseUpdateParams,
+  ): Promise<ImprovedResponse> => {
+    const rows = await updateIn(
+      getLibsqlClient(c),
+      'improved_responses',
+      { id },
+      {
+        improved_response_body:
+          update.improved_response_body === undefined
+            ? undefined
+            : toJsonColumn(update.improved_response_body),
+      },
+      z.array(ImprovedResponseSchema),
+    );
+    return rows[0];
+  },
+
+  deleteImprovedResponse: async (c: AppContext, id: string): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'improved_responses', { id });
+  },
+
+  // --------------------------------------------------------------- Agents
+  getAgents: async (
+    c: AppContext,
+    queryParams: AgentQueryParams,
+  ): Promise<Agent[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'agents',
+      { id: queryParams.id, name: queryParams.name },
+      z.array(AgentSchema),
+      { limit: queryParams.limit, offset: queryParams.offset },
+    ),
+
+  createAgent: async (
+    c: AppContext,
+    agent: AgentCreateParams,
+  ): Promise<Agent> => {
+    const rows = await insertInto(
+      getLibsqlClient(c),
+      'agents',
+      {
+        id: uuidv4(),
+        name: agent.name,
+        description: agent.description,
+        metadata: toJsonColumn(agent.metadata ?? {}),
+      },
+      z.array(AgentSchema),
+    );
+    return rows[0];
+  },
+
+  updateAgent: async (
+    c: AppContext,
+    id: string,
+    update: AgentUpdateParams,
+  ): Promise<Agent> => {
+    const rows = await updateIn(
+      getLibsqlClient(c),
+      'agents',
+      { id },
+      {
+        description: update.description ?? undefined,
+        metadata:
+          update.metadata === undefined
+            ? undefined
+            : toJsonColumn(update.metadata),
+      },
+      z.array(AgentSchema),
+    );
+    return rows[0];
+  },
+
+  deleteAgent: async (c: AppContext, id: string): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'agents', { id });
+  },
+
+  // --------------------------------------------------------------- Skills
+  getSkills: async (
+    c: AppContext,
+    queryParams: SkillQueryParams,
+  ): Promise<Skill[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'skills',
+      {
+        id: queryParams.id,
+        agent_id: queryParams.agent_id,
+        name: queryParams.name,
+      },
+      z.array(SkillSchema),
+      { limit: queryParams.limit, offset: queryParams.offset },
+    ),
+
+  createSkill: async (
+    c: AppContext,
+    skill: SkillCreateParams,
+  ): Promise<Skill> => {
+    const { metadata, allowed_template_variables, optimize, ...rest } =
+      skill as SkillCreateParams & Record<string, unknown>;
+
+    const rows = await insertInto(
+      getLibsqlClient(c),
+      'skills',
+      {
+        ...asColumns(rest),
+        id: uuidv4(),
+        metadata: toJsonColumn(metadata ?? {}),
+        allowed_template_variables: toJsonColumn(
+          allowed_template_variables ?? [],
+        ),
+        optimize: optimize === undefined ? undefined : optimize ? 1 : 0,
+      },
+      z.array(SkillSchema),
+    );
+    return rows[0];
+  },
+
+  updateSkill: async (
+    c: AppContext,
+    id: string,
+    update: SkillUpdateParams,
+  ): Promise<Skill> => {
+    const { metadata, allowed_template_variables, optimize, ...rest } =
+      update as SkillUpdateParams & Record<string, unknown>;
+
+    const rows = await updateIn(
+      getLibsqlClient(c),
+      'skills',
+      { id },
+      {
+        ...asColumns(rest),
+        metadata: metadata === undefined ? undefined : toJsonColumn(metadata),
+        allowed_template_variables:
+          allowed_template_variables === undefined
+            ? undefined
+            : toJsonColumn(allowed_template_variables),
+        optimize: optimize === undefined ? undefined : optimize ? 1 : 0,
+      },
+      z.array(SkillSchema),
+    );
+    return rows[0];
+  },
+
+  deleteSkill: async (c: AppContext, id: string): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'skills', { id });
+  },
+
+  /** Replaces the `increment_skill_total_requests` RPC. */
+  incrementSkillTotalRequests: async (
+    c: AppContext,
+    skillId: string,
+  ): Promise<Skill> => {
+    const client = getLibsqlClient(c);
+    await client.execute({
+      sql: 'UPDATE skills SET total_requests = total_requests + 1 WHERE id = ?',
+      args: [skillId],
+    });
+    const rows = await selectFrom(
+      client,
+      'skills',
+      { id: skillId },
+      z.array(SkillSchema),
+    );
+    return rows[0];
+  },
+
+  /**
+   * Replaces the `try_acquire_reclustering_lock` RPC.
+   *
+   * The conditional UPDATE is what makes this a lock: two callers racing both
+   * issue it, SQLite serialises them, and only the one that finds
+   * `last_clustering_at` still stale changes a row.
+   */
+  tryAcquireReclusteringLock: async (
+    c: AppContext,
+    skillId: string,
+    lockThresholdMs: number,
+  ): Promise<Skill | null> => {
+    const client = getLibsqlClient(c);
+    const now = new Date();
+    const cutoff = new Date(now.getTime() - lockThresholdMs).toISOString();
+
+    const result = await client.execute({
+      sql: `UPDATE skills SET last_clustering_at = ?
+            WHERE id = ?
+              AND (last_clustering_at IS NULL OR last_clustering_at < ?)`,
+      args: [now.toISOString(), skillId, cutoff],
+    });
+
+    if (result.rowsAffected === 0) {
+      return null;
+    }
+
+    const rows = await selectFrom(
+      client,
+      'skills',
+      { id: skillId },
+      z.array(SkillSchema),
+    );
+    return rows[0] ?? null;
+  },
+
+  // ---------------------------------------------------------------- Tools
+  getTools: async (
+    c: AppContext,
+    queryParams: ToolQueryParams,
+  ): Promise<Tool[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'tools',
+      {
+        id: queryParams.id,
+        agent_id: queryParams.agent_id,
+        hash: queryParams.hash,
+        type: queryParams.type,
+        name: queryParams.name,
+      },
+      z.array(ToolSchema),
+      { limit: queryParams.limit, offset: queryParams.offset },
+    ),
+
+  createTool: async (c: AppContext, tool: ToolCreateParams): Promise<Tool> => {
+    const rows = await insertInto(
+      getLibsqlClient(c),
+      'tools',
+      {
+        ...withId(tool as ToolCreateParams & { id?: string }),
+        raw_data: toJsonColumn(tool.raw_data),
+      },
+      z.array(ToolSchema),
+    );
+    return rows[0];
+  },
+
+  deleteTool: async (c: AppContext, id: string): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'tools', { id });
+  },
+
+  // ------------------------------------------------- AI Provider API Keys
+  getAIProviderAPIKeys: async (
+    c: AppContext,
+    queryParams: AIProviderConfigQueryParams,
+  ): Promise<AIProviderConfig[]> => {
+    const rows = await selectFrom(
+      getLibsqlClient(c),
+      'ai_providers',
+      {
+        id: queryParams.id,
+        ai_provider: queryParams.ai_provider,
+        name: queryParams.name,
+      },
+      z.array(AIProviderConfigSchema),
+      { limit: queryParams.limit, offset: queryParams.offset },
+    );
+
+    return rows.map((row) => ({
+      ...row,
+      api_key: row.api_key ? decryptAPIKey(c, row.api_key) : null,
+    }));
+  },
+
+  getAIProviderAPIKeyById: async (
+    c: AppContext,
+    id: string,
+  ): Promise<AIProviderConfig | null> => {
+    const rows = await selectFrom(
+      getLibsqlClient(c),
+      'ai_providers',
+      { id },
+      z.array(AIProviderConfigSchema),
+    );
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    return {
+      ...rows[0],
+      api_key: rows[0].api_key ? decryptAPIKey(c, rows[0].api_key) : null,
+    };
+  },
+
+  createAIProvider: async (
+    c: AppContext,
+    apiKey: AIProviderConfigCreateParams,
+  ): Promise<AIProviderConfig> => {
+    const rows = await insertInto(
+      getLibsqlClient(c),
+      'ai_providers',
+      {
+        id: uuidv4(),
+        ai_provider: apiKey.ai_provider,
+        name: apiKey.name,
+        api_key: apiKey.api_key ? encryptAPIKey(c, apiKey.api_key) : null,
+        custom_fields: toJsonColumn(apiKey.custom_fields ?? {}),
+      },
+      z.array(AIProviderConfigSchema),
+    );
+
+    return {
+      ...rows[0],
+      api_key: rows[0].api_key ? decryptAPIKey(c, rows[0].api_key) : null,
+    };
+  },
+
+  updateAIProvider: async (
+    c: AppContext,
+    id: string,
+    update: AIProviderConfigUpdateParams,
+  ): Promise<AIProviderConfig> => {
+    const rows = await updateIn(
+      getLibsqlClient(c),
+      'ai_providers',
+      { id },
+      {
+        ai_provider: update.ai_provider,
+        name: update.name,
+        api_key:
+          update.api_key === undefined
+            ? undefined
+            : update.api_key
+              ? encryptAPIKey(c, update.api_key)
+              : null,
+        custom_fields:
+          update.custom_fields === undefined
+            ? undefined
+            : toJsonColumn(update.custom_fields),
+      },
+      z.array(AIProviderConfigSchema),
+    );
+
+    return {
+      ...rows[0],
+      api_key: rows[0].api_key ? decryptAPIKey(c, rows[0].api_key) : null,
+    };
+  },
+
+  deleteAIProvider: async (c: AppContext, id: string): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'ai_providers', { id });
+  },
+
+  // --------------------------------------------------------------- Models
+  getModels: async (
+    c: AppContext,
+    queryParams: ModelQueryParams,
+  ): Promise<Model[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'models',
+      {
+        id: queryParams.id,
+        ai_provider_id: queryParams.ai_provider_id,
+        model_name: queryParams.model_name,
+      },
+      z.array(ModelSchema),
+      { limit: queryParams.limit, offset: queryParams.offset },
+    ),
+
+  createModel: async (
+    c: AppContext,
+    model: ModelCreateParams,
+  ): Promise<Model> => {
+    const rows = await insertInto(
+      getLibsqlClient(c),
+      'models',
+      withId(model as ModelCreateParams & { id?: string }),
+      z.array(ModelSchema),
+    );
+    return rows[0];
+  },
+
+  updateModel: async (
+    c: AppContext,
+    id: string,
+    update: ModelUpdateParams,
+  ): Promise<Model> => {
+    const rows = await updateIn(
+      getLibsqlClient(c),
+      'models',
+      { id },
+      asColumns(update),
+      z.array(ModelSchema),
+    );
+    return rows[0];
+  },
+
+  deleteModel: async (c: AppContext, id: string): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'models', { id });
+  },
+
+  // --------------------------------------------- Skill-Model Relationships
+  /** PostgREST expresses this as an embedded select; here it is a plain join. */
+  getSkillModels: async (c: AppContext, skillId: string): Promise<Model[]> => {
+    const result = await getLibsqlClient(c).execute({
+      sql: `SELECT m.* FROM skill_models sm
+            JOIN models m ON m.id = sm.model_id
+            WHERE sm.skill_id = ?`,
+      args: [skillId],
+    });
+    return parseRows('models', result.rows, z.array(ModelSchema));
+  },
+
+  getSkillsByModelId: async (
+    c: AppContext,
+    modelId: string,
+  ): Promise<Skill[]> => {
+    const result = await getLibsqlClient(c).execute({
+      sql: `SELECT s.* FROM skill_models sm
+            JOIN skills s ON s.id = sm.skill_id
+            WHERE sm.model_id = ?`,
+      args: [modelId],
+    });
+    return parseRows('skills', result.rows, z.array(SkillSchema));
+  },
+
+  addModelsToSkill: async (
+    c: AppContext,
+    skillId: string,
+    modelIds: string[],
+  ): Promise<void> => {
+    if (modelIds.length === 0) {
+      return;
+    }
+
+    await getLibsqlClient(c).batch(
+      modelIds.map((modelId) => ({
+        sql: 'INSERT OR IGNORE INTO skill_models (skill_id, model_id) VALUES (?, ?)',
+        args: [skillId, modelId],
+      })),
+      'write',
+    );
+  },
+
+  removeModelsFromSkill: async (
+    c: AppContext,
+    skillId: string,
+    modelIds: string[],
+  ): Promise<void> => {
+    if (modelIds.length === 0) {
+      return;
+    }
+
+    await getLibsqlClient(c).batch(
+      modelIds.map((modelId) => ({
+        sql: 'DELETE FROM skill_models WHERE skill_id = ? AND model_id = ?',
+        args: [skillId, modelId],
+      })),
+      'write',
+    );
+  },
+
+  // ------------------------------------------ Skill Optimization Clusters
+  getSkillOptimizationClusters: async (
+    c: AppContext,
+    queryParams: SkillOptimizationClusterQueryParams,
+  ): Promise<SkillOptimizationCluster[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'skill_optimization_clusters',
+      {
+        id: queryParams.id,
+        agent_id: queryParams.agent_id,
+        skill_id: queryParams.skill_id,
+      },
+      z.array(SkillOptimizationClusterSchema),
+      {
+        orderBy: 'name asc',
+        limit: queryParams.limit,
+        offset: queryParams.offset,
+      },
+    ),
+
+  createSkillOptimizationClusters: async (
+    c: AppContext,
+    params_list: SkillOptimizationClusterCreateParams[],
+  ): Promise<SkillOptimizationCluster[]> => {
+    const client = getLibsqlClient(c);
+    const created: SkillOptimizationCluster[] = [];
+
+    for (const params of params_list) {
+      const rows = await insertInto(
+        client,
+        'skill_optimization_clusters',
+        {
+          ...withId(
+            params as SkillOptimizationClusterCreateParams & {
+              id?: string;
+            },
+          ),
+          centroid: toJsonColumn(params.centroid),
+        },
+        z.array(SkillOptimizationClusterSchema),
+      );
+      created.push(rows[0]);
+    }
+
+    return created;
+  },
+
+  updateSkillOptimizationCluster: async (
+    c: AppContext,
+    id: string,
+    update: SkillOptimizationClusterUpdateParams,
+  ): Promise<SkillOptimizationCluster> => {
+    const { centroid, ...rest } =
+      update as SkillOptimizationClusterUpdateParams & Record<string, unknown>;
+
+    const rows = await updateIn(
+      getLibsqlClient(c),
+      'skill_optimization_clusters',
+      { id },
+      {
+        ...asColumns(rest),
+        centroid: centroid === undefined ? undefined : toJsonColumn(centroid),
+      },
+      z.array(SkillOptimizationClusterSchema),
+    );
+    return rows[0];
+  },
+
+  deleteSkillOptimizationCluster: async (
+    c: AppContext,
+    id: string,
+  ): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'skill_optimization_clusters', { id });
+  },
+
+  /** Replaces the `increment_cluster_counters` RPC. */
+  incrementClusterCounters: async (
+    c: AppContext,
+    clusterId: string,
+  ): Promise<SkillOptimizationCluster> => {
+    const client = getLibsqlClient(c);
+    await client.execute({
+      sql: `UPDATE skill_optimization_clusters
+            SET total_steps = total_steps + 1,
+                observability_total_requests = observability_total_requests + 1
+            WHERE id = ?`,
+      args: [clusterId],
+    });
+    const rows = await selectFrom(
+      client,
+      'skill_optimization_clusters',
+      { id: clusterId },
+      z.array(SkillOptimizationClusterSchema),
+    );
+    return rows[0];
+  },
+
+  // ---------------------------------------------- Skill Optimization Arms
+  getSkillOptimizationArms: async (
+    c: AppContext,
+    queryParams: SkillOptimizationArmQueryParams,
+  ): Promise<SkillOptimizationArm[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'skill_optimization_arms',
+      {
+        id: queryParams.id,
+        agent_id: queryParams.agent_id,
+        skill_id: queryParams.skill_id,
+        cluster_id: queryParams.cluster_id,
+      },
+      z.array(SkillOptimizationArmSchema),
+      {
+        orderBy: 'created_at desc',
+        limit: queryParams.limit,
+        offset: queryParams.offset,
+      },
+    ),
+
+  createSkillOptimizationArms: async (
+    c: AppContext,
+    params_list: SkillOptimizationArmCreateParams[],
+  ): Promise<SkillOptimizationArm[]> => {
+    const client = getLibsqlClient(c);
+    const created: SkillOptimizationArm[] = [];
+
+    for (const params of params_list) {
+      const rows = await insertInto(
+        client,
+        'skill_optimization_arms',
+        {
+          ...withId(
+            params as SkillOptimizationArmCreateParams & {
+              id?: string;
+            },
+          ),
+          params: toJsonColumn(params.params),
+        },
+        z.array(SkillOptimizationArmSchema),
+      );
+      created.push(rows[0]);
+    }
+
+    return created;
+  },
+
+  updateSkillOptimizationArm: async (
+    c: AppContext,
+    id: string,
+    update: SkillOptimizationArmUpdateParams,
+  ): Promise<SkillOptimizationArm> => {
+    const { params, ...rest } = update as SkillOptimizationArmUpdateParams &
+      Record<string, unknown>;
+
+    const rows = await updateIn(
+      getLibsqlClient(c),
+      'skill_optimization_arms',
+      { id },
+      {
+        ...asColumns(rest),
+        params: params === undefined ? undefined : toJsonColumn(params),
+      },
+      z.array(SkillOptimizationArmSchema),
+    );
+    return rows[0];
+  },
+
+  /**
+   * Replaces the `update_arm_and_increment_counters` RPC.
+   *
+   * This is the one operation that genuinely needs a transaction rather than a
+   * batch: the arm stats, the cluster counters and the skill counter have to
+   * move together, and the stat update is read-modify-write per evaluation.
+   */
+  updateArmAndIncrementCounters: async (
+    c: AppContext,
+    armId: string,
+    evaluationResults: Array<{ evaluation_id: string; score: number }>,
+  ): Promise<{
+    arm: SkillOptimizationArm;
+    cluster: SkillOptimizationCluster;
+    skill: Skill;
+  }> => {
+    const client = getLibsqlClient(c);
+    const tx = await client.transaction('write');
+
+    try {
+      const armRow = await tx.execute({
+        sql: 'SELECT agent_id, skill_id, cluster_id FROM skill_optimization_arms WHERE id = ?',
+        args: [armId],
+      });
+
+      if (armRow.rows.length === 0) {
+        throw new Error(`Arm with id ${armId} not found`);
+      }
+
+      const agentId = String(armRow.rows[0].agent_id);
+      const skillId = String(armRow.rows[0].skill_id);
+      const clusterId = String(armRow.rows[0].cluster_id);
+
+      for (const { evaluation_id, score } of evaluationResults) {
+        const existing = await tx.execute({
+          sql: 'SELECT n, total_reward, n2 FROM skill_optimization_arm_stats WHERE arm_id = ? AND evaluation_id = ?',
+          args: [armId, evaluation_id],
+        });
+
+        const oldN = Number(existing.rows[0]?.n ?? 0);
+        const oldTotal = Number(existing.rows[0]?.total_reward ?? 0);
+        const oldN2 = Number(existing.rows[0]?.n2 ?? 0);
+
+        // Incremental update formulas used by Thompson Sampling, matching the
+        // plpgsql version exactly.
+        const newN = oldN + 1;
+        const newTotal = oldTotal + score;
+        const newMean = newTotal / newN;
+        const newN2 = oldN2 + score * score;
+
+        await tx.execute({
+          sql: `INSERT INTO skill_optimization_arm_stats
+                  (arm_id, evaluation_id, agent_id, skill_id, cluster_id, n, mean, n2, total_reward)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (arm_id, evaluation_id) DO UPDATE SET
+                  n = excluded.n,
+                  mean = excluded.mean,
+                  n2 = excluded.n2,
+                  total_reward = excluded.total_reward,
+                  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+          args: [
+            armId,
+            evaluation_id,
+            agentId,
+            skillId,
+            clusterId,
+            newN,
+            newMean,
+            newN2,
+            newTotal,
+          ],
+        });
+      }
+
+      const clusterUpdate = await tx.execute({
+        sql: `UPDATE skill_optimization_clusters
+              SET total_steps = total_steps + 1,
+                  observability_total_requests = observability_total_requests + 1
+              WHERE id = ?`,
+        args: [clusterId],
+      });
+      if (clusterUpdate.rowsAffected === 0) {
+        throw new Error(`Cluster with id ${clusterId} not found`);
+      }
+
+      const skillUpdate = await tx.execute({
+        sql: 'UPDATE skills SET total_requests = total_requests + 1 WHERE id = ?',
+        args: [skillId],
+      });
+      if (skillUpdate.rowsAffected === 0) {
+        throw new Error(`Skill with id ${skillId} not found`);
+      }
+
+      const [arm, cluster, skill] = await Promise.all([
+        selectFrom(
+          tx,
+          'skill_optimization_arms',
+          { id: armId },
+          z.array(SkillOptimizationArmSchema),
+        ),
+        selectFrom(
+          tx,
+          'skill_optimization_clusters',
+          { id: clusterId },
+          z.array(SkillOptimizationClusterSchema),
+        ),
+        selectFrom(tx, 'skills', { id: skillId }, z.array(SkillSchema)),
+      ]);
+
+      await tx.commit();
+
+      return { arm: arm[0], cluster: cluster[0], skill: skill[0] };
+    } catch (e) {
+      await tx.rollback();
+      throw e;
+    }
+  },
+
+  deleteSkillOptimizationArm: async (
+    c: AppContext,
+    id: string,
+  ): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'skill_optimization_arms', { id });
+  },
+
+  deleteSkillOptimizationArmsForSkill: async (
+    c: AppContext,
+    skillId: string,
+  ): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'skill_optimization_arms', {
+      skill_id: skillId,
+    });
+  },
+
+  deleteSkillOptimizationArmsForCluster: async (
+    c: AppContext,
+    clusterId: string,
+  ): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'skill_optimization_arms', {
+      cluster_id: clusterId,
+    });
+  },
+
+  // ----------------------------------------- Skill Optimization Arm Stats
+  getSkillOptimizationArmStats: async (
+    c: AppContext,
+    queryParams: SkillOptimizationArmStatQueryParams,
+  ): Promise<SkillOptimizationArmStat[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'skill_optimization_arm_stats',
+      {
+        arm_id: queryParams.arm_id,
+        evaluation_id: queryParams.evaluation_id,
+        agent_id: queryParams.agent_id,
+        skill_id: queryParams.skill_id,
+        cluster_id: queryParams.cluster_id,
+      },
+      z.array(SkillOptimizationArmStatSchema),
+      {
+        orderBy: 'created_at desc',
+        limit: queryParams.limit,
+        offset: queryParams.offset,
+      },
+    ),
+
+  deleteSkillOptimizationArmStats: async (
+    c: AppContext,
+    queryParams: SkillOptimizationArmStatQueryParams,
+  ): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'skill_optimization_arm_stats', {
+      arm_id: queryParams.arm_id,
+      evaluation_id: queryParams.evaluation_id,
+      agent_id: queryParams.agent_id,
+      skill_id: queryParams.skill_id,
+      cluster_id: queryParams.cluster_id,
+    });
+  },
+
+  // --------------------------------------- Skill Optimization Evaluations
+  getSkillOptimizationEvaluations: async (
+    c: AppContext,
+    queryParams: SkillOptimizationEvaluationQueryParams,
+  ): Promise<SkillOptimizationEvaluation[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'skill_optimization_evaluations',
+      {
+        id: queryParams.id,
+        agent_id: queryParams.agent_id,
+        skill_id: queryParams.skill_id,
+        evaluation_method: queryParams.evaluation_method,
+      },
+      z.array(SkillOptimizationEvaluationSchema),
+      {
+        orderBy: 'created_at desc',
+        limit: queryParams.limit,
+        offset: queryParams.offset,
+      },
+    ),
+
+  createSkillOptimizationEvaluations: async (
+    c: AppContext,
+    params_list: SkillOptimizationEvaluationCreateParams[],
+  ): Promise<SkillOptimizationEvaluation[]> => {
+    const client = getLibsqlClient(c);
+    const created: SkillOptimizationEvaluation[] = [];
+
+    for (const params of params_list) {
+      const rows = await insertInto(
+        client,
+        'skill_optimization_evaluations',
+        {
+          ...withId(
+            params as SkillOptimizationEvaluationCreateParams & {
+              id?: string;
+            },
+          ),
+          params: toJsonColumn(params.params ?? {}),
+        },
+        z.array(SkillOptimizationEvaluationSchema),
+      );
+      created.push(rows[0]);
+    }
+
+    return created;
+  },
+
+  updateSkillOptimizationEvaluation: async (
+    c: AppContext,
+    id: string,
+    update: SkillOptimizationEvaluationUpdateParams,
+  ): Promise<SkillOptimizationEvaluation> => {
+    const { params, ...rest } =
+      update as SkillOptimizationEvaluationUpdateParams &
+        Record<string, unknown>;
+
+    const rows = await updateIn(
+      getLibsqlClient(c),
+      'skill_optimization_evaluations',
+      { id },
+      {
+        ...asColumns(rest),
+        params: params === undefined ? undefined : toJsonColumn(params),
+      },
+      z.array(SkillOptimizationEvaluationSchema),
+    );
+
+    if (rows.length === 0) {
+      throw new Error('Evaluation not found');
+    }
+
+    return rows[0];
+  },
+
+  deleteSkillOptimizationEvaluation: async (
+    c: AppContext,
+    id: string,
+  ): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'skill_optimization_evaluations', {
+      id,
+    });
+  },
+
+  deleteSkillOptimizationEvaluationsForSkill: async (
+    c: AppContext,
+    skillId: string,
+  ): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'skill_optimization_evaluations', {
+      skill_id: skillId,
+    });
+  },
+
+  // ----------------------------------- Skill Optimization Evaluation Runs
+  getSkillOptimizationEvaluationRuns: async (
+    c: AppContext,
+    queryParams: SkillOptimizationEvaluationRunQueryParams,
+  ): Promise<SkillOptimizationEvaluationRun[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'skill_optimization_evaluation_runs',
+      {
+        id: queryParams.id,
+        agent_id: queryParams.agent_id,
+        skill_id: queryParams.skill_id,
+        log_id: queryParams.log_id,
+      },
+      z.array(SkillOptimizationEvaluationRunSchema),
+      {
+        orderBy: 'created_at desc',
+        limit: queryParams.limit,
+        offset: queryParams.offset,
+      },
+    ),
+
+  createSkillOptimizationEvaluationRun: async (
+    c: AppContext,
+    params: SkillOptimizationEvaluationRunCreateParams,
+  ): Promise<SkillOptimizationEvaluationRun> => {
+    const rows = await insertInto(
+      getLibsqlClient(c),
+      'skill_optimization_evaluation_runs',
+      {
+        ...withId(
+          params as SkillOptimizationEvaluationRunCreateParams & {
+            id?: string;
+          },
+        ),
+        results: toJsonColumn(params.results),
+      },
+      z.array(SkillOptimizationEvaluationRunSchema),
+    );
+    return rows[0];
+  },
+
+  deleteSkillOptimizationEvaluationRun: async (
+    c: AppContext,
+    id: string,
+  ): Promise<void> => {
+    await deleteFrom(getLibsqlClient(c), 'skill_optimization_evaluation_runs', {
+      id,
+    });
+  },
+
+  getEvaluationScoresByTimeBucket: async (
+    c: AppContext,
+    params: EvaluationScoresByTimeBucketParams,
+  ) => aggregateScoresByTimeBucket(getLibsqlClient(c), params),
+
+  // --------------------------------------------------------- Skill Events
+  getSkillEvents: async (
+    c: AppContext,
+    queryParams: SkillEventQueryParams,
+  ): Promise<SkillEvent[]> =>
+    selectFrom(
+      getLibsqlClient(c),
+      'skill_events',
+      {
+        id: queryParams.id,
+        agent_id: queryParams.agent_id,
+        skill_id: queryParams.skill_id,
+        cluster_id: queryParams.cluster_id,
+        event_type: queryParams.event_type,
+      },
+      z.array(SkillEventSchema),
+      {
+        orderBy: 'created_at desc',
+        limit: queryParams.limit,
+        offset: queryParams.offset,
+      },
+    ),
+
+  createSkillEvent: async (
+    c: AppContext,
+    params: SkillEventCreateParams,
+  ): Promise<SkillEvent> => {
+    const rows = await insertInto(
+      getLibsqlClient(c),
+      'skill_events',
+      {
+        ...withId(params as SkillEventCreateParams & { id?: string }),
+        metadata: toJsonColumn(params.metadata ?? {}),
+      },
+      z.array(SkillEventSchema),
+    );
+
+    emitSSEEvent('skill-optimization:event-created', {
+      eventId: rows[0].id,
+      skillId: rows[0].skill_id,
+      clusterId: rows[0].cluster_id,
+      eventType: rows[0].event_type,
+    });
+
+    return rows[0];
+  },
+
+  // ------------------------------------------------------- System Settings
+  getSystemSettings: async (c: AppContext): Promise<SystemSettings> => {
+    const rows = await selectFrom(
+      getLibsqlClient(c),
+      'system_settings',
+      {},
+      z.array(SystemSettingsSchema),
+      { limit: 1 },
+    );
+    // Seeded by migration 0003, so there is always exactly one row.
+    return rows[0];
+  },
+
+  updateSystemSettings: async (
+    c: AppContext,
+    update: SystemSettingsUpdateParams,
+  ): Promise<SystemSettings> => {
+    const client = getLibsqlClient(c);
+    const current = await selectFrom(
+      client,
+      'system_settings',
+      {},
+      z.array(SystemSettingsSchema),
+      { limit: 1 },
+    );
+
+    const { developer_mode, ...rest } = update as SystemSettingsUpdateParams &
+      Record<string, unknown>;
+
+    const rows = await updateIn(
+      client,
+      'system_settings',
+      { id: current[0].id },
+      {
+        ...asColumns(rest),
+        developer_mode:
+          developer_mode === undefined ? undefined : developer_mode ? 1 : 0,
+      },
+      z.array(SystemSettingsSchema),
+    );
+    return rows[0];
+  },
+};

--- a/packages/api/src/connectors/supabase/supabase.ts
+++ b/packages/api/src/connectors/supabase/supabase.ts
@@ -1,11 +1,10 @@
-import crypto from 'node:crypto';
-import { getAiProviderApiKeyEncryptionKey } from '@api/constants';
 import type {
   CacheStorageConnector,
   LogsStorageConnector,
   UserDataStorageConnector,
 } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
+import { decryptAPIKey, encryptAPIKey } from '@api/utils/api-key-encryption';
 import { emitSSEEvent } from '@api/utils/sse-event-manager';
 import {
   Agent,
@@ -89,51 +88,6 @@ import {
   selectFromSupabase,
   updateInSupabase,
 } from './base';
-
-const encryptAPIKey = (c: AppContext, plaintext: string): string => {
-  const algorithm = 'aes-256-gcm';
-  const key = crypto
-    .createHash('sha256')
-    .update(getAiProviderApiKeyEncryptionKey(c))
-    .digest();
-  const iv = crypto.randomBytes(16);
-
-  const cipher = crypto.createCipheriv(algorithm, key, iv);
-  cipher.setAAD(Buffer.from('api-key'));
-
-  let encrypted = cipher.update(plaintext, 'utf8', 'hex');
-  encrypted += cipher.final('hex');
-
-  const authTag = cipher.getAuthTag();
-
-  // Format: iv:authTag:encrypted
-  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
-};
-
-const decryptAPIKey = (c: AppContext, encryptedData: string): string => {
-  const algorithm = 'aes-256-gcm';
-  const key = crypto
-    .createHash('sha256')
-    .update(getAiProviderApiKeyEncryptionKey(c))
-    .digest();
-
-  const [ivHex, authTagHex, encrypted] = encryptedData.split(':');
-  if (!ivHex || !authTagHex || !encrypted) {
-    throw new Error('Invalid encrypted data format');
-  }
-
-  const iv = Buffer.from(ivHex, 'hex');
-  const authTag = Buffer.from(authTagHex, 'hex');
-
-  const decipher = crypto.createDecipheriv(algorithm, key, iv);
-  decipher.setAAD(Buffer.from('api-key'));
-  decipher.setAuthTag(authTag);
-
-  let decrypted = decipher.update(encrypted, 'hex', 'utf8');
-  decrypted += decipher.final('utf8');
-
-  return decrypted;
-};
 
 export const supabaseUserDataStorageConnector: UserDataStorageConnector = {
   getFeedback: async (

--- a/packages/api/src/utils/api-key-encryption.ts
+++ b/packages/api/src/utils/api-key-encryption.ts
@@ -1,0 +1,54 @@
+import crypto from 'node:crypto';
+import { getAiProviderApiKeyEncryptionKey } from '@api/constants';
+import type { AppContext } from '@api/types/hono';
+
+/**
+ * AES-256-GCM encryption for stored AI provider API keys.
+ *
+ * Extracted from the Supabase connector so every storage backend produces and
+ * reads the same ciphertext: a key written by one backend has to stay readable
+ * after a migration to the other.
+ *
+ * `node:crypto` resolves on Workers through `nodejs_compat_v2`.
+ */
+
+const ALGORITHM = 'aes-256-gcm';
+const AAD = 'api-key';
+
+const derivedKey = (c: AppContext): Buffer =>
+  crypto
+    .createHash('sha256')
+    .update(getAiProviderApiKeyEncryptionKey(c))
+    .digest();
+
+/** Returns `iv:authTag:ciphertext`, all hex. */
+export const encryptAPIKey = (c: AppContext, plaintext: string): string => {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALGORITHM, derivedKey(c), iv);
+  cipher.setAAD(Buffer.from(AAD));
+
+  let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+
+  return `${iv.toString('hex')}:${cipher.getAuthTag().toString('hex')}:${encrypted}`;
+};
+
+export const decryptAPIKey = (c: AppContext, encryptedData: string): string => {
+  const [ivHex, authTagHex, encrypted] = encryptedData.split(':');
+  if (!ivHex || !authTagHex || !encrypted) {
+    throw new Error('Invalid encrypted data format');
+  }
+
+  const decipher = crypto.createDecipheriv(
+    ALGORITHM,
+    derivedKey(c),
+    Buffer.from(ivHex, 'hex'),
+  );
+  decipher.setAAD(Buffer.from(AAD));
+  decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
+
+  let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+
+  return decrypted;
+};

--- a/supabase/migrations/20260826000000_feedbacks_updated_at.sql
+++ b/supabase/migrations/20260826000000_feedbacks_updated_at.sql
@@ -1,0 +1,20 @@
+-- ================================================
+-- Add the missing feedbacks.updated_at column
+-- ================================================
+-- `Feedback` in @shared/types/data/feedback is `.strict()` and requires
+-- `updated_at`, and `FeedbackCreateParams` generates one on every create. The
+-- table never had the column, so PostgREST rejected the insert with PGRST204
+-- and any row that did exist failed to parse on read. Every test mocks the
+-- connector, so neither showed up in CI.
+--
+-- The column is added rather than removed from the schemas because the rest of
+-- the tables that carry `created_at` also carry `updated_at`, and the type has
+-- always advertised it.
+
+ALTER TABLE feedbacks
+ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE TRIGGER update_feedbacks_updated_at BEFORE UPDATE ON feedbacks
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON COLUMN feedbacks.updated_at IS 'Timestamp of the last update to this feedback row';


### PR DESCRIPTION
## What this completes

All ~65 `UserDataStorageConnector` methods, the three `LogsStorageConnector` methods, the five RPCs the API actually calls, and the time-bucket aggregation.

**Still not selectable.** `v1/index.ts` wires the Supabase connectors unconditionally, so nothing changes at runtime. See *Remaining work* — there's a design question attached to the wiring that deserves its own PR.

`query.ts` does in-process what PostgREST does over HTTP, which is why the methods read almost identically to their Supabase counterparts: they build the same filter objects and only the executor differs.

## Three findings that changed the implementation

Each was confirmed by running the code, not by reading docs:

1. **SQLite computes `RETURNING` before `AFTER` triggers fire.** So `UPDATE ... RETURNING *` hands back the `updated_at` from *before* the trigger rewrote it — I verified this directly (`RETURNING` gave `seed`, the stored value was `TRIGGERED`). Postgres uses a BEFORE trigger where RETURNING already sees the new value, so `updateIn` re-selects instead. Without this, every update would return a stale timestamp to the client.

2. **NULL has to stay NULL.** My first pass mapped NULL to `undefined`. But PostgREST serialises a NULL column as JSON `null`, so the Zod schemas are written with `.nullable()` and reject `undefined` — `Skill.last_clustering_at` is the case that caught it. Preserving null is both simpler and faithful.

3. **`client.transaction()` checks out a separate connection**, and for a `:memory:` database that means a separate, *empty* database — `updateArmAndIncrementCounters` failed with "no such table". The connector tests use a temp file, which is also what the container deployment actually uses. Documented in `AGENTS.md` so the next person doesn't lose an hour to it.

## Two schema corrections

Both land as new migrations on **both** backends, so their histories stay in step.

**`feedbacks` never had `updated_at`** — but `Feedback` is `.strict()` and requires it, and `FeedbackCreateParams` generates one on every create. So `POST /v1/super-agents/feedbacks` was rejected by PostgREST with PGRST204, and any row that did exist failed to parse on read. **Feedback has been broken end-to-end on Supabase**; every test mocks the connector, so nothing caught it. I couldn't write a working libSQL feedback connector without fixing the column, so this adds it to Postgres too (`supabase/migrations/20260826000000_feedbacks_updated_at.sql` — additive, so it passes the migration-immutability check).

**The libSQL initial migration created `system_settings` but not the singleton row** the Postgres migration seeds, which `getSystemSettings` assumes exists. Added as `0003`.

## Shared API-key encryption

`encryptAPIKey`/`decryptAPIKey` move out of the Supabase connector into `utils/api-key-encryption.ts`. Both backends must produce and read the same ciphertext — a key written by one has to stay readable after migrating to the other. Pure move, no behaviour change; the Supabase connector's own 23 tests still pass.

## Verification

**33 new tests** (63 total in the libSQL suite):

- CRUD, filtering, `limit`/`offset` (including offset-without-limit, which PostgREST allows and raw SQLite doesn't)
- JSON columns (`metadata`, `params`, `centroid`, `embedding`) and boolean columns (`optimize`, `developer_mode`) round-tripping
- API keys encrypted at rest — asserts the stored value doesn't contain the plaintext and matches the `iv:tag:ciphertext` shape
- Bridge joins in both directions, idempotent adds, selective removes
- **Each atomic operation**: counter increments, the reclustering lock granting once while held, the Thompson Sampling incremental `mean`/`n2` formulas across calls, one stat row per evaluation with counters bumped once, and **transaction rollback** leaving `total_requests` at 0 when the arm doesn't exist
- Log ordering, range filtering (Postgres's combined `and=(gte,lte)`), embedding-presence filter
- **Six time-bucket cases**: epoch-aligned bucketing, interval sensitivity, weighted averaging (`(1.0×3 + 0.0×1)/4 = 0.75`), retroactive weight changes, range/skill filtering, empty series

`pnpm check`, `pnpm typecheck`, `pnpm test` (138 files, 2425 tests) all pass. `scripts/check-worker-runtime.sh` passes with all three connectors reachable from the Workers entry; `packages/api/src/index.ts` is byte-identical to `main` in the diff.

## Notes for review

- The **one operation that genuinely needs a transaction** is `updateArmAndIncrementCounters` — arm stats, cluster counters and skill counter must move together, and the stat update is read-modify-write per evaluation. The other four are single statements.
- `tryAcquireReclusteringLock` is a conditional UPDATE: racing callers both issue it, SQLite serialises them, and only the one that finds the lock stale changes a row. Its test backdates the column rather than passing a zero threshold, because with zero the cutoff equals the timestamp just written and the strict comparison would depend on the clock ticking.
- The time-bucket aggregation is TypeScript rather than one dense query, deliberately — it stays readable against the plpgsql it replaces, and the semantics it reproduces are listed in the file header.
- `getEvaluationScoresByTimeBucket` recomputes from **current** weights rather than the per-run stored average, matching Postgres, so re-weighting an evaluation retroactively changes the chart. There's a test for exactly that.

## Remaining work

Wiring the selection — three call sites in `v1/index.ts`, plus turning the three middlewares into resolvers so the choice can be made per-request (on Workers, env only exists in the request context).

The reason that isn't here: **who migrates a remote database?** A Worker running migrations on first request is very different from a deploy-time step, and that call shouldn't be buried at the end of a 2,500-line PR. Happy to take a direction on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wM59ecJTFbb3gZYDDva1Z