### PR TITLE
ci: publish the coverage report to Pages and badge it in the README

### DIFF
--- a/.github/workflows/ci-pull.yml
+++ b/.github/workflows/ci-pull.yml
@@ -241,6 +241,55 @@ jobs:
         if: always()
         run: scripts/e2e-postgres.sh down
 
+  # Coverage on a pull request: the report is an artifact to download, not a
+  # Pages deploy. Only main publishes, so a PR cannot overwrite the badge with
+  # a number that was never merged.
+  coverage:
+    name: Coverage
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10.10.0
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      - name: Report the line coverage
+        run: |
+          set -euo pipefail
+          node -p "'Line coverage: ' + require('./coverage/coverage-summary.json').total.lines.pct + '%'" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage/index.html
+            coverage/lcov.info
+          retention-days: 14
+
   migrations:
     name: Test Migrations
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,97 @@ jobs:
         if: always()
         run: scripts/e2e-postgres.sh down
 
+  # Publishes the browsable HTML coverage report to GitHub Pages, and writes a
+  # shields.io "endpoint" JSON beside it so the README badge reads the current
+  # line-% straight from Pages -- no Gist, no PAT, no third-party service.
+  #
+  # One-time repo setup: Settings -> Pages -> Source = "GitHub Actions".
+  # Served at https://jorge-menjivar.github.io/super-agents/.
+  #
+  # This is unit-test coverage only. The end-to-end suite runs a built bundle in
+  # a separate process, so v8 cannot instrument it and it contributes nothing to
+  # this number -- see e2e/README.md for what it covers instead.
+  coverage-pages:
+    name: Coverage (Pages)
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    # Serialize deploys; never cancel an in-flight Pages deployment.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10.10.0
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      - name: Write the badge endpoint JSON
+        run: |
+          set -euo pipefail
+          pct=$(node -p "require('./coverage/coverage-summary.json').total.lines.pct")
+          if   awk "BEGIN{exit !($pct>=90)}"; then color=brightgreen
+          elif awk "BEGIN{exit !($pct>=75)}"; then color=green
+          elif awk "BEGIN{exit !($pct>=60)}"; then color=yellow
+          elif awk "BEGIN{exit !($pct>=40)}"; then color=orange
+          else color=red
+          fi
+          printf '{"schemaVersion":1,"label":"coverage","message":"%.1f%%","color":"%s"}\n' \
+            "$pct" "$color" > coverage/coverage.json
+          cat coverage/coverage.json
+
+      # The `lcov` reporter renders a second copy of the same HTML here. Keep
+      # `lcov.info` for anything external, drop the duplicate report.
+      - name: Trim the duplicate report
+        run: rm -rf coverage/lcov-report
+
+      - name: Upload the lcov report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          retention-days: 14
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: coverage
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
   migrations:
     name: Test Migrations
     timeout-minutes: 10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ pnpm test:e2e:ui       # interactive runner (skips the build)
 pnpm test:e2e:report   # open the report from the last run
 
 # Coverage (unit tests only; the e2e suite runs a built bundle out-of-process)
-pnpm test:coverage     # writes coverage/index.html
+pnpm test:coverage     # writes coverage/index.html and coverage/lcov.info
 
 # Runtime checks (also run in CI; both are slow, so they are not part of `pnpm test`)
 pnpm verify:worker     # Bundle and boot the API on workerd
@@ -254,7 +254,20 @@ Database management:
 - **Location**: beside the code they cover, inside `packages/`
 - **Naming**: `*.test.ts` or `*.test.tsx`
 - **Run**: `pnpm test` (CI mode) or `pnpm test:watch` (dev)
