### PR TITLE
feat(api): select the storage backend from LIBSQL_URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,11 +171,21 @@ Uses **connector pattern** for data access:
 | Backend | Location | Status |
 | --- | --- | --- |
 | Supabase / PostgREST | `packages/api/src/connectors/supabase/` | complete; what the app uses |
-| libSQL | `packages/api/src/connectors/libsql/` | complete; not yet selectable |
+| libSQL | `packages/api/src/connectors/libsql/` | complete |
 
-The libSQL backend implements all three interfaces but is **not yet
-selectable** — `v1/index.ts` still wires the Supabase connectors
-unconditionally. Wiring it up is the remaining step.
+**Selection** lives in `packages/api/src/connectors/index.ts`. Setting
+`LIBSQL_URL` chooses libSQL; leaving it unset keeps Supabase, which is what
+every existing deployment does. The URL scheme carries the rest of the
+decision — `file:` is an embedded database, `libsql://` or `https://` is a
+remote one.
+
+The choice is made **per request**, not at module load, because on Workers
+there is no environment until a request arrives. That is why the three storage
+middlewares take a resolver rather than a connector.
+
+libSQL migrations run on the first request that touches storage
+(`ensureStorageReady`); Postgres is migrated by the `migrations` compose
+service. Single-container deployment: see `docker-compose.libsql.yml`.
 
 Its schema (`connectors/libsql/schema.ts`) is a translation of
 `supabase/migrations/`, not a replay: one consolidated migration describing the
@@ -189,6 +199,10 @@ current shape. Notable differences, all deliberate:
   mapping it to `undefined`.
 - **Updates re-select instead of using `RETURNING`.** SQLite computes RETURNING
   before AFTER triggers run, so it would return a stale `updated_at`.
+- **`libsql` is external to the esbuild bundle.** It loads a platform-specific
+  native addon through a runtime require, so `packages/api/build.js` excludes it
+  and the Docker images install it in the runner stage. Bundling it produces an
+  image that fails at boot with `Cannot find module '@libsql/linux-x64-gnu'`.
 - **Row-level security is dropped.** The Postgres policies grant unrestricted
   access to the service role, which is the only role the API connects as.
 - **`PRAGMA foreign_keys = ON` per connection.** SQLite leaves foreign keys
