### PR TITLE
test(e2e): cover the gateway request path against a stub provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,6 +260,11 @@ Database management:
 - **Run**: `pnpm test:e2e`; browsers install with `pnpm exec playwright install chromium`
 - **What runs**: the built single-process server (`packages/api/dist/server.js`)
   on a throwaway libSQL file, so no Postgres, PostgREST or Docker is involved
+- **Gateway**: `e2e/contract/gateway.spec.ts` drives `/v1/chat/completions`
+  against `scripts/start-stub-provider.mjs`, a stub OpenAI-compatible provider.
+  It covers proxying, streaming, caching and retries, and records what the
+  gateway forwarded so the built request can be asserted. Tests key their
+  traffic by a unique model name, since one stub serves the whole run
 - **Parity**: `e2e/contract/` runs against *both* storage backends —
   `pnpm test:e2e:all` adds a Supabase pass (Postgres + PostgREST via compose,
   either docker or podman). This is the check that the hand-written type

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -61,10 +61,12 @@ the environment — the storage backend and whether the dashboard needs a login:
 | Project             | Port | Backend  | Covers                              |
 | ------------------- | ---- | -------- | ----------------------------------- |
 | `api`               | 3100 | libSQL   | server shape: routing, SPA fallback, headers |
-| `contract:libsql`   | 3100 | libSQL   | the storage contract                |
+| `contract:libsql`   | 3100 | libSQL   | the storage contract and the gateway |
 | `contract:supabase` | 3102 | Supabase | the same specs, other connector     |
 | `dashboard`         | 3100 | libSQL   | the dashboard in Chromium           |
 | `auth`              | 3101 | libSQL   | the login flow                      |
+
+A stub AI provider runs alongside them on port 3103.
 
 Neither `api` nor the two `contract` projects launches a browser — they use
 Playwright's `request` fixture only, which is what keeps the whole suite at a
@@ -91,6 +93,38 @@ libSQL cannot tell the difference.
 
 When `E2E_POSTGREST_URL` is unset the Supabase project is not registered, and
 the config says so on stderr rather than skipping quietly.
+
+## The stub provider
+
+`scripts/start-stub-provider.mjs` imitates an OpenAI-compatible provider so the
+gateway has something to proxy to. Pointing at a real provider would need API
+keys, cost money on every run, and answer differently each time.
+
+The `ollama` provider is the shape being imitated because it is
+OpenAI-compatible, requires no API key, and honours `custom_host` — so
+`gateway.spec.ts` names it in `sa-config` and points it at the stub. No AI
+provider or model records are needed in the database.
+
+Beyond answering, the stub **records what the gateway actually sent**. That is
+the only way to assert on the request the gateway builds — the model it
+resolved, the parameters it injected — because none of it appears in the
+response the client receives. It also injects failures on demand, which is how
+the retry tests work.
+
+Everything is keyed by model name. One stub process serves the whole run, so
+tests coin a unique model with `uniqueModelName()` the way they coin agent
+names, and never see each other's traffic.
+
+```
+GET  /__control/requests?model=NAME   what the gateway sent
+POST /__control/fail                  {model, times, status}
+POST /__control/reset                 {model}
+```
+
+Cache behaviour is asserted by **counting provider calls**, not by reading a
+response header — no header distinguishes a hit from a miss, and the call count
+is the behaviour that actually matters. That test is the end-to-end half of the
+fix in #237, and it fails against the pre-fix connector.
 
 ## Writing tests
 