-- **Coverage**: Reports generated in text/json/html
+- **Coverage**: see below
+
+**Coverage** — Vitest + v8, published to GitHub Pages
+- `pnpm test:coverage` writes `coverage/` (browsable `index.html`, `lcov.info`)
+- The `coverage-pages` CI job publishes the report on every push to `main`, and
+  writes `coverage/coverage.json` — a shields.io *endpoint* payload — beside it,
+  which is what the README badge reads. No Gist, no token, no third-party service
+- **The number is unit coverage only.** The e2e suite runs a built bundle in a
+  separate process, so v8 cannot instrument it; a well-covered end-to-end path
+  still reads as 0% here. Judge gateway and storage coverage from `e2e/`, not
+  from this figure
+- `coverage.exclude` in `vitest.config.ts` drops dependencies, examples, build
+  output and vendored `components/ui/**`. Without it the figure is inflated by
+  roughly thirty points, because `node_modules` counts as fully covered
 
 **End-to-end tests** — Playwright, in `e2e/` (see `e2e/README.md`)
 - **Run**: `pnpm test:e2e`; browsers install with `pnpm exec playwright install chromium`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Super Agents
 
+[![coverage](https://img.shields.io/endpoint?url=https://jorge-menjivar.github.io/super-agents/coverage.json)](https://jorge-menjivar.github.io/super-agents/)
+
 > Automatically optimize your AI agents based on performance with OpenAI API compatibility.
 
 ## What is Super Agents?

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,7 +21,9 @@ export default defineConfig({
     teardownTimeout: 3000,
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'json-summary', 'html'],
+      // `html` is what gets published to Pages, `json-summary` is what the
+      // badge reads, and `lcov` is the portable format for anything external.
+      reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],
       reportsDirectory: './coverage',
       /**
        * Without these, the report is dominated by code nobody writes tests


### PR DESCRIPTION
Mirrors the setup in [super-stt-voxtral](https://github.com/jorge-menjivar/super-stt-voxtral): a shields.io endpoint badge backed by a coverage report published to GitHub Pages.

## Problem

Coverage had no visible home. `pnpm test:coverage` produced a report only the person who ran it ever saw, so the number moved without anyone noticing.

## Solution

**`coverage-pages`** (push to `main`) publishes the browsable HTML report to Pages and writes `coverage/coverage.json` beside it — a shields.io *endpoint* payload — which is what the README badge reads.

```
[![coverage](https://img.shields.io/endpoint?url=https://jorge-menjivar.github.io/super-agents/coverage.json)](https://jorge-menjivar.github.io/super-agents/)
```

No Gist, no PAT, no third-party service. The report and the number it advertises are the same artifact, so they can't drift apart. Colour thresholds match the reference repo (90/75/60/40).

**`coverage`** (pull requests) runs the same coverage but uploads an artifact and writes the percentage into the job summary — it does **not** deploy. Only `main` publishes, so a branch can't overwrite the badge with a number that was never merged.

I enabled Pages on the repo (`build_type: workflow`), so no manual Settings step is needed. It'll serve at **https://jorge-menjivar.github.io/super-agents/** once this merges and the job runs.

## One deliberate difference from the reference repo

super-stt-voxtral runs coverage twice on main — once for the lcov artifact, once for the Pages deploy. Here the Pages job does both, since running a 2,446-test suite twice per push buys nothing.

## Two things worth knowing about the number

**It will read ~41%, and it's honest.** An unconfigured run reports 71.6% by counting `node_modules` as fully covered — dependencies alone are more lines than the whole application. `coverage.exclude` drops those, plus examples, build output and vendored `components/ui/**`.

**It's unit coverage only.** The e2e suite runs a built bundle in a separate process, so v8 can't instrument it — a well-covered gateway path still reads as 0% here. `AGENTS.md` says so explicitly next to the badge docs, because a low number next to a green e2e suite invites exactly the wrong conclusion. Judge gateway and storage coverage from `e2e/`.

Also adds the `lcov` reporter for anything consuming the data outside this repo.

## Test notes

- Badge generation verified locally against a real run: `{"schemaVersion":1,"label":"coverage","message":"41.1%","color":"orange"}`
- `pnpm test` — 2446 passed; `pnpm typecheck`, `pnpm check` — 940 files clean
- `coverage/` stays gitignored; nothing generated is committed
- The Pages deploy itself can only be verified after merge, since the job is `main`-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wM59ecJTFbb3gZYDDva1Z