@@ -369,9 +383,9 @@ The system uses special auto-generated skills in the `super-agents` agent (defin
   - `ACCESS_PASSWORD` - Dashboard password (optional)
   - `AUTH_JWT_SECRET` - JWT signing secret for the dashboard session cookie (required in production)
   - `AI_PROVIDER_API_KEY_ENCRYPTION_KEY` - Encryption key for stored AI provider API keys (required in production)
-  - `LIBSQL_URL` - libSQL database. `file:` for an embedded SQLite file,
-    `libsql://` or `https://` for a remote one. Only read by the libSQL
-    connector, which is not wired up yet.
+  - `LIBSQL_URL` - libSQL database, and the switch that selects the libSQL
+    backend. `file:` for an embedded SQLite file, `libsql://` or `https://`
+    for a remote one. Unset means Supabase.
   - Note: tests for the libSQL connector use a temp **file** database, not
     `:memory:` — `client.transaction()` checks out a separate connection, and
     for an in-memory database that is a separate, empty database.

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,21 @@ ENV NODE_ENV=production
 RUN pnpm --filter @super-agents/api build
 RUN pnpm --filter @super-agents/web build
 
+# Pin the runtime's `libsql` to whatever version pnpm resolved for the
+# workspace, so the image and the lockfile cannot drift.
+RUN node -e "const p=require('./packages/api/package.json'); require('fs').writeFileSync('runtime-package.json', JSON.stringify({ name: 'super-agents-runtime', private: true, dependencies: { libsql: p.dependencies.libsql } }, null, 2))"
+
 FROM node:22-alpine AS runner
 WORKDIR /app
 
-# The API is bundled by esbuild, so no node_modules are needed at runtime.
+# `libsql` loads a platform-specific native addon through a runtime require, so
+# esbuild leaves it external (see packages/api/build.js) and it is installed
+# here instead. Only the local-file libSQL backend loads it -- Supabase and
+# remote libSQL deployments never touch it.
+COPY --from=builder /app/runtime-package.json ./package.json
+RUN npm install --omit=dev --no-audit --no-fund && npm cache clean --force
+
+# Everything else is bundled by esbuild.
 COPY --from=builder /app/packages/api/dist ./dist
 # `DASHBOARD_ROOT` defaults to ./public, relative to WORKDIR.
 COPY --from=builder /app/packages/web/dist ./public

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Super Agents is a self-optimizing AI agent platform that automatically improves 
    ```
    The web application will be available at `http://localhost:3000`.
 
+   For a single container with an embedded database and no Postgres to run
+   alongside it, use `docker compose -f docker-compose.libsql.yml up` instead.
+
 3. Configure your application from the UI. 
     
     1. In the "AI Providers & Models" section, add the models you want to use. You will be able to select these models within the app settings and within each of your agent's skills later on. You will need at least one LLM model and one embedding model from any provider to configure the application.

--- a/docker-compose.libsql.yml
+++ b/docker-compose.libsql.yml
@@ -1,0 +1,42 @@
+# Single-container deployment backed by an embedded libSQL (SQLite) database.
+#
+# The default docker-compose.yml runs four services: postgres, a one-shot
+# migration runner, postgrest, and the app. Setting LIBSQL_URL to a file path
+# moves storage into the container's own volume, which leaves nothing else to
+# orchestrate.
+#
+#   docker compose -f docker-compose.libsql.yml up
+#
+# Or without compose at all:
+#
+#   docker run -d --name super-agents -p 3000:3000 \
+#     -v super-agents:/app/data \
+#     -e LIBSQL_URL=file:/app/data/super-agents.db \
+#     ghcr.io/idkhub-com/super-agents:latest
+#
+# Migrations run on the first request. To point at a hosted database instead,
+# set LIBSQL_URL to a libsql:// URL and supply LIBSQL_AUTH_TOKEN; the volume is
+# then unused.
+services:
+  super-agents:
+    image: ghcr.io/idkhub-com/super-agents:${SA_VERSION:-latest}
+    pull_policy: always
+    container_name: super-agents
+    restart: unless-stopped
+    ports:
+      - "${DOCKER_HOST_IP:-127.0.0.1}:3000:3000"
+    environment:
+      LIBSQL_URL: ${LIBSQL_URL:-file:/app/data/super-agents.db}
+      LIBSQL_AUTH_TOKEN: ${LIBSQL_AUTH_TOKEN:-}
+      ACCESS_PASSWORD: ${ACCESS_PASSWORD}
+      BEARER_TOKEN: ${BEARER_TOKEN}
+      AUTH_JWT_SECRET: ${AUTH_JWT_SECRET:-you-should-change-this-in-production}
+      AI_PROVIDER_API_KEY_ENCRYPTION_KEY: ${AI_PROVIDER_API_KEY_ENCRYPTION_KEY:-default-32-byte-key-change-in-prod}
+      # Set to "false" to run the gateway without serving the dashboard.
+      SERVE_DASHBOARD: ${SERVE_DASHBOARD:-true}
+      NODE_ENV: production
+    volumes:
+      - super_agents_data:/app/data
+
+volumes:
+  super_agents_data:

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -25,10 +25,21 @@ COPY packages/shared ./packages/shared
 
 RUN pnpm --filter @super-agents/api build
 
+# Pin the runtime's `libsql` to whatever version pnpm resolved for the
+# workspace, so the image and the lockfile cannot drift.
+RUN node -e "const p=require('./packages/api/package.json'); require('fs').writeFileSync('runtime-package.json', JSON.stringify({ name: 'super-agents-runtime', private: true, dependencies: { libsql: p.dependencies.libsql } }, null, 2))"
+
 FROM node:22-alpine AS runner
 WORKDIR /app
 
-# Copy bundled output (everything is bundled, no node_modules needed)
+# `libsql` loads a platform-specific native addon through a runtime require, so
+# esbuild leaves it external (see packages/api/build.js) and it is installed
+# here instead. Only the local-file libSQL backend loads it -- Supabase and
+# remote libSQL deployments never touch it.
+COPY --from=builder /app/runtime-package.json ./package.json
+RUN npm install --omit=dev --no-audit --no-fund && npm cache clean --force
+
+# Everything else is bundled by esbuild.
 COPY --from=builder /app/packages/api/dist ./dist
 
 RUN addgroup --system --gid 1001 nodejs && \

--- a/packages/api/build.js
+++ b/packages/api/build.js
@@ -15,6 +15,16 @@ await esbuild.build({
     '@server': path.join(__dirname, 'src'),
     '@shared': path.join(__dirname, '../shared/src'),
   },
+  /**
+   * `libsql` loads a platform-specific native addon with a runtime `require`,
+   * which cannot be bundled. Leaving it external means Node resolves it from
+   * node_modules instead, so the runtime image has to carry it -- see the
+   * runner stage of the root Dockerfile.
+   *
+   * Only the local-file path needs it. A deployment using remote libSQL, or
+   * Supabase, never loads it.
+   */
+  external: ['libsql'],
   sourcemap: true,
   banner: {
     js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,6 +31,7 @@
     "hono": "^4.9.6",
     "json-schema-to-zod": "^2.6.1",
     "json-stable-stringify": "^1.3.0",
+    "libsql": "^0.5.29",
     "lodash": "^4.17.21",
     "nanoid": "^5.1.5",
     "openai": "^6.7.0",

--- a/packages/api/src/connectors/connectors.test.ts
+++ b/packages/api/src/connectors/connectors.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AppContext } from '@api/types/hono';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ensureStorageReady,
+  resetStorageReady,
+  resolveCacheConnector,
+  resolveLogsConnector,
+  resolveUserDataConnector,
+  usesLibsql,
+} from '.';
+import {
+  libsqlCacheStorageConnector,
+  libsqlLogsStorageConnector,
+  libsqlUserDataStorageConnector,
+  resetLibsqlClients,
+} from './libsql';
+import {
+  supabaseCacheStorageConnector,
+  supabaseLogsStorageConnector,
+  supabaseUserDataStorageConnector,
+} from './supabase';
+
+const tempDirs: string[] = [];
+
+const libsqlContext = (): AppContext => {
+  const dir = mkdtempSync(join(tmpdir(), 'sa-select-'));
+  tempDirs.push(dir);
+  return {
+    env: { LIBSQL_URL: `file:${join(dir, 'test.db')}` },
+  } as unknown as AppContext;
+};
+
+const supabaseContext = (): AppContext =>
+  ({
+    env: { POSTGREST_URL: 'http://localhost:54321/rest/v1' },
+  }) as unknown as AppContext;
+
+beforeEach(() => {
+  resetStorageReady();
+  resetLibsqlClients();
+});
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('storage backend selection', () => {
+  it('keeps Supabase when LIBSQL_URL is unset', () => {
+    const c = supabaseContext();
+
+    expect(usesLibsql(c)).toBe(false);
+    expect(resolveUserDataConnector(c)).toBe(supabaseUserDataStorageConnector);
+    expect(resolveLogsConnector(c)).toBe(supabaseLogsStorageConnector);
+    expect(resolveCacheConnector(c)).toBe(supabaseCacheStorageConnector);
+  });
+
+  it('selects libSQL when LIBSQL_URL is set', () => {
+    const c = libsqlContext();
+
+    expect(usesLibsql(c)).toBe(true);
+    expect(resolveUserDataConnector(c)).toBe(libsqlUserDataStorageConnector);
+    expect(resolveLogsConnector(c)).toBe(libsqlLogsStorageConnector);
+    expect(resolveCacheConnector(c)).toBe(libsqlCacheStorageConnector);
+  });
+
+  it('selects per context rather than once per process', () => {
+    // On Workers the environment only exists per request, so two contexts in
+    // the same isolate must be able to resolve differently.
+    expect(resolveUserDataConnector(libsqlContext())).toBe(
+      libsqlUserDataStorageConnector,
+    );
+    expect(resolveUserDataConnector(supabaseContext())).toBe(
+      supabaseUserDataStorageConnector,
+    );
+  });
+});
+
+describe('ensureStorageReady', () => {
+  it('migrates a libSQL database on first use', async () => {
+    const c = libsqlContext();
+
+    await ensureStorageReady(c);
+
+    const { getLibsqlClient } = await import('./libsql');
+    const applied = await getLibsqlClient(c).execute(
+      'SELECT version FROM schema_migrations ORDER BY version',
+    );
+    expect(applied.rows.map((r) => String(r.version))).toEqual([
+      '0001_initial_schema',
+      '0002_feedbacks_updated_at',
+      '0003_default_system_settings',
+    ]);
+  });
+
+  it('runs the migration once even when called concurrently', async () => {
+    const c = libsqlContext();
+
+    // The cached promise is what stops a second request from starting its own
+    // migration while the first is still running.
+    await Promise.all([
+      ensureStorageReady(c),
+      ensureStorageReady(c),
+      ensureStorageReady(c),
+    ]);
+
+    const { getLibsqlClient } = await import('./libsql');
+    const applied = await getLibsqlClient(c).execute(
+      'SELECT COUNT(*) AS n FROM schema_migrations',
+    );
+    expect(Number(applied.rows[0].n)).toBe(3);
+  });
+
+  it('does nothing for a Supabase deployment', async () => {
+    // Postgres is migrated by the `migrations` compose service, so there is
+    // nothing to do here and no libSQL client should be built.
+    await expect(
+      ensureStorageReady(supabaseContext()),
+    ).resolves.toBeUndefined();
+  });
+
+  it('retries after a failure rather than caching the rejection', async () => {
+    const broken = {
+      env: { LIBSQL_URL: 'file:/proc/definitely-not-writable/x.db' },
+    } as unknown as AppContext;
+
+    await expect(ensureStorageReady(broken)).rejects.toThrow();
+
+    // A cached rejected promise would make every later request fail too.
+    const working = libsqlContext();
+    resetLibsqlClients();
+    await expect(ensureStorageReady(working)).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/connectors/index.ts
+++ b/packages/api/src/connectors/index.ts
@@ -1,0 +1,88 @@
+import { getLibsqlUrl } from '@api/constants';
+import type {
+  CacheStorageConnector,
+  LogsStorageConnector,
+  UserDataStorageConnector,
+} from '@api/types/connector';
+import type { AppContext } from '@api/types/hono';
+import { info } from '@shared/console-logging';
+import {
+  getLibsqlClient,
+  libsqlCacheStorageConnector,
+  libsqlLogsStorageConnector,
+  libsqlUserDataStorageConnector,
+  migrateLibsql,
+} from './libsql';
+import {
+  supabaseCacheStorageConnector,
+  supabaseLogsStorageConnector,
+  supabaseUserDataStorageConnector,
+} from './supabase';
+
+/**
+ * Storage backend selection.
+ *
+ * Setting `LIBSQL_URL` chooses libSQL; leaving it unset keeps Supabase, which
+ * is what every existing deployment does. One variable covers both shapes
+ * because the URL scheme carries the rest of the decision: `file:` is an
+ * embedded database for the single-container deployment, `libsql://` or
+ * `https://` is a remote one for Workers or any multi-instance deployment.
+ *
+ * The choice is made per request rather than at module load because on
+ * Cloudflare Workers there is no environment until a request arrives — `c.env`
+ * is populated from the request context, and `server.ts` merges `process.env`
+ * into it so Node resolves the same way.
+ */
+export const usesLibsql = (c: AppContext): boolean => Boolean(getLibsqlUrl(c));
+
+export const resolveUserDataConnector = (
+  c: AppContext,
+): UserDataStorageConnector =>
+  usesLibsql(c)
+    ? libsqlUserDataStorageConnector
+    : supabaseUserDataStorageConnector;
+
+export const resolveLogsConnector = (c: AppContext): LogsStorageConnector =>
+  usesLibsql(c) ? libsqlLogsStorageConnector : supabaseLogsStorageConnector;
+
+export const resolveCacheConnector = (c: AppContext): CacheStorageConnector =>
+  usesLibsql(c) ? libsqlCacheStorageConnector : supabaseCacheStorageConnector;
+
+/**
+ * Migration state for the life of the process (or the Worker isolate).
+ *
+ * The promise is cached rather than a boolean so that requests arriving while
+ * the first migration is still running wait for it instead of starting their
+ * own. A failure clears the cache so the next request retries rather than
+ * inheriting a rejected promise forever.
+ *
+ * Postgres is migrated by the `migrations` service in docker-compose, so this
+ * only ever applies to libSQL.
+ */
+let migration: Promise<void> | null = null;
+
+export const ensureStorageReady = async (c: AppContext): Promise<void> => {
+  if (!usesLibsql(c)) {
+    return;
+  }
+
+  if (!migration) {
+    migration = migrateLibsql(getLibsqlClient(c))
+      .then((applied) => {
+        if (applied.length > 0) {
+          info(`[libsql] applied ${applied.length} migration(s)`);
+        }
+      })
+      .catch((e: unknown) => {
+        migration = null;
+        throw e;
+      });
+  }
+
+  await migration;
+};
+
+/** Test helper: forget that migrations have run. */
+export const resetStorageReady = (): void => {
+  migration = null;
+};

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -45,11 +45,14 @@ export const getPostgrestUrl = (c: AppContext) => {
  * multi-instance deployment needs.
  */
 export const getLibsqlUrl = (c: AppContext): string | undefined =>
-  c.env.LIBSQL_URL;
+  // Optional access: these two are read on every request by the storage
+  // middleware, including from apps constructed without bindings, where
+  // `c.env` is undefined.
+  c.env?.LIBSQL_URL;
 
 /** Auth token for a remote libSQL database. Unused by `file:` databases. */
 export const getLibsqlAuthToken = (c: AppContext): string | undefined =>
-  c.env.LIBSQL_AUTH_TOKEN;
+  c.env?.LIBSQL_AUTH_TOKEN;
 
 /**
  * How long a cached response stays valid, in seconds.

--- a/packages/api/src/middlewares/cache.ts
+++ b/packages/api/src/middlewares/cache.ts
@@ -160,10 +160,10 @@ const getHookResponseFromCache = async (
  */
 export const cacheMiddleware = (
   factory: Factory<AppEnv>,
-  connector: CacheStorageConnector,
+  resolve: (c: AppContext) => CacheStorageConnector,
 ): MiddlewareHandler =>
   factory.createMiddleware(async (c, next) => {
-    c.set('cache_storage_connector', connector);
+    c.set('cache_storage_connector', resolve(c));
     c.set('getAIProviderResponseFromCache', getAIProviderResponseFromCache);
     c.set('getHookResponseFromCache', getHookResponseFromCache);
 

--- a/packages/api/src/middlewares/logs.ts
+++ b/packages/api/src/middlewares/logs.ts
@@ -612,10 +612,10 @@ async function processLogsAndOptimizeSkill(
 
 export const logsMiddleware = (
   factory: Factory<AppEnv>,
-  connector: LogsStorageConnector,
+  resolve: (c: AppContext) => LogsStorageConnector,
 ): MiddlewareHandler =>
   factory.createMiddleware(async (c, next) => {
-    c.set('logs_storage_connector', connector);
+    c.set('logs_storage_connector', resolve(c));
     c.set('addLogsClient', addLogsClient);
     c.set('removeLogsClient', removeLogsClient);
 

--- a/packages/api/src/middlewares/user-data.ts
+++ b/packages/api/src/middlewares/user-data.ts
@@ -1,5 +1,6 @@
+import { ensureStorageReady } from '@api/connectors';
 import type { UserDataStorageConnector } from '@api/types/connector';
-import type { AppEnv } from '@api/types/hono';
+import type { AppContext, AppEnv } from '@api/types/hono';
 import type { MiddlewareHandler } from 'hono';
 import type { Factory } from 'hono/factory';
 
@@ -7,14 +8,21 @@ import type { Factory } from 'hono/factory';
  * Middleware that sets up a connection with the UserDataStorageConnector
  * This middleware makes the UserDataStorageConnector available in the context
  * for use in routes that need to access user data (feedback, etc.)
+ *
+ * Takes a resolver rather than a connector because the backend is chosen from
+ * the environment, and on Workers there is no environment until a request
+ * arrives. This is also the first middleware to touch storage, so it is where
+ * libSQL gets migrated.
  */
 export const userDataMiddleware = (
   factory: Factory<AppEnv>,
-  connector: UserDataStorageConnector,
+  resolve: (c: AppContext) => UserDataStorageConnector,
 ): MiddlewareHandler =>
   factory.createMiddleware(async (c, next) => {
+    await ensureStorageReady(c);
+
     // Set the connector in the context for use in routes
-    c.set('user_data_storage_connector', connector);
+    c.set('user_data_storage_connector', resolve(c));
 
     await next();
   });

--- a/packages/api/src/v1/index.ts
+++ b/packages/api/src/v1/index.ts
@@ -1,4 +1,9 @@
 import { initializeModelCapabilities } from '@api/ai-providers/initialize-capabilities';
+import {
+  resolveCacheConnector,
+  resolveLogsConnector,
+  resolveUserDataConnector,
+} from '@api/connectors';
 // import { argumentCorrectnessEvaluationConnector } from '@api/connectors/evaluations/argument-correctness';
 import { conversationCompletenessEvaluationConnector } from '@api/connectors/evaluations/conversation-completeness';
 import { knowledgeRetentionEvaluationConnector } from '@api/connectors/evaluations/knowledge-retention';
@@ -7,11 +12,6 @@ import { latencyEvaluationConnector } from '@api/connectors/evaluations/latency/
 import { taskCompletionEvaluationConnector } from '@api/connectors/evaluations/task-completion';
 import { toolCorrectnessEvaluationConnector } from '@api/connectors/evaluations/tool-correctness';
 import { turnRelevancyEvaluationConnector } from '@api/connectors/evaluations/turn-relevancy';
-import {
-  supabaseCacheStorageConnector,
-  supabaseLogsStorageConnector,
-  supabaseUserDataStorageConnector,
-} from '@api/connectors/supabase';
 import { getAllowedOrigins } from '@api/constants';
 import { agentAndSkillMiddleware } from '@api/middlewares/agent-and-skill';
 import { authenticatedMiddleware } from '@api/middlewares/auth';
@@ -81,11 +81,11 @@ app.use('*', commonVariablesMiddleware);
 
 // Keep this middleware before agent and skill middleware
 // Use user data middleware for all routes
-app.use('*', userDataMiddleware(factory, supabaseUserDataStorageConnector));
+app.use('*', userDataMiddleware(factory, resolveUserDataConnector));
 
 // Use logs middleware for all routes
 // Runs skill optimizer after processing logs
-app.use('*', logsMiddleware(factory, supabaseLogsStorageConnector));
+app.use('*', logsMiddleware(factory, resolveLogsConnector));
 
 // Use hooks middleware for all routes
 app.use('*', hooksMiddleware(factory, []));
@@ -106,7 +106,7 @@ app.use(
 );
 
 // Use cache middleware for all routes
-app.use('*', cacheMiddleware(factory, supabaseCacheStorageConnector));
+app.use('*', cacheMiddleware(factory, resolveCacheConnector));
 
 // Use authenticated middleware for all routes
 app.use('*', authenticatedMiddleware(factory));

--- a/packages/api/src/v1/super-agents/improved-responses.test.ts
+++ b/packages/api/src/v1/super-agents/improved-responses.test.ts
@@ -1052,7 +1052,7 @@ describe('Improved Responses API', () => {
       authenticatedApp.use('*', commonVariablesMiddleware);
       authenticatedApp.use(
         '*',
-        userDataMiddleware(factory, mockUserDataStorageConnector),
+        userDataMiddleware(factory, () => mockUserDataStorageConnector),
       );
       authenticatedApp.use('*', authenticatedMiddleware(factory));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
       json-stable-stringify:
         specifier: ^1.3.0
         version: 1.3.0
+      libsql:
+        specifier: ^0.5.29
+        version: 0.5.29
       lodash:
         specifier: ^4.17.21
         version: 4.17.21

--- a/scripts/check-container-image.sh
+++ b/scripts/check-container-image.sh
@@ -119,6 +119,30 @@ check "GET / (dashboard off)" "404" "$(status /)"
 check "GET /v1/super-agents/nope" "404" "$(status /v1/super-agents/nope)"
 echo
 
+# The libSQL backend is the reason the image carries node_modules at all:
+# `libsql` loads a native addon that esbuild cannot bundle. Exercising a real
+# write proves the addon resolved, the migrations ran, and the connector works
+# -- a bundling regression here shows up as a 500, not a build failure.
+echo "==> libSQL backend (embedded database)"
+start_container -e LIBSQL_URL=file:/app/data/super-agents.db --tmpfs /app/data
+
+agent_status="$(curl -s -o "$repo_root/.container-agent.json" -w '%{http_code}' -m 20 \
+  -X POST "$base/v1/super-agents/agents" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"smoke-agent","description":"Created by the container smoke test to exercise libSQL."}' \
+  || echo "000")"
+check "POST /v1/super-agents/agents" "201" "$agent_status"
+
+listed="$(curl -s -m 20 "$base/v1/super-agents/agents")"
+if printf '%s' "$listed" | grep -q 'smoke-agent'; then
+  printf '    ok   the agent reads back from libSQL\n'
+else
+  printf '    FAIL agent did not read back: %s\n' "$listed"
+  failures=$((failures + 1))
+fi
+rm -f "$repo_root/.container-agent.json"
+echo
+
 if [ "$failures" -gt 0 ]; then
   echo "Container image check FAILED ($failures problem(s))." >&2
   docker logs "$name" >&2 || true


### PR DESCRIPTION
## What this does

Makes the libSQL backend reachable. Setting `LIBSQL_URL` chooses it; leaving it unset keeps Supabase, which is what every existing deployment does. The URL scheme carries the rest of the decision — `file:` embedded, `libsql://`/`https://` remote.

Per your call on migrations: they run on the first request that touches storage, no orchestration. The cached promise means concurrent requests wait on one migration instead of starting their own, and a failure clears it so the next request retries rather than inheriting a rejected promise forever.

**Selection is per request, not per process.** On Workers there is no environment until a request arrives, so the three storage middlewares now take a resolver `(c) => connector` rather than a fixed connector.

## Two things that only showed up by running the built server

**1. The esbuild bundle cannot carry `libsql`.** It loads a platform-specific native addon through a runtime `require`, so the built server died at boot:

```
Error: Cannot find module '@libsql/linux-x64-gnu'
```

`build.js` now marks it external, and both Dockerfiles install it in the runner stage from a generated `runtime-package.json` pinned to the version pnpm resolved — so the image and the lockfile can't drift. `libsql` is now an explicit dependency of `@super-agents/api` so that version is tracked rather than inherited transitively. (libsql publishes musl builds for x64 and arm64, so alpine and both release architectures are covered.)

I also checked `@libsql/client/sqlite3` hoping it used `node:sqlite` and avoided the addon entirely — it doesn't, it imports the same native package. The addon is unavoidable for local-file mode.

**2. `getLibsqlUrl` read `c.env.LIBSQL_URL` directly.** Fine when it was unused; not fine now that it runs on *every* request, including from Hono apps constructed without bindings where `c.env` is undefined. Four existing tests went red on it. Both libSQL getters now use optional access.

## Verification

**End to end against a real file database** — the thing all three tracks were building toward:

```
POST /v1/super-agents/agents  -> 201, agent returned with a generated uuid
GET  /v1/super-agents/agents  -> 200, agent reads back
ls   data/                    -> sa.db, 438 KB
```

Migrations ran on the first request. No Postgres, no PostgREST, no second container.

With `LIBSQL_URL` unset, the same build reaches for PostgREST instead (fails with "bad port" against the dummy URL I gave it) — so selection works in both directions.

**7 new selection tests**: each backend resolves correctly, two contexts in the same process resolve differently (the Workers case), migrations run once under concurrent calls, Supabase is a no-op, and a failed migration retries rather than caching the rejection.

`pnpm check`, `pnpm typecheck`, `pnpm test` (139 files, 2432 tests) all pass. `scripts/check-worker-runtime.sh` passes — and note the libSQL connector is now genuinely *in* the Worker bundle, since `v1/index.ts` imports the selection module, so CI covers it continuously from here rather than only when I probe it by hand.

## The container check now covers libSQL

The bundling failure above is precisely what `scripts/check-container-image.sh` should catch, so it now starts the container with `LIBSQL_URL` and a tmpfs, POSTs an agent, and reads it back. A regression in the native-module handling shows up as a failed smoke test rather than a broken published image.

Still unexecuted here (no Docker daemon on this machine), so the first CI run is where both that and the Dockerfile changes prove themselves.

## The payoff

`docker-compose.libsql.yml` — one service, one volume, nothing to orchestrate. Or without compose at all:

```bash
docker run -d --name super-agents -p 3000:3000 \
  -v super-agents:/app/data \
  -e LIBSQL_URL=file:/app/data/super-agents.db \
  ghcr.io/idkhub-com/super-agents:latest
```

Which is the OpenWebUI shape this started from: five services down to one.

## Notes for review

- **Nothing changes for existing deployments.** `docker-compose.yml` is untouched and still runs Postgres + PostgREST; `LIBSQL_URL` unset means the Supabase path, byte for byte.
- The middleware signature change touches the Supabase path too — that's the main regression surface. The full suite covers it, and `improved-responses.test.ts` needed a one-line update to pass a resolver.
- Local-file mode is single-instance, as covered in the design doc. Worth documenting for users before anyone points a horizontally-scaled deployment at a file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wM59ecJTFbb3gZYDDva1Z