--- a/e2e/contract/gateway.spec.ts
+++ b/e2e/contract/gateway.spec.ts
@@ -1,0 +1,287 @@
+import { type APIRequestContext, expect, test } from '@playwright/test';
+import { createAgent, deleteAgent, uniqueAgentName } from '../fixtures/agents';
+import {
+  CHAT_COMPLETIONS_PATH,
+  chatBody,
+  parseSSE,
+  saConfig,
+  stubFail,
+  stubRequests,
+  stubReset,
+  uniqueModelName,
+} from '../fixtures/gateway';
+import { createSkill } from '../fixtures/skills';
+
+/**
+ * The gateway request path, against a stub provider.
+ *
+ * This is the product's hot path and the least covered part of it -- request
+ * transformation, streaming, retries and caching are all but untouched by the
+ * unit suites, because none of them can run without something to proxy to.
+ * `scripts/start-stub-provider.mjs` is that something: it imitates an
+ * OpenAI-compatible provider, and records what the gateway actually sent, which
+ * is the only way to assert on a request the client never sees.
+ *
+ * These live in `contract/` rather than `api/` because the path writes through
+ * storage -- logs on every request, and the cache on a cacheable one -- so both
+ * connectors have to agree on it.
+ */
+test.describe('gateway', () => {
+  /** An agent and skill exist purely because the gateway resolves them first. */
+  const withSkill = async (request: APIRequestContext, prefix: string) => {
+    const agent = await createAgent(request, uniqueAgentName(prefix));
+    await createSkill(request, agent.id, 'gateway_skill');
+    return agent;
+  };
+
+  test('proxies a chat completion and returns the provider response', async ({
+    request,
+  }) => {
+    const agent = await withSkill(request, 'gw');
+    const model = uniqueModelName('complete');
+
+    try {
+      const response = await request.post(CHAT_COMPLETIONS_PATH, {
+        headers: {
+          'sa-config': saConfig(agent.name, 'gateway_skill', { model }),
+        },
+        data: chatBody('hello gateway'),
+      });
+
+      expect(response.status()).toBe(200);
+      const body = (await response.json()) as {
+        model: string;
+        choices: { message: { content: string } }[];
+      };
+
+      // The stub echoes the user message, so this asserts *this* request
+      // produced *this* response rather than matching a constant any request
+      // would have satisfied.
+      expect(body.choices[0].message.content).toBe('echo: hello gateway');
+      // The gateway replaces the client's model with the target's.
+      expect(body.model).toBe(model);
+    } finally {
+      await stubReset(request, model);
+      await deleteAgent(request, agent.id);
+    }
+  });
+
+  test('forwards the resolved model rather than the one the client sent', async ({
+    request,
+  }) => {
+    const agent = await withSkill(request, 'gwfwd');
+    const model = uniqueModelName('forward');
+
+    try {
+      await request.post(CHAT_COMPLETIONS_PATH, {
+        headers: {
+          'sa-config': saConfig(agent.name, 'gateway_skill', { model }),
+        },
+        data: chatBody('what was forwarded?'),
+      });
+
+      // Asserted at the provider, because the request the gateway builds is
+      // never visible in the response the client gets back.
+      const [forwarded] = await stubRequests(request, model);
+      expect(forwarded.model).toBe(model);
+      expect(forwarded.messages).toEqual([
+        { role: 'user', content: 'what was forwarded?' },
+      ]);
+    } finally {
+      await stubReset(request, model);
+      await deleteAgent(request, agent.id);
+    }
+  });
+
+  test('streams a completion back as server-sent events', async ({
+    request,
+  }) => {
+    const agent = await withSkill(request, 'gwstream');
+    const model = uniqueModelName('stream');
+
+    try {
+      const response = await request.post(CHAT_COMPLETIONS_PATH, {
+        headers: {
+          'sa-config': saConfig(agent.name, 'gateway_skill', { model }),
+        },
+        data: chatBody('one two three', true),
+      });
+
+      expect(response.status()).toBe(200);
+      expect(response.headers()['content-type']).toContain('text/event-stream');
+
+      const chunks = parseSSE(await response.text());
+
+      // Several chunks, not one that happens to hold the whole answer: the
+      // point is that the stream was relayed incrementally.
+      expect(chunks.length).toBeGreaterThan(2);
+
+      const assembled = chunks
+        .map(
+          (chunk) =>
+            (
+              chunk as {
+                choices?: { delta?: { content?: string } }[];
+              }
+            ).choices?.[0]?.delta?.content ?? '',
+        )
+        .join('');
+      expect(assembled.trim()).toBe('echo: one two three');
+
+      const last = chunks[chunks.length - 1] as {
+        choices: { finish_reason: string | null }[];
+      };
+      expect(last.choices[0].finish_reason).toBe('stop');
+    } finally {
+      await stubReset(request, model);
+      await deleteAgent(request, agent.id);
+    }
+  });
+
+  test('serves a repeated request from the cache without calling the provider', async ({
+    request,
+  }) => {
+    /**
+     * The end-to-end half of the fix in #237. The Supabase connector used to
+     * write `expires_at = now`, so every entry expired on write and this second
+     * request would have reached the provider again. Counting calls at the
+     * provider is the assertion, because no response header distinguishes a hit
+     * from a miss -- and it is the behaviour that actually matters.
+     */
+    const agent = await withSkill(request, 'gwcache');
+    const model = uniqueModelName('cache');
+    const headers = {
+      'sa-config': saConfig(agent.name, 'gateway_skill', {
+        model,
+        cache: { mode: 'simple' as const },
+      }),
+    };
+
+    try {
+      const first = await request.post(CHAT_COMPLETIONS_PATH, {
+        headers,
+        data: chatBody('cache this'),
+      });
+      expect(first.status()).toBe(200);
+
+      const second = await request.post(CHAT_COMPLETIONS_PATH, {
+        headers,
+        data: chatBody('cache this'),
+      });
+      expect(second.status()).toBe(200);
+
+      expect(await second.json()).toEqual(await first.json());
+      expect(await stubRequests(request, model)).toHaveLength(1);
+    } finally {
+      await stubReset(request, model);
+      await deleteAgent(request, agent.id);
+    }
+  });
+
+  test('does not cache when caching is left disabled', async ({ request }) => {
+    // The default. Worth pinning: a cache that engages when it was not asked
+    // for would serve stale answers, and the previous bug meant nobody would
+    // have noticed the difference.
+    const agent = await withSkill(request, 'gwnocache');
+    const model = uniqueModelName('nocache');
+    const headers = {
+      'sa-config': saConfig(agent.name, 'gateway_skill', { model }),
+    };
+
+    try {
+      await request.post(CHAT_COMPLETIONS_PATH, {
+        headers,
+        data: chatBody('do not cache this'),
+      });
+      await request.post(CHAT_COMPLETIONS_PATH, {
+        headers,
+        data: chatBody('do not cache this'),
+      });
+
+      expect(await stubRequests(request, model)).toHaveLength(2);
+    } finally {
+      await stubReset(request, model);
+      await deleteAgent(request, agent.id);
+    }
+  });
+
+  test('retries a retryable provider failure and then succeeds', async ({
+    request,
+  }) => {
+    const agent = await withSkill(request, 'gwretry');
+    const model = uniqueModelName('retry');
+
+    try {
+      // 503 is in RETRY_STATUS_CODES; two failures then a success.
+      await stubFail(request, model, 2, 503);
+
+      const response = await request.post(CHAT_COMPLETIONS_PATH, {
+        headers: {
+          'sa-config': saConfig(agent.name, 'gateway_skill', {
+            model,
+            retry: { attempts: 3 },
+          }),
+        },
+        data: chatBody('retry me'),
+      });
+
+      expect(response.status()).toBe(200);
+      const body = (await response.json()) as {
+        choices: { message: { content: string } }[];
+      };
+      expect(body.choices[0].message.content).toBe('echo: retry me');
+
+      // Two failures plus the successful attempt.
+      expect(await stubRequests(request, model)).toHaveLength(3);
+    } finally {
+      await stubReset(request, model);
+      await deleteAgent(request, agent.id);
+    }
+  });
+
+  test('gives up and surfaces the provider failure once attempts run out', async ({
+    request,
+  }) => {
+    const agent = await withSkill(request, 'gwgiveup');
+    const model = uniqueModelName('giveup');
+
+    try {
+      await stubFail(request, model, 5, 503);
+
+      const response = await request.post(CHAT_COMPLETIONS_PATH, {
+        headers: {
+          'sa-config': saConfig(agent.name, 'gateway_skill', {
+            model,
+            retry: { attempts: 2 },
+          }),
+        },
+        data: chatBody('always fails'),
+      });
+
+      // The provider's failure has to reach the client rather than being
+      // retried forever or reported as a gateway error.
+      expect(response.status()).toBe(503);
+      expect(await stubRequests(request, model)).toHaveLength(3);
+    } finally {
+      await stubReset(request, model);
+      await deleteAgent(request, agent.id);
+    }
+  });
+
+  test('rejects a request naming an agent that does not exist', async ({
+    request,
+  }) => {
+    const model = uniqueModelName('noagent');
+
+    const response = await request.post(CHAT_COMPLETIONS_PATH, {
+      headers: {
+        'sa-config': saConfig('agent_that_does_not_exist', 'nope', { model }),
+      },
+      data: chatBody('hello'),
+    });
+
+    expect(response.status()).toBe(404);
+    // Nothing should have been proxied for a request that never resolved.
+    expect(await stubRequests(request, model)).toHaveLength(0);
+  });
+});

