### PR TITLE
fix(api): give Supabase cache entries a real TTL

### DIFF
--- a/packages/api/src/connectors/libsql/cache.ts
+++ b/packages/api/src/connectors/libsql/cache.ts
@@ -7,13 +7,9 @@ import { nowIso } from './rows';
 /**
  * Cache backed by libSQL.
  *
- * Note a deliberate difference from the Supabase connector: that one writes
- * `expires_at: new Date().toISOString()` on every `setCache`, so every entry is
- * already expired by the time `getCache` filters on `expires_at >= now` and the
- * cache never returns a hit. `CacheStorageConnector.setCache` has no TTL
- * parameter, so the backend has to pick one; this uses `CACHE_TTL_SECONDS`.
- * Fixing the Supabase side is left alone here on purpose — it changes cache
- * behaviour for existing deployments and belongs in its own change.
+ * `CacheStorageConnector.setCache` takes no TTL parameter, so each backend has
+ * to pick one. Both use `CACHE_TTL_SECONDS`, which is what keeps a cached
+ * response live for the same length of time whichever storage is configured.
  */
 export const libsqlCacheStorageConnector: CacheStorageConnector = {
   getCache: async (c: AppContext, key: string): Promise<string | null> => {

--- a/packages/api/src/connectors/libsql/libsql.test.ts
+++ b/packages/api/src/connectors/libsql/libsql.test.ts
@@ -1,6 +1,7 @@
+import { CACHE_TTL_SECONDS } from '@api/constants';
 import type { AppContext } from '@api/types/hono';
 import type { Client } from '@libsql/client';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { libsqlCacheStorageConnector } from './cache';
 import {
   createLibsqlClient,
@@ -448,6 +449,10 @@ describe('evaluation_runs_with_scores', () => {
 });
 
 describe('libsql cache connector', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('round-trips a value', async () => {
     const { c } = await freshDatabase();
 
@@ -478,6 +483,34 @@ describe('libsql cache connector', () => {
     await libsqlCacheStorageConnector.deleteCache(c, 'k');
 
     expect(await libsqlCacheStorageConnector.getCache(c, 'k')).toBeNull();
+  });
+
+  it('sets the expiry one full TTL in the future', async () => {
+    /**
+     * Pins the TTL to the shared constant rather than merely checking that a
+     * fresh entry reads back. Both connectors have to agree on how long a
+     * cached response stays live -- the Supabase side once wrote `now`, which
+     * expired every entry on write and turned its cache into a permanent miss
+     * without failing anything.
+     *
+     * Only `Date` is faked; the database underneath is a real file and faking
+     * timers wholesale would stall its I/O.
+     */
+    vi.useFakeTimers({ toFake: ['Date'] });
+    const t0 = new Date('2026-03-01T12:00:00.000Z').getTime();
+    vi.setSystemTime(t0);
+
+    const { client, c } = await freshDatabase();
+    await libsqlCacheStorageConnector.setCache(c, 'k', 'v');
+
+    const stored = await client.execute({
+      sql: 'SELECT expires_at FROM cache WHERE key = ?',
+      args: ['k'],
+    });
+
+    expect(new Date(String(stored.rows[0].expires_at)).getTime()).toBe(
+      t0 + CACHE_TTL_SECONDS * 1000,
+    );
   });
 
   it('does not return an expired entry', async () => {

--- a/packages/api/src/connectors/supabase/cache.test.ts
+++ b/packages/api/src/connectors/supabase/cache.test.ts
@@ -1,0 +1,162 @@
+import { supabaseCacheStorageConnector } from '@api/connectors/supabase';
+import { CACHE_TTL_SECONDS } from '@api/constants';
+import { createMockContext } from '@api/test-utils/mock-context';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockContext = createMockContext();
+
+// Only the connection details are stubbed. `CACHE_TTL_SECONDS` is kept real,
+// because the point of these tests is the value the connector actually writes.
+vi.mock('@api/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@api/constants')>()),
+  getPostgrestServiceRoleKey: () => 'test-service-role-key',
+  getPostgrestUrl: () => 'https://test.supabase.co/rest/v1',
+  getSupabaseSecretKey: () => 'test-secret-key',
+}));
+
+global.fetch = vi.fn();
+
+/** The body of the single fetch call the connector made, parsed. */
+const writtenBody = (): { key: string; value: string; expires_at: string } => {
+  const mockFetch = vi.mocked(fetch);
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const [, init] = mockFetch.mock.calls[0];
+  return JSON.parse(String(init?.body));
+};
+
+/** An arbitrary fixed instant; the assertions are all relative to it. */
+const T0 = new Date('2026-03-01T12:00:00.000Z').getTime();
+
+describe('supabaseCacheStorageConnector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    /**
+     * The clock is frozen because both halves of this contract are times, and
+     * a real clock makes the interesting assertions meaningless: write and read
+     * land in the same millisecond, so an entry that expires *now* looks
+     * indistinguishable from one that expires in an hour.
+     */
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('setCache', () => {
+    it('writes an expiry one full TTL in the future', async () => {
+      /**
+       * The regression this file exists for. `expires_at` used to be
+       * `new Date()`, the same instant `getCache` compares against with
+       * `expires_at >= now`, so every entry was already expired when written
+       * and the cache never returned a hit. Nothing failed loudly -- every
+       * request simply missed.
+       */
+      await supabaseCacheStorageConnector.setCache(mockContext, 'k', 'v');
+
+      expect(new Date(writtenBody().expires_at).getTime()).toBe(
+        T0 + CACHE_TTL_SECONDS * 1000,
+      );
+    });
+
+    it('writes the key and value it was given', async () => {
+      await supabaseCacheStorageConnector.setCache(
+        mockContext,
+        'cache-key',
+        'cached-body',
+      );
+
+      const body = writtenBody();
+      expect(body.key).toBe('cache-key');
+      expect(body.value).toBe('cached-body');
+    });
+
+    it('upserts so a repeated key replaces rather than conflicts', async () => {
+      await supabaseCacheStorageConnector.setCache(mockContext, 'k', 'second');
+
+      // PostgREST needs to be told to merge duplicates; without this header the
+      // second write of a key fails on the primary key instead of replacing.
+      const [, init] = vi.mocked(fetch).mock.calls[0];
+      const headers = new Headers(init?.headers);
+      expect(headers.get('Prefer')).toContain('resolution=merge-duplicates');
+    });
+  });
+
+  describe('getCache', () => {
+    it('filters out entries that have already expired', async () => {
+      await supabaseCacheStorageConnector.getCache(mockContext, 'k');
+
+      const [url] = vi.mocked(fetch).mock.calls[0];
+      const query = new URL(String(url)).searchParams;
+
+      expect(query.get('key')).toBe('eq.k');
+
+      // The other half of the contract: the filter is what makes a stale row
+      // invisible, and it has to be a lower bound on `expires_at`.
+      const filter = query.get('expires_at');
+      expect(filter).toMatch(/^gte\./);
+      expect(
+        new Date(String(filter).slice('gte.'.length)).getTime(),
+      ).not.toBeNaN();
+    });
+
+    it('returns the cached value on a hit', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => [
+          {
+            key: 'k',
+            value: 'cached-body',
+            expires_at: new Date(Date.now() + 60_000).toISOString(),
+          },
+        ],
+      } as Response);
+
+      expect(
+        await supabaseCacheStorageConnector.getCache(mockContext, 'k'),
+      ).toBe('cached-body');
+    });
+
+    it('returns null when nothing matches', async () => {
+      expect(
+        await supabaseCacheStorageConnector.getCache(mockContext, 'absent'),
+      ).toBeNull();
+    });
+  });
+
+  describe('round trip', () => {
+    it('writes an entry a later read would still accept', async () => {
+      /**
+       * Ties the two halves together. Time is advanced between the write and
+       * the read, which is what makes this meaningful: with the old
+       * `expires_at = now` the entry is already behind the read's lower bound
+       * a second later, while a real TTL is still comfortably ahead of it.
+       */
+      await supabaseCacheStorageConnector.setCache(mockContext, 'k', 'v');
+      const expiresAt = new Date(writtenBody().expires_at).getTime();
+
+      vi.clearAllMocks();
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      } as Response);
+      vi.setSystemTime(T0 + 1_000);
+
+      await supabaseCacheStorageConnector.getCache(mockContext, 'k');
+      const filter = new URL(
+        String(vi.mocked(fetch).mock.calls[0][0]),
+      ).searchParams.get('expires_at');
+      const lowerBound = new Date(
+        String(filter).slice('gte.'.length),
+      ).getTime();
+
+      expect(lowerBound).toBe(T0 + 1_000);
+      expect(expiresAt).toBeGreaterThanOrEqual(lowerBound);
+    });
+  });
+});