--- a/e2e/fixtures/gateway.ts
+++ b/e2e/fixtures/gateway.ts
@@ -1,0 +1,108 @@
+import type { APIRequestContext } from '@playwright/test';
+
+/**
+ * The stub provider runs once for the whole suite, on its own origin, so every
+ * helper here takes an absolute URL rather than relying on a project baseURL.
+ */
+export const STUB_URL = process.env.E2E_STUB_URL ?? 'http://127.0.0.1:3103';
+
+export const CHAT_COMPLETIONS_PATH = '/v1/chat/completions';
+
+/**
+ * Model names are how the stub separates one test's traffic from another's.
+ * The suite runs in parallel against a single stub process, so a shared name
+ * would mean shared recorded requests and shared injected failures.
+ */
+export const uniqueModelName = (prefix: string): string => {
+  const stamp = Date.now().toString(36);
+  const salt = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${stamp}-${salt}`;
+};
+
+export interface TargetOptions {
+  model: string;
+  cache?: { mode: 'disabled' | 'simple' | 'semantic' };
+  retry?: { attempts: number; on_status_codes?: number[] };
+}
+
+/**
+ * Builds the `sa-config` header.
+ *
+ * The target names the provider and model directly rather than going through
+ * `optimization: auto`, which keeps these tests about the gateway -- transform,
+ * stream, cache, retry -- instead of about arm selection. `ollama` is the
+ * provider being imitated because it is OpenAI-compatible, needs no API key,
+ * and honours `custom_host`.
+ */
+export const saConfig = (
+  agentName: string,
+  skillName: string,
+  target: TargetOptions,
+): string =>
+  JSON.stringify({
+    agent_name: agentName,
+    skill_name: skillName,
+    targets: [
+      {
+        provider: 'ollama',
+        custom_host: STUB_URL,
+        ...target,
+      },
+    ],
+  });
+
+/**
+ * OpenAI-compatible clients always send `model`, and the gateway requires it
+ * even though it replaces the value with the one the target resolved to.
+ */
+export const chatBody = (content: string, stream = false) => ({
+  model: 'ignored-by-the-gateway',
+  messages: [{ role: 'user', content }],
+  ...(stream ? { stream: true } : {}),
+});
+
+/** Request bodies the gateway forwarded to the provider, oldest first. */
+export const stubRequests = async (
+  request: APIRequestContext,
+  model: string,
+): Promise<Record<string, unknown>[]> => {
+  const response = await request.get(
+    `${STUB_URL}/__control/requests?model=${encodeURIComponent(model)}`,
+  );
+  const body = (await response.json()) as {
+    requests: Record<string, unknown>[];
+  };
+  return body.requests;
+};
+
+/** Make the next `times` calls for this model fail with `status`. */
+export const stubFail = async (
+  request: APIRequestContext,
+  model: string,
+  times: number,
+  status = 503,
+): Promise<void> => {
+  await request.post(`${STUB_URL}/__control/fail`, {
+    data: { model, times, status },
+  });
+};
+
+export const stubReset = async (
+  request: APIRequestContext,
+  model: string,
+): Promise<void> => {
+  try {
+    await request.post(`${STUB_URL}/__control/reset`, { data: { model } });
+  } catch {
+    // Ignored: teardown must not mask the assertion that actually failed.
+  }
+};
+
+/** Collects the `data:` payloads from an SSE body, ignoring the [DONE] marker. */
+export const parseSSE = (body: string): Record<string, unknown>[] =>
+  body
+    .split('\n')
+    .filter((line) => line.startsWith('data: '))
+    .map((line) => line.slice('data: '.length).trim())
+    .filter((payload) => payload && payload !== '[DONE]')
+    .map((payload) => JSON.parse(payload) as Record<string, unknown>);

--- a/packages/api/src/connectors/libsql/cache.ts
+++ b/packages/api/src/connectors/libsql/cache.ts
@@ -7,13 +7,9 @@ import { nowIso } from './rows';
 /**
  * Cache backed by libSQL.
  *
- * Note a deliberate difference from the Supabase connector: that one writes
- * `expires_at: new Date().toISOString()` on every `setCache`, so every entry is
- * already expired by the time `getCache` filters on `expires_at >= now` and the
- * cache never returns a hit. `CacheStorageConnector.setCache` has no TTL
- * parameter, so the backend has to pick one; this uses `CACHE_TTL_SECONDS`.
- * Fixing the Supabase side is left alone here on purpose — it changes cache
- * behaviour for existing deployments and belongs in its own change.
+ * `CacheStorageConnector.setCache` takes no TTL parameter, so each backend has
+ * to pick one. Both use `CACHE_TTL_SECONDS`, which is what keeps a cached
+ * response live for the same length of time whichever storage is configured.
  */
 export const libsqlCacheStorageConnector: CacheStorageConnector = {
   getCache: async (c: AppContext, key: string): Promise<string | null> => {

--- a/packages/api/src/connectors/libsql/libsql.test.ts
+++ b/packages/api/src/connectors/libsql/libsql.test.ts
@@ -1,6 +1,7 @@
+import { CACHE_TTL_SECONDS } from '@api/constants';
 import type { AppContext } from '@api/types/hono';
 import type { Client } from '@libsql/client';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { libsqlCacheStorageConnector } from './cache';
 import {
   createLibsqlClient,
@@ -448,6 +449,10 @@ describe('evaluation_runs_with_scores', () => {
 });
 
 describe('libsql cache connector', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('round-trips a value', async () => {
     const { c } = await freshDatabase();
 
@@ -478,6 +483,34 @@ describe('libsql cache connector', () => {
     await libsqlCacheStorageConnector.deleteCache(c, 'k');
 
     expect(await libsqlCacheStorageConnector.getCache(c, 'k')).toBeNull();
+  });
+
+  it('sets the expiry one full TTL in the future', async () => {
+    /**
+     * Pins the TTL to the shared constant rather than merely checking that a
+     * fresh entry reads back. Both connectors have to agree on how long a
+     * cached response stays live -- the Supabase side once wrote `now`, which
+     * expired every entry on write and turned its cache into a permanent miss
+     * without failing anything.
+     *
+     * Only `Date` is faked; the database underneath is a real file and faking
+     * timers wholesale would stall its I/O.
+     */
+    vi.useFakeTimers({ toFake: ['Date'] });
+    const t0 = new Date('2026-03-01T12:00:00.000Z').getTime();
+    vi.setSystemTime(t0);
+
+    const { client, c } = await freshDatabase();
+    await libsqlCacheStorageConnector.setCache(c, 'k', 'v');
+
+    const stored = await client.execute({
+      sql: 'SELECT expires_at FROM cache WHERE key = ?',
+      args: ['k'],
+    });
+
+    expect(new Date(String(stored.rows[0].expires_at)).getTime()).toBe(
+      t0 + CACHE_TTL_SECONDS * 1000,
+    );
   });
 
   it('does not return an expired entry', async () => {

--- a/packages/api/src/connectors/supabase/cache.test.ts
+++ b/packages/api/src/connectors/supabase/cache.test.ts
@@ -1,0 +1,162 @@
+import { supabaseCacheStorageConnector } from '@api/connectors/supabase';
+import { CACHE_TTL_SECONDS } from '@api/constants';
+import { createMockContext } from '@api/test-utils/mock-context';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockContext = createMockContext();
+
+// Only the connection details are stubbed. `CACHE_TTL_SECONDS` is kept real,
+// because the point of these tests is the value the connector actually writes.
+vi.mock('@api/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@api/constants')>()),
+  getPostgrestServiceRoleKey: () => 'test-service-role-key',
+  getPostgrestUrl: () => 'https://test.supabase.co/rest/v1',
+  getSupabaseSecretKey: () => 'test-secret-key',
+}));
+
+global.fetch = vi.fn();
+
+/** The body of the single fetch call the connector made, parsed. */
+const writtenBody = (): { key: string; value: string; expires_at: string } => {
+  const mockFetch = vi.mocked(fetch);
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const [, init] = mockFetch.mock.calls[0];
+  return JSON.parse(String(init?.body));
+};
+
+/** An arbitrary fixed instant; the assertions are all relative to it. */
+const T0 = new Date('2026-03-01T12:00:00.000Z').getTime();
+
+describe('supabaseCacheStorageConnector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    /**
+     * The clock is frozen because both halves of this contract are times, and
+     * a real clock makes the interesting assertions meaningless: write and read
+     * land in the same millisecond, so an entry that expires *now* looks
+     * indistinguishable from one that expires in an hour.
+     */
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('setCache', () => {
+    it('writes an expiry one full TTL in the future', async () => {
+      /**
+       * The regression this file exists for. `expires_at` used to be
+       * `new Date()`, the same instant `getCache` compares against with
+       * `expires_at >= now`, so every entry was already expired when written
+       * and the cache never returned a hit. Nothing failed loudly -- every
+       * request simply missed.
+       */
+      await supabaseCacheStorageConnector.setCache(mockContext, 'k', 'v');
+
+      expect(new Date(writtenBody().expires_at).getTime()).toBe(
+        T0 + CACHE_TTL_SECONDS * 1000,
+      );
+    });
+
+    it('writes the key and value it was given', async () => {
+      await supabaseCacheStorageConnector.setCache(
+        mockContext,
+        'cache-key',
+        'cached-body',
+      );
+
+      const body = writtenBody();
+      expect(body.key).toBe('cache-key');
+      expect(body.value).toBe('cached-body');
+    });
+
+    it('upserts so a repeated key replaces rather than conflicts', async () => {
+      await supabaseCacheStorageConnector.setCache(mockContext, 'k', 'second');
+
+      // PostgREST needs to be told to merge duplicates; without this header the
+      // second write of a key fails on the primary key instead of replacing.
+      const [, init] = vi.mocked(fetch).mock.calls[0];
+      const headers = new Headers(init?.headers);
+      expect(headers.get('Prefer')).toContain('resolution=merge-duplicates');
+    });
+  });
+
+  describe('getCache', () => {
+    it('filters out entries that have already expired', async () => {
+      await supabaseCacheStorageConnector.getCache(mockContext, 'k');
+
+      const [url] = vi.mocked(fetch).mock.calls[0];
+      const query = new URL(String(url)).searchParams;
+
+      expect(query.get('key')).toBe('eq.k');
+
+      // The other half of the contract: the filter is what makes a stale row
+      // invisible, and it has to be a lower bound on `expires_at`.
+      const filter = query.get('expires_at');
+      expect(filter).toMatch(/^gte\./);
+      expect(
+        new Date(String(filter).slice('gte.'.length)).getTime(),
+      ).not.toBeNaN();
+    });
+
+    it('returns the cached value on a hit', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => [
+          {
+            key: 'k',
+            value: 'cached-body',
+            expires_at: new Date(Date.now() + 60_000).toISOString(),
+          },
+        ],
+      } as Response);
+
+      expect(
+        await supabaseCacheStorageConnector.getCache(mockContext, 'k'),
+      ).toBe('cached-body');
+    });
+
+    it('returns null when nothing matches', async () => {
+      expect(
+        await supabaseCacheStorageConnector.getCache(mockContext, 'absent'),
+      ).toBeNull();
+    });
+  });
+
+  describe('round trip', () => {
+    it('writes an entry a later read would still accept', async () => {
+      /**
+       * Ties the two halves together. Time is advanced between the write and
+       * the read, which is what makes this meaningful: with the old
+       * `expires_at = now` the entry is already behind the read's lower bound
+       * a second later, while a real TTL is still comfortably ahead of it.
+       */
+      await supabaseCacheStorageConnector.setCache(mockContext, 'k', 'v');
+      const expiresAt = new Date(writtenBody().expires_at).getTime();
+
+      vi.clearAllMocks();
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      } as Response);
+      vi.setSystemTime(T0 + 1_000);
+
+      await supabaseCacheStorageConnector.getCache(mockContext, 'k');
+      const filter = new URL(
+        String(vi.mocked(fetch).mock.calls[0][0]),
+      ).searchParams.get('expires_at');
+      const lowerBound = new Date(
+        String(filter).slice('gte.'.length),
+      ).getTime();
+
+      expect(lowerBound).toBe(T0 + 1_000);
+      expect(expiresAt).toBeGreaterThanOrEqual(lowerBound);
+    });
+  });
+});

--- a/packages/api/src/connectors/supabase/supabase.ts
+++ b/packages/api/src/connectors/supabase/supabase.ts
@@ -1,3 +1,4 @@
+import { CACHE_TTL_SECONDS } from '@api/constants';
 import type {
   CacheStorageConnector,
   LogsStorageConnector,
@@ -1222,7 +1223,14 @@ export const supabaseCacheStorageConnector: CacheStorageConnector = {
     const cachedValue: CachedValue = {
       key,
       value,
-      expires_at: new Date().toISOString(),
+      /**
+       * This used to be `new Date()`, which is the same instant `getCache`
+       * compares against with `expires_at >= now` -- so every entry was
+       * already expired when it was written and the cache never returned a
+       * hit. `CacheStorageConnector.setCache` takes no TTL, so the backend
+       * picks one; this matches the libSQL connector.
+       */
+      expires_at: new Date(Date.now() + CACHE_TTL_SECONDS * 1000).toISOString(),
     };
     // We use upsert to replace the existing value if it exists
     await insertIntoSupabase(c, 'cache', cachedValue, null, true);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,7 @@ import { defineConfig, devices } from '@playwright/test';
 const LIBSQL_PORT = Number(process.env.E2E_LIBSQL_PORT ?? 3100);
 const AUTH_PORT = Number(process.env.E2E_AUTH_PORT ?? 3101);
 const SUPABASE_PORT = Number(process.env.E2E_SUPABASE_PORT ?? 3102);
+const STUB_PORT = Number(process.env.E2E_STUB_PORT ?? 3103);
 
 /** Only ever reaches the throwaway server started below. */
 export const AUTH_PASSWORD = 'e2e-access-password';
@@ -121,6 +122,21 @@ export default defineConfig({
   ],
 
   webServer: [
+    /**
+     * The stub AI provider. One process for the whole run, shared by both
+     * storage backends: the gateway specs separate their traffic by model name
+     * rather than by process, the same way other specs separate theirs by agent
+     * name. Its `/__control` surface doubles as the readiness probe.
+     */
+    {
+      command: 'node scripts/start-stub-provider.mjs',
+      url: `http://127.0.0.1:${STUB_PORT}/__control/requests?model=ready`,
+      env: { E2E_STUB_PORT: String(STUB_PORT) },
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+      stdout: 'pipe' as const,
+      stderr: 'pipe' as const,
+    },
     // Each libSQL server owns its database file, so the two cannot see each
     // other's writes and the projects stay independent.
     server(LIBSQL_PORT, { E2E_DB_NAME: 'main.db' }),

--- a/scripts/start-stub-provider.mjs
+++ b/scripts/start-stub-provider.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * A stub OpenAI-compatible provider for the end-to-end suite.
+ *
+ * The gateway is the product's hot path -- every proxied request goes through
+ * request transformation, streaming, retries and caching -- but none of it can
+ * be exercised without something to proxy *to*. Pointing at a real provider
+ * would need API keys, cost money, and give non-deterministic answers, so the
+ * suite points at this instead: the `ollama` provider is OpenAI-compatible,
+ * needs no API key, and honours `custom_host`, which is what makes it usable
+ * as the shape to imitate.
+ *
+ * Beyond answering, it records what the gateway actually sent. That is the
+ * only way to assert on the request the gateway builds -- the system prompt it
+ * injected, the parameters it resolved, the model it chose -- since none of
+ * that is visible in the response.
+ *
+ * Everything is keyed by model name. The suite runs in parallel and this is one
+ * shared process, so tests coin a unique model the way they coin agent names,
+ * and never see each other's recorded requests or injected failures.
+ *
+ *   POST /v1/chat/completions   the provider endpoint the gateway calls
+ *   POST /api/embeddings        ditto, for embeddings
+ *   GET  /__control/requests?model=NAME   what the gateway sent for that model
+ *   POST /__control/fail        {model, times, status} -- inject failures
+ *   POST /__control/reset       {model} -- forget everything for that model
+ *
+ * Configured with E2E_STUB_PORT (default 3103).
+ */
+import { createServer } from 'node:http';
+
+const port = Number(process.env.E2E_STUB_PORT ?? 3103);
+
+/** model name -> request bodies the gateway sent, oldest first. */
+const received = new Map();
+/** model name -> queued failures, shifted one per request. */
+const failures = new Map();
+
+const recordFor = (model) => {
+  if (!received.has(model)) {
+    received.set(model, []);
+  }
+  return received.get(model);
+};
+
+const readBody = (request) =>
+  new Promise((resolve, reject) => {
+    const chunks = [];
+    request.on('data', (chunk) => chunks.push(chunk));
+    request.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    request.on('error', reject);
+  });
+
+const sendJson = (response, status, payload) => {
+  const body = JSON.stringify(payload);
+  response.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  response.end(body);
+};
+
+/**
+ * The assistant reply echoes the last user message, so a test can tell that
+ * *its* request produced *this* response rather than matching a fixed string
+ * that any request would have produced.
+ */
+const replyText = (body) => {
+  const messages = Array.isArray(body?.messages) ? body.messages : [];
+  const lastUser = [...messages].reverse().find((m) => m?.role === 'user');
+  const content =
+    typeof lastUser?.content === 'string' ? lastUser.content : 'nothing';
+  return `echo: ${content}`;
+};
+
+const completionPayload = (body, text) => ({
+  id: 'chatcmpl-stub',
+  object: 'chat.completion',
+  // Fixed rather than Date.now(), so a response is byte-identical across
+  // requests and a cache hit cannot be confused with a fresh call.
+  created: 1_780_000_000,
+  model: body?.model ?? 'stub-model',
+  choices: [
+    {
+      index: 0,
+      message: { role: 'assistant', content: text },
+      finish_reason: 'stop',
+    },
+  ],
+  usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+});
+
+const streamCompletion = (response, body, text) => {
+  response.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+
+  const base = {
+    id: 'chatcmpl-stub',
+    object: 'chat.completion.chunk',
+    created: 1_780_000_000,
+    model: body?.model ?? 'stub-model',
+  };
+
+  // Split into several chunks so the test sees real incremental assembly
+  // rather than one chunk that happens to contain the whole answer.
+  const write = (chunk) => response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+
+  write({
+    ...base,
+    choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }],
+  });
+  for (const word of text.split(' ')) {
+    write({
+      ...base,
+      choices: [
+        { index: 0, delta: { content: `${word} ` }, finish_reason: null },
+      ],
+    });
+  }
+  write({ ...base, choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] });
+  response.write('data: [DONE]\n\n');
+  response.end();
+};
+
+const server = createServer(async (request, response) => {
+  const url = new URL(request.url, `http://127.0.0.1:${port}`);
+
+  if (url.pathname === '/__control/requests') {
+    const model = url.searchParams.get('model') ?? '';
+    sendJson(response, 200, { requests: received.get(model) ?? [] });
+    return;
+  }
+
+  if (url.pathname === '/__control/fail') {
+    const {
+      model,
+      times = 1,
+      status = 503,
+    } = JSON.parse((await readBody(request)) || '{}');
+    failures.set(
+      model,
+      Array.from({ length: times }, () => status),
+    );
+    sendJson(response, 200, { ok: true });
+    return;
+  }
+
+  if (url.pathname === '/__control/reset') {
+    const { model } = JSON.parse((await readBody(request)) || '{}');
+    received.delete(model);
+    failures.delete(model);
+    sendJson(response, 200, { ok: true });
+    return;
+  }
+
+  const raw = await readBody(request);
+  let body;
+  try {
+    body = raw ? JSON.parse(raw) : {};
+  } catch {
+    sendJson(response, 400, { error: { message: 'stub: invalid JSON' } });
+    return;
+  }
+
+  const model = body?.model ?? '';
+  recordFor(model).push(body);
+
+  const queued = failures.get(model);
+  if (queued?.length) {
+    const status = queued.shift();
+    // Shaped like a provider error so the retry handler treats it as one.
+    sendJson(response, status, {
+      error: { message: `stub: injected failure (${status})`, type: 'stub' },
+    });
+    return;
+  }
+
+  if (url.pathname === '/api/embeddings') {
+    sendJson(response, 200, {
+      embedding: Array.from({ length: 8 }, () => 0.1),
+    });
+    return;
+  }
+
+  if (url.pathname === '/v1/chat/completions') {
+    const text = replyText(body);
+    if (body?.stream) {
+      streamCompletion(response, body, text);
+    } else {
+      sendJson(response, 200, completionPayload(body, text));
+    }
+    return;
+  }
+
+  sendJson(response, 404, {
+    error: { message: `stub: no handler for ${url.pathname}` },
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  console.log(`Stub AI provider listening on http://127.0.0.1:${port}`);
+});


### PR DESCRIPTION
## Problem

The gateway is the product's hot path — every proxied request goes through request transformation, streaming, retries and caching — and it is the least covered part of the codebase:

| File | Line coverage |
| --- | --- |
| `handlers/stream-handler.ts` | 2% |
| `handlers/retry-handler.ts` | 2% |
| `handlers/handler-utils.ts` | 33% |
| `middlewares/cache.ts` | 6% |

None of it can be exercised without something to proxy *to*. Pointing at a real provider would need API keys, cost money on every CI run, and answer differently each time.

## Solution

`scripts/start-stub-provider.mjs` — a stub OpenAI-compatible provider.

The `ollama` provider is the shape it imitates, for three reasons: it's OpenAI-compatible, it requires no API key (`isAPIKeyRequired: false`), and it honours `custom_host`. That last one is what makes this work without touching the database — a target in `sa-config` names the provider and points `custom_host` at the stub, so no AI provider or model records are needed:

```json
{ "agent_name": "...", "skill_name": "...",
  "targets": [{ "provider": "ollama", "model": "...", "custom_host": "http://127.0.0.1:3103" }] }
```

Beyond answering, the stub **records what the gateway actually sent**. That's the only way to assert on the request the gateway builds — the model it resolved, the parameters it injected — because none of it appears in the response the client receives. It also injects failures on demand, which is how the retry cases work.

Everything is keyed by **model name**. One stub process serves the whole run and the suite is parallel, so tests coin a unique model with `uniqueModelName()` exactly the way they already coin agent names, and never see each other's traffic.

## What's covered

Eight cases, in `contract/` so they run against **both** storage backends (the path writes logs on every request and the cache on a cacheable one):

- proxies a completion and returns the provider response
- forwards the **resolved** model, not the one the client sent
- relays a stream as SSE, assembled from multiple chunks with a `stop` finish
- serves a repeat from cache **without calling the provider**
- does *not* cache when caching is left disabled
- retries a 503 and then succeeds — 3 provider calls for 2 injected failures
- gives up once attempts run out and surfaces the provider's 503
- rejects an unknown agent with 404 and proxies nothing

## The cache case is the end-to-end half of #237

When I fixed the Supabase cache TTL I noted there was no end-to-end proof a cache **hit** is served, because `getCache`/`setCache` are reachable only through this middleware. This is that proof.

Cache behaviour is asserted by **counting calls at the provider**, not by reading a response header — I checked, and no header distinguishes a hit from a miss. The call count is the behaviour that actually matters anyway.

I verified the test earns its keep by reverting #237's fix and re-running it against Supabase:

```
✘ gateway › serves a repeated request from the cache without calling the provider
  Expected length: 1
  Received length: 2
```

I checked this deliberately, having already been caught once in #237 by a test that passed against the bug it was meant to catch.

## Test notes

- `pnpm test:e2e:all` — **60/60** across both backends (was 44)
- `pnpm test:e2e` — 39/39, libSQL only, no container runtime
- `pnpm test` — 2446 passed; `pnpm typecheck`, `pnpm check` — 940 files clean
- Gateway spec verified green on libSQL *and* Supabase independently

## Scope

The targets here name provider and model directly rather than going through `optimization: auto`, which keeps these tests about the gateway rather than about arm selection. Driving the optimizer end-to-end — the loop that runs off these logged requests — is the next piece this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wM59ecJTFbb3gZYDDva1Z