--- a/packages/api/src/connectors/supabase/supabase.ts
+++ b/packages/api/src/connectors/supabase/supabase.ts
@@ -1,3 +1,4 @@
+import { CACHE_TTL_SECONDS } from '@api/constants';
 import type {
   CacheStorageConnector,
   LogsStorageConnector,
@@ -1222,7 +1223,14 @@ export const supabaseCacheStorageConnector: CacheStorageConnector = {
     const cachedValue: CachedValue = {
       key,
       value,
-      expires_at: new Date().toISOString(),
+      /**
+       * This used to be `new Date()`, which is the same instant `getCache`
+       * compares against with `expires_at >= now` -- so every entry was
+       * already expired when it was written and the cache never returned a
+       * hit. `CacheStorageConnector.setCache` takes no TTL, so the backend
+       * picks one; this matches the libSQL connector.
+       */
+      expires_at: new Date(Date.now() + CACHE_TTL_SECONDS * 1000).toISOString(),
     };
     // We use upsert to replace the existing value if it exists
     await insertIntoSupabase(c, 'cache', cachedValue, null, true);


### PR DESCRIPTION
## Problem

`supabaseCacheStorageConnector.setCache` wrote the current instant as the expiry:

```ts
expires_at: new Date().toISOString(),
```

`getCache` filters with `expires_at >= now`. So every entry was **already expired at the moment it was written**, and the Supabase cache never returned a hit.

Nothing failed. Each request simply missed and went to the provider, which from the outside is indistinguishable from a cold cache — no error, no log, just a cache that silently did nothing and a provider bill that was higher than it needed to be.

The libSQL connector already did this correctly with `CACHE_TTL_SECONDS`. I found the divergence while implementing that connector and documented it in `libsql/cache.ts` rather than fixing it, because changing cache behaviour for existing deployments deserved its own change. This is that change.

## Solution

`CacheStorageConnector.setCache` takes no TTL parameter, so each backend picks one. Supabase now uses the same `CACHE_TTL_SECONDS` libSQL does, so a cached response stays live for the same hour whichever storage is configured.

The now-stale comment in `libsql/cache.ts` is replaced with one describing the shared contract rather than the divergence.

## Why it survived

The Supabase connector had **no cache tests at all** — `connectors/supabase/supabase.ts` sits at 12% line coverage, while the libSQL connector it mirrors has a dedicated suite. That asymmetry is the same one that motivated the parity work in #236.

`connectors/supabase/cache.test.ts` now covers both halves of the contract, and the libSQL suite gains the matching TTL assertion — it covered expiry *behaviour* but never the TTL *value*, so the two could have drifted apart again with nothing noticing.

## On the frozen clock

The timing tests freeze time deliberately. My first attempt used a real clock, and the round-trip test **passed against the buggy implementation** — the write and the read landed in the same millisecond, so an entry expiring *now* was indistinguishable from one expiring in an hour.

With `vi.setSystemTime` the assertions are exact, and I confirmed both fail against the previous implementation before restoring the fix:

```
× setCache > writes an expiry one full TTL in the future
× round trip > writes an entry a later read would still accept
```

The libSQL test fakes only `Date` (`toFake: ['Date']`), since that suite runs against a real SQLite file and faking timers wholesale would stall its I/O.

## Test notes

- `pnpm test` — 140 files, 2446 passed (up 8)
- `pnpm test:e2e:all` — 44/44 across both storage backends
- `pnpm typecheck`, `pnpm check` — 937 files clean

Not covered here: an end-to-end assertion that a cache *hit* is served, since `getCache`/`setCache` are reachable only through the gateway middleware. That needs the stub provider, which is the next piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wM59ecJTFbb3gZYDDva1Z
