### PR TITLE
test(api): cover the optimizer's selection maths and example extraction

### DIFF
--- a/packages/api/src/middlewares/optimizer-selection.test.ts
+++ b/packages/api/src/middlewares/optimizer-selection.test.ts
@@ -1,0 +1,346 @@
+import {
+  getOptimalArm,
+  getOptimalCluster,
+} from '@api/middlewares/super-agents-configuration';
+import { createMockContext } from '@api/test-utils/mock-context';
+import type { UserDataStorageConnector } from '@api/types/connector';
+import type {
+  SkillOptimizationArm,
+  SkillOptimizationCluster,
+} from '@shared/types/data';
+import type { SkillOptimizationArmStat } from '@shared/types/data/skill-optimization-arm-stats';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The two choices the optimizer makes on every request: which cluster a request
+ * belongs to, and which arm within it serves the request.
+ *
+ * Neither is reachable from an end-to-end test in any meaningful way -- both are
+ * probabilistic, so a single request proves nothing about the distribution --
+ * and both fail silently. A bandit that systematically prefers the wrong arm
+ * still answers every request successfully; it just never improves.
+ */
+
+const mockContext = createMockContext();
+
+/**
+ * Seeded stand-in for `Math.random`, so the frequency assertions below are
+ * reproducible. Thompson sampling is random by construction: the only honest
+ * assertions are about how often each arm wins over many draws, and those are
+ * only stable if the draws are.
+ */
+const seeded = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const withSeed = (seed: number): void => {
+  vi.spyOn(Math, 'random').mockImplementation(seeded(seed));
+};
+
+const uuid = (n: number): string =>
+  `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`;
+
+const arm = (id: string): SkillOptimizationArm =>
+  ({ id, skill_id: uuid(1), cluster_id: uuid(2) }) as SkillOptimizationArm;
+
+const stat = (
+  armId: string,
+  evaluationId: string,
+  n: number,
+  totalReward: number,
+): SkillOptimizationArmStat =>
+  ({
+    arm_id: armId,
+    evaluation_id: evaluationId,
+    n,
+    total_reward: totalReward,
+    mean: n > 0 ? totalReward / n : 0,
+    n2: totalReward,
+  }) as SkillOptimizationArmStat;
+
+/**
+ * A connector that answers only the two reads `getOptimalArm` performs.
+ * `statsByArm` maps an arm id to the rows that arm has accumulated.
+ */
+const connectorWith = (
+  evaluations: { id: string; weight: number }[],
+  statsByArm: Record<string, SkillOptimizationArmStat[]>,
+): UserDataStorageConnector =>
+  ({
+    getSkillOptimizationEvaluations: vi.fn().mockResolvedValue(evaluations),
+    getSkillOptimizationArmStats: vi
+      .fn()
+      .mockImplementation(
+        async (_c: unknown, query: { arm_id: string }) =>
+          statsByArm[query.arm_id] ?? [],
+      ),
+  }) as unknown as UserDataStorageConnector;
+
+/** How often each arm is chosen across `rounds` independent selections. */
+const winRate = async (
+  rounds: number,
+  select: () => Promise<SkillOptimizationArm>,
+): Promise<Record<string, number>> => {
+  const wins: Record<string, number> = {};
+  for (let i = 0; i < rounds; i++) {
+    const chosen = await select();
+    wins[chosen.id] = (wins[chosen.id] ?? 0) + 1;
+  }
+  return wins;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getOptimalCluster', () => {
+  const cluster = (id: string, centroid: number[]): SkillOptimizationCluster =>
+    ({ id, centroid }) as SkillOptimizationCluster;
+
+  it('routes to the cluster whose centroid points the same way', () => {
+    const chosen = getOptimalCluster(
+      [1, 0, 0],
+      [
+        cluster('a', [0, 1, 0]),
+        cluster('b', [1, 0, 0]),
+        cluster('c', [0, 0, 1]),
+      ],
+    );
+
+    expect(chosen.id).toBe('b');
+  });
+
+  it('compares direction, not distance', () => {
+    // A centroid that points the right way but is much shorter still wins.
+    // Using distance here would route to the nearer, wrongly-aimed cluster.
+    const chosen = getOptimalCluster(
+      [10, 0],
+      [cluster('near', [9, 9]), cluster('aligned', [0.01, 0])],
+    );
+
+    expect(chosen.id).toBe('aligned');
+  });
+
+  it('prefers a positively aligned cluster over an opposed one', () => {
+    const chosen = getOptimalCluster(
+      [1, 1],
+      [cluster('opposed', [-1, -1]), cluster('aligned', [1, 1])],
+    );
+
+    expect(chosen.id).toBe('aligned');
+  });
+
+  it('still returns a cluster when every centroid is degenerate', () => {
+    // `cosineSimilarity` returns 0 for a zero vector. Falling through without
+    // a choice would mean no configuration at all for that request.
+    const chosen = getOptimalCluster(
+      [1, 1],
+      [cluster('a', [0, 0]), cluster('b', [0, 0])],
+    );
+
+    expect(chosen.id).toBe('a');
+  });
+
+  it('returns the only cluster when there is one', () => {
+    expect(getOptimalCluster([1, 2], [cluster('solo', [3, 4])]).id).toBe(
+      'solo',
+    );
+  });
+});
+
+describe('getOptimalArm', () => {
+  const evaluation = uuid(10);
+
+  it('returns the only arm when there is one', async () => {
+    const only = arm('only');
+    const connector = connectorWith([{ id: evaluation, weight: 1 }], {});
+
+    expect(
+      (await getOptimalArm(mockContext, [only], uuid(1), connector)).id,
+    ).toBe('only');
+  });
+
+  it('favours the arm with the better record', async () => {
+    /**
+     * The property the whole bandit rests on. Neither arm is guaranteed to win
+     * any single round -- that is what exploration means -- so this asserts the
+     * frequency over many rounds instead of a single choice.
+     */
+    withSeed(101);
+    const connector = connectorWith([{ id: evaluation, weight: 1 }], {
+      good: [stat('good', evaluation, 50, 45)],
+      bad: [stat('bad', evaluation, 50, 5)],
+    });
+
+    const wins = await winRate(300, () =>
+      getOptimalArm(mockContext, [arm('good'), arm('bad')], uuid(1), connector),
+    );
+
+    expect(wins.good ?? 0).toBeGreaterThan(wins.bad ?? 0);
+    // With records this far apart the better arm should dominate, not merely
+    // edge ahead; a marginal lead would suggest the reward is barely read.
+    expect(wins.good).toBeGreaterThan(250);
+  });
+
+  it('still explores the weaker arm sometimes', async () => {
+    // A bandit that never revisits a losing arm cannot recover from an early
+    // unlucky streak. Records are close here, so both should see traffic.
+    withSeed(103);
+    const connector = connectorWith([{ id: evaluation, weight: 1 }], {
+      slightly_better: [stat('slightly_better', evaluation, 20, 12)],
+      slightly_worse: [stat('slightly_worse', evaluation, 20, 10)],
+    });
+
+    const wins = await winRate(300, () =>
+      getOptimalArm(
+        mockContext,
+        [arm('slightly_better'), arm('slightly_worse')],
+        uuid(1),
+        connector,
+      ),
+    );
+
+    expect(wins.slightly_better ?? 0).toBeGreaterThan(0);
+    expect(wins.slightly_worse ?? 0).toBeGreaterThan(0);
+  });
+
+  it('treats an arm with no stats as the uniform prior', async () => {
+    /**
+     * A new arm has no rows at all, and must start from Beta(1,1) rather than
+     * from zero -- otherwise a freshly generated configuration would never be
+     * tried and regeneration would have no effect.
+     */
+    withSeed(107);
+    const connector = connectorWith([{ id: evaluation, weight: 1 }], {
+      established: [stat('established', evaluation, 40, 20)],
+      // `fresh` deliberately absent.
+    });
+
+    const wins = await winRate(300, () =>
+      getOptimalArm(
+        mockContext,
+        [arm('established'), arm('fresh')],
+        uuid(1),
+        connector,
+      ),
+    );
+
+    expect(wins.fresh ?? 0).toBeGreaterThan(0);
+  });
+
+  it('weights evaluations against each other', async () => {
+    /**
+     * Two evaluations disagree: `a` prefers the first arm, `b` prefers the
+     * second, and `b` carries nine times the weight. The heavier evaluation
+     * has to decide the outcome, or configured weights mean nothing.
+     */
+    const light = uuid(11);
+    const heavy = uuid(12);
+    withSeed(109);
+
+    const connector = connectorWith(
+      [
+        { id: light, weight: 1 },
+        { id: heavy, weight: 9 },
+      ],
+      {
+        light_favourite: [
+          stat('light_favourite', light, 30, 30),
+          stat('light_favourite', heavy, 30, 0),
+        ],
+        heavy_favourite: [
+          stat('heavy_favourite', light, 30, 0),
+          stat('heavy_favourite', heavy, 30, 30),
+        ],
+      },
+    );
+
+    const wins = await winRate(300, () =>
+      getOptimalArm(
+        mockContext,
+        [arm('light_favourite'), arm('heavy_favourite')],
+        uuid(1),
+        connector,
+      ),
+    );
+
+    expect(wins.heavy_favourite ?? 0).toBeGreaterThan(
+      wins.light_favourite ?? 0,
+    );
+  });
+
+  it('explores more at a higher temperature', async () => {
+    /**
+     * `exploration_temperature` is a per-skill setting, so its direction has to
+     * hold: raising it must widen the spread of traffic, not narrow it. The
+     * same seed is used for both runs so the comparison is like for like.
+     */
+    // Records deliberately close together: two arms far apart stay far apart
+    // at any temperature, so the setting would have nothing visible to do.
+    const stats = {
+      good: [stat('good', evaluation, 20, 13)],
+      bad: [stat('bad', evaluation, 20, 9)],
+    };
+    const connector = connectorWith([{ id: evaluation, weight: 1 }], stats);
+    const arms = [arm('good'), arm('bad')];
+
+    withSeed(113);
+    const exploiting = await winRate(500, () =>
+      getOptimalArm(mockContext, arms, uuid(1), connector, 0.2),
+    );
+
+    withSeed(113);
+    const exploring = await winRate(500, () =>
+      getOptimalArm(mockContext, arms, uuid(1), connector, 5.0),
+    );
+
+    // Direction *and* magnitude: a temperature setting that moved traffic by a
+    // round or two would satisfy `>` while doing nothing useful. At 0.2 the
+    // weaker arm is all but shut out; at 5.0 it gets a substantial share.
+    expect(exploiting.bad ?? 0).toBeLessThan(20);
+    expect(exploring.bad ?? 0).toBeGreaterThan(50);
+  });
+
+  it('reads stats for every arm it is given', async () => {
+    // A short-circuit that skipped an arm would silently exclude it from
+    // selection for good.
+    withSeed(127);
+    const connector = connectorWith([{ id: evaluation, weight: 1 }], {});
+
+    await getOptimalArm(
+      mockContext,
+      [arm('a'), arm('b'), arm('c')],
+      uuid(1),
+      connector,
+    );
+
+    const calls = vi.mocked(connector.getSkillOptimizationArmStats).mock.calls;
+    expect(
+      calls.map(([, query]) => (query as { arm_id: string }).arm_id),
+    ).toEqual(['a', 'b', 'c']);
+  });
+
+  it('defaults an unweighted evaluation to weight 1', async () => {
+    // Stats can reference an evaluation that the weights lookup does not know
+    // about; dropping those rows would discard real reward history.
+    withSeed(131);
+    const unknown = uuid(13);
+    const connector = connectorWith([], {
+      good: [stat('good', unknown, 40, 36)],
+      bad: [stat('bad', unknown, 40, 4)],
+    });
+
+    const wins = await winRate(200, () =>
+      getOptimalArm(mockContext, [arm('good'), arm('bad')], uuid(1), connector),
+    );
+
+    expect(wins.good ?? 0).toBeGreaterThan(wins.bad ?? 0);
+  });
+});

--- a/packages/api/src/middlewares/optimizer/example-conversations.test.ts
+++ b/packages/api/src/middlewares/optimizer/example-conversations.test.ts
@@ -1,0 +1,216 @@
+import { generateExampleConversations } from '@api/middlewares/optimizer/system-prompt';
+import { HttpMethod } from '@api/types/http';
+import { FunctionName } from '@shared/types/api/request';
+import { AIProvider } from '@shared/types/constants';
+import type { Log } from '@shared/types/data/log';
+import { CacheMode, CacheStatus } from '@shared/types/middleware/cache';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The step that turns request logs into the contrastive examples reflection
+ * learns from.
+ *
+ * Its failure mode is the quiet one: a log it cannot parse is swallowed and
+ * dropped from the result. If that happened to every log, reflection would run
+ * against an empty example set and regenerate prompts from nothing at all --
+ * with no error anywhere, because from the caller's side an empty array is a
+ * perfectly ordinary answer.
+ */
+
+const conversationLog = (
+  overrides: {
+    userMessage?: string;
+    assistantMessage?: string;
+    requestBody?: Record<string, unknown>;
+    responseBody?: unknown;
+  } = {},
+): Log => {
+  const {
+    userMessage = 'Book a flight to Paris',
+    assistantMessage = 'Booked your flight to Paris.',
+    requestBody,
+  } = overrides;
+
+  // Checked by presence rather than with `??`, so a test can pass an explicit
+  // `null` body and actually get one instead of silently falling back.
+  const responseBody =
+    'responseBody' in overrides
+      ? overrides.responseBody
+      : {
+          id: 'chatcmpl-123',
+          object: 'chat.completion',
+          created: 1677652288,
+          model: 'gpt-4',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: assistantMessage },
+              finish_reason: 'stop',
+            },
+          ],
+        };
+
+  return {
+    id: 'log-1',
+    start_time: 1677652288000,
+    first_token_time: null,
+    end_time: 1677652289000,
+    duration: 1000,
+    base_sa_config: {},
+    ai_provider: AIProvider.OPENAI,
+    model: 'gpt-4',
+    hook_logs: [],
+    cache_status: CacheStatus.MISS,
+    embedding: null,
+    trace_id: null,
+    parent_span_id: null,
+    span_id: null,
+    span_name: null,
+    app_id: null,
+    external_user_id: null,
+    external_user_human_name: null,
+    user_metadata: null,
+    metadata: {},
+    ai_provider_request_log: {
+      provider: AIProvider.OPENAI,
+      function_name: FunctionName.CHAT_COMPLETE,
+      method: HttpMethod.POST,
+      request_url: 'https://api.openai.com/v1/chat/completions',
+      request_body: requestBody ?? {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: userMessage }],
+      },
+      response_body: responseBody,
+      raw_request_body: '{}',
+      raw_response_body: '{}',
+      status: 200,
+      cache_mode: CacheMode.DISABLED,
+      cache_status: CacheStatus.MISS,
+    },
+  } as unknown as Log;
+};
+
+beforeEach(() => {
+  // The drop path logs the failure; silence it so a passing run stays readable.
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('generateExampleConversations', () => {
+  it('renders a log as its input followed by the assistant reply', () => {
+    const [conversation] = generateExampleConversations([
+      conversationLog({
+        userMessage: 'Book a flight to Paris',
+        assistantMessage: 'Booked your flight to Paris.',
+      }),
+    ]);
+
+    expect(conversation).toContain('Book a flight to Paris');
+    expect(conversation).toContain('Assistant: Booked your flight to Paris.');
+  });
+
+  it('returns one entry per log, in order', () => {
+    const conversations = generateExampleConversations([
+      conversationLog({ userMessage: 'first' }),
+      conversationLog({ userMessage: 'second' }),
+      conversationLog({ userMessage: 'third' }),
+    ]);
+
+    expect(conversations).toHaveLength(3);
+    expect(conversations[0]).toContain('first');
+    expect(conversations[1]).toContain('second');
+    expect(conversations[2]).toContain('third');
+  });
+
+  it('returns nothing for no logs', () => {
+    expect(generateExampleConversations([])).toEqual([]);
+  });
+
+  it('carries the response format through as a constraint', () => {
+    /**
+     * Structured-output constraints have to reach the prompt writer. A skill
+     * that must return a particular JSON schema will keep failing its
+     * evaluations if the regenerated prompt never learns the schema exists.
+     */
+    const [conversation] = generateExampleConversations([
+      conversationLog({
+        requestBody: {
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'Extract the event' }],
+          response_format: {
+            type: 'json_schema',
+            json_schema: { name: 'CalendarEvent' },
+          },
+        },
+      }),
+    ]);
+
+    expect(conversation).toContain('Request Constraints');
+    expect(conversation).toContain('Response Format');
+    expect(conversation).toContain('CalendarEvent');
+  });
+
+  it('carries available tools through as a constraint', () => {
+    const [conversation] = generateExampleConversations([
+      conversationLog({
+        requestBody: {
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'Check the weather' }],
+          tools: [{ type: 'function', function: { name: 'get_weather' } }],
+        },
+      }),
+    ]);
+
+    expect(conversation).toContain('Available Tools');
+    expect(conversation).toContain('get_weather');
+  });
+
+  it('omits the constraints block when there is nothing to constrain', () => {
+    // Sampling parameters are deliberately excluded: they do not change the
+    // task, so mentioning them would be noise in the prompt.
+    const [conversation] = generateExampleConversations([
+      conversationLog({
+        requestBody: {
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'Just chat' }],
+          temperature: 0.9,
+          max_tokens: 100,
+        },
+      }),
+    ]);
+
+    expect(conversation).not.toContain('Request Constraints');
+    expect(conversation).not.toContain('temperature');
+  });
+
+  it('drops a log it cannot parse instead of failing the batch', () => {
+    // One malformed row must not cost the reflection its other examples.
+    const conversations = generateExampleConversations([
+      conversationLog({ userMessage: 'good one' }),
+      conversationLog({ responseBody: { nonsense: true } }),
+      conversationLog({ userMessage: 'another good one' }),
+    ]);
+
+    expect(conversations).toHaveLength(2);
+    expect(conversations[0]).toContain('good one');
+    expect(conversations[1]).toContain('another good one');
+  });
+
+  it('returns an empty set rather than throwing when every log is unusable', () => {
+    /**
+     * The dangerous case, pinned deliberately. Reflection receives `[]` and
+     * carries on, so a systematic parsing break degrades every regenerated
+     * prompt without surfacing an error anywhere. The behaviour is correct --
+     * the point is that it is a decision, not an accident.
+     */
+    const conversations = generateExampleConversations([
+      conversationLog({ responseBody: { nonsense: true } }),
+      conversationLog({ responseBody: null }),
+    ]);
+
+    expect(conversations).toEqual([]);
+  });
+});

--- a/packages/api/src/middlewares/super-agents-configuration.ts
+++ b/packages/api/src/middlewares/super-agents-configuration.ts
@@ -28,7 +28,13 @@ import type { SkillOptimizationClusterCreateParams } from '@shared/types/data/sk
 import type { Next } from 'hono';
 import { createMiddleware } from 'hono/factory';
 
-async function getOptimalArm(
+/**
+ * Exported for tests. This is the decision that picks which configuration
+ * serves a request, and the middleware around it needs a database, an
+ * embedding and a resolved skill before it is reached -- so the choice itself
+ * is only reachable directly.
+ */
+export async function getOptimalArm(
   c: AppContext,
   arms: SkillOptimizationArm[],
   skillId: string,
@@ -139,7 +145,8 @@ async function getOptimalArm(
   return optimalArm;
 }
 
-function getOptimalCluster(
+/** Exported for tests, for the same reason as `getOptimalArm`. */
+export function getOptimalCluster(
   embedding: number[],
   clusters: SkillOptimizationCluster[],
 ): SkillOptimizationCluster {

--- a/packages/api/src/utils/math.test.ts
+++ b/packages/api/src/utils/math.test.ts
@@ -1,0 +1,328 @@
+import {
+  calculateDistance,
+  cosineSimilarity,
+  getInitialClusterCentroids,
+  kMeansClustering,
+  sampleBeta,
+  sampleGamma,
+  sampleNormal,
+} from '@api/utils/math';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The numerical foundation the optimizer stands on.
+ *
+ * Every one of these is reached from the request path: `cosineSimilarity`
+ * chooses the cluster a request is routed to, `sampleBeta` chooses the arm
+ * within it, and `kMeansClustering` decides what the clusters are in the first
+ * place. None of them had a test, and none of them fails loudly -- a wrong
+ * answer here shows up as an agent that optimizes badly, not as an error.
+ */
+
+/**
+ * A seeded generator standing in for `Math.random`.
+ *
+ * The samplers cannot be asserted exactly without controlling their randomness,
+ * and asserting nothing but "returns a number" would let real distribution bugs
+ * through. Seeding makes the statistical assertions below reproducible: the
+ * same sequence runs on every machine and every CI run, so a tolerance that
+ * passes once passes always.
+ */
+const seeded = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const withSeed = (seed: number): void => {
+  vi.spyOn(Math, 'random').mockImplementation(seeded(seed));
+};
+
+/** Sample mean of `count` draws. */
+const meanOf = (count: number, draw: () => number): number => {
+  let total = 0;
+  for (let i = 0; i < count; i++) {
+    total += draw();
+  }
+  return total / count;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('cosineSimilarity', () => {
+  // This is what routes a request to a cluster, so its ordering behaviour is
+  // the thing that matters, not the absolute number.
+  it('returns 1 for identical directions', () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 10);
+  });
+
+  it('ignores magnitude and compares direction only', () => {
+    // A centroid is normalised but an embedding need not be; if magnitude
+    // leaked into the score, longer inputs would win regardless of direction.
+    expect(cosineSimilarity([1, 2, 3], [10, 20, 30])).toBeCloseTo(1, 10);
+  });
+
+  it('returns 0 for orthogonal vectors', () => {
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0, 10);
+  });
+
+  it('returns -1 for opposite directions', () => {
+    expect(cosineSimilarity([1, 2], [-1, -2])).toBeCloseTo(-1, 10);
+  });
+
+  it('returns 0 rather than NaN for a zero vector', () => {
+    // A zero-magnitude centroid would otherwise divide by zero, and `NaN`
+    // loses every `>` comparison, silently making that cluster unreachable.
+    expect(cosineSimilarity([0, 0], [1, 2])).toBe(0);
+    expect(cosineSimilarity([1, 2], [0, 0])).toBe(0);
+  });
+
+  it('rejects vectors of different lengths', () => {
+    expect(() => cosineSimilarity([1, 2], [1, 2, 3])).toThrow(
+      'Vectors must have the same length',
+    );
+  });
+});
+
+describe('calculateDistance', () => {
+  it('computes the Euclidean distance', () => {
+    expect(calculateDistance([0, 0], [3, 4])).toBe(5);
+  });
+
+  it('is zero for identical points', () => {
+    expect(calculateDistance([1, 2, 3], [1, 2, 3])).toBe(0);
+  });
+
+  it('is symmetric', () => {
+    expect(calculateDistance([1, 5], [4, 1])).toBe(
+      calculateDistance([4, 1], [1, 5]),
+    );
+  });
+
+  it('rejects vectors of different dimensions', () => {
+    expect(() => calculateDistance([1, 2], [1])).toThrow(
+      'Vectors must have the same dimension',
+    );
+  });
+});
+
+describe('getInitialClusterCentroids', () => {
+  it('returns the requested shape', () => {
+    withSeed(1);
+    const centroids = getInitialClusterCentroids(4, 8);
+
+    expect(centroids).toHaveLength(4);
+    for (const centroid of centroids) {
+      expect(centroid).toHaveLength(8);
+    }
+  });
+
+  it('normalises every centroid to unit length', () => {
+    // `cosineSimilarity` divides by both magnitudes, so a non-unit centroid
+    // would not break routing -- but the clustering code assumes unit vectors
+    // when it compares centroids to each other.
+    withSeed(7);
+    for (const centroid of getInitialClusterCentroids(5, 16)) {
+      const magnitude = Math.sqrt(
+        centroid.reduce((sum, value) => sum + value * value, 0),
+      );
+      expect(magnitude).toBeCloseTo(1, 10);
+    }
+  });
+
+  it('spreads centroids rather than repeating one', () => {
+    // Identical centroids would make every request route to the same cluster
+    // and quietly disable the whole clustering step.
+    withSeed(3);
+    const [first, second] = getInitialClusterCentroids(2, 32);
+    expect(cosineSimilarity(first, second)).toBeLessThan(0.9);
+  });
+
+  it('returns nothing when asked for no clusters', () => {
+    expect(getInitialClusterCentroids(0, 4)).toEqual([]);
+  });
+});
+
+describe('kMeansClustering', () => {
+  it('separates two well-spaced groups', () => {
+    withSeed(11);
+    const embeddings = [
+      [0, 0],
+      [0.1, 0.1],
+      [0, 0.2],
+      [10, 10],
+      [10.1, 10.2],
+      [9.9, 10],
+    ];
+
+    const { clusters, centroids } = kMeansClustering(embeddings, 2);
+
+    expect(centroids).toHaveLength(2);
+    // Membership is asserted by grouping rather than by label, because which
+    // group gets index 0 depends on initialisation.
+    expect(clusters[0]).toBe(clusters[1]);
+    expect(clusters[1]).toBe(clusters[2]);
+    expect(clusters[3]).toBe(clusters[4]);
+    expect(clusters[4]).toBe(clusters[5]);
+    expect(clusters[0]).not.toBe(clusters[3]);
+  });
+
+  it('converges before exhausting its iteration budget', () => {
+    withSeed(5);
+    const embeddings = [
+      [0, 0],
+      [0.1, 0],
+      [5, 5],
+      [5.1, 5],
+    ];
+
+    const { iterations } = kMeansClustering(embeddings, 2, 100);
+
+    expect(iterations).toBeGreaterThan(0);
+    expect(iterations).toBeLessThan(100);
+  });
+
+  it('gives every point its own cluster when k meets the point count', () => {
+    const embeddings = [
+      [1, 1],
+      [2, 2],
+    ];
+
+    const result = kMeansClustering(embeddings, 2);
+
+    expect(result.clusters).toEqual([0, 1]);
+    expect(result.centroids).toEqual(embeddings);
+    expect(result.iterations).toBe(0);
+  });
+
+  it('returns fewer clusters than asked for when k exceeds the point count', () => {
+    // Worth pinning: the caller asks for `configuration_count` clusters and
+    // gets one per point instead, so a skill with few logs silently ends up
+    // with fewer arms than its configuration says.
+    const embeddings = [[1], [2]];
+
+    const result = kMeansClustering(embeddings, 5);
+
+    expect(result.centroids).toHaveLength(2);
+    expect(result.clusters).toEqual([0, 1]);
+  });
+
+  it('handles duplicate points without producing an empty centroid', () => {
+    // k-means++ divides by the total squared distance, which is zero when
+    // every point is identical.
+    withSeed(2);
+    const embeddings = [
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+    ];
+
+    const { centroids } = kMeansClustering(embeddings, 2);
+
+    for (const centroid of centroids) {
+      for (const value of centroid) {
+        expect(Number.isNaN(value)).toBe(false);
+      }
+    }
+  });
+
+  it('rejects an empty embedding set', () => {
+    expect(() => kMeansClustering([], 2)).toThrow(
+      'Cannot cluster empty embedding set',
+    );
+  });
+
+  it('rejects a non-positive cluster count', () => {
+    expect(() => kMeansClustering([[1]], 0)).toThrow(
+      'Number of clusters must be positive',
+    );
+  });
+});
+
+describe('sampleNormal', () => {
+  it('has approximately zero mean and unit variance', () => {
+    withSeed(42);
+    const draws = Array.from({ length: 20_000 }, () => sampleNormal());
+    const mean = draws.reduce((sum, value) => sum + value, 0) / draws.length;
+    const variance =
+      draws.reduce((sum, value) => sum + (value - mean) ** 2, 0) / draws.length;
+
+    expect(mean).toBeCloseTo(0, 1);
+    expect(variance).toBeCloseTo(1, 1);
+  });
+});
+
+describe('sampleGamma', () => {
+  // Gamma(shape) has mean == shape. Both branches of the implementation are
+  // exercised: shape >= 1 directly, shape < 1 through the boost step.
+  it('has a mean equal to its shape for shape >= 1', () => {
+    withSeed(13);
+    expect(meanOf(20_000, () => sampleGamma(2))).toBeCloseTo(2, 1);
+  });
+
+  it('has a mean equal to its shape for shape < 1', () => {
+    withSeed(17);
+    expect(meanOf(20_000, () => sampleGamma(0.5))).toBeCloseTo(0.5, 1);
+  });
+
+  it('never returns a negative value', () => {
+    withSeed(19);
+    for (let i = 0; i < 2_000; i++) {
+      expect(sampleGamma(1.5)).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe('sampleBeta', () => {
+  /**
+   * This is the draw that picks which arm serves a request. Its mean has to
+   * track alpha/(alpha+beta), because that ratio is how an arm's observed
+   * success rate turns into its chance of being chosen -- if the mean were
+   * biased, the bandit would favour the wrong arm forever and nothing would
+   * report an error.
+   */
+  it('has mean alpha / (alpha + beta)', () => {
+    withSeed(23);
+    expect(meanOf(20_000, () => sampleBeta(2, 8))).toBeCloseTo(0.2, 1);
+  });
+
+  it('is symmetric for equal parameters', () => {
+    withSeed(29);
+    expect(meanOf(20_000, () => sampleBeta(5, 5))).toBeCloseTo(0.5, 1);
+  });
+
+  it('stays within [0, 1]', () => {
+    withSeed(31);
+    for (let i = 0; i < 5_000; i++) {
+      const value = sampleBeta(3, 4);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('favours the arm with more successes', () => {
+    // The property the bandit actually depends on: an arm with a better record
+    // has to draw higher on average than one with a worse record.
+    withSeed(37);
+    const better = meanOf(10_000, () => sampleBeta(9, 2));
+    withSeed(37);
+    const worse = meanOf(10_000, () => sampleBeta(2, 9));
+
+    expect(better).toBeGreaterThan(worse);
+  });
+
+  it('is a uniform draw for the Beta(1, 1) prior', () => {
+    // Beta(1,1) is the prior an arm starts from, so a brand-new arm must be
+    // picked uniformly rather than being systematically preferred or ignored.
+    withSeed(41);
+    expect(meanOf(20_000, () => sampleBeta(1, 1))).toBeCloseTo(0.5, 1);
+  });
+});


### PR DESCRIPTION
## Problem

The self-optimization loop — the thing the product *is* — had **no tests at all**. 2,359 lines across `middlewares/optimizer/` and `optimization/`, and `utils/math.ts`, which all of it rests on, had no test file either.

It's the worst place in the codebase for that, because nothing here fails loudly. A bandit that systematically prefers the wrong arm still answers every request successfully — it just never improves, and no error is raised for anyone to notice. This was the last of the three gaps from the coverage analysis, and the highest-risk one.

## What's covered

**`utils/math.ts` — 0% → 98%.** `cosineSimilarity` picks the cluster a request routes to, `sampleBeta` picks the arm within it, `kMeansClustering` decides what the clusters are.

The samplers are checked *statistically* — Gamma's mean equals its shape, Beta's is `alpha/(alpha+beta)`, Beta(1,1) is uniform — against a **seeded generator substituted for `Math.random`**. Asserting only "returns a number" would let a genuinely biased distribution through; seeding makes the tolerances reproducible rather than merely usually true.

**`getOptimalArm` / `getOptimalCluster`** — exported for tests, since the middleware around them needs a database, an embedding and a resolved skill before they're reachable. Both are probabilistic, so the assertions are frequencies over many seeded rounds:

- a better record wins more often — and *dominates*, not merely edges ahead
- a weaker arm still gets explored, so an early unlucky streak isn't permanent
- a brand-new arm starts from the uniform prior, not from zero — otherwise a freshly regenerated configuration would never be tried
- evaluation weights decide between two evaluations that disagree
- raising `exploration_temperature` widens the traffic spread: **2/500** at 0.2 vs **137/500** at 5.0

**`generateExampleConversations`** — turns logs into the contrastive examples reflection learns from. It carries `response_format` and `tools` through as constraints (a regenerated prompt that never learns the required JSON schema will keep failing its evaluations), and deliberately omits sampling parameters.

## Every claim was mutation-checked

I removed each behaviour from the implementation and confirmed the matching test — and only that test — failed:

| Mutation | Result |
| --- | --- |
| ignore evaluation weights (`weight = 1.0`) | ✘ *weights evaluations against each other* |
| ignore temperature (`alpha = baseAlpha`) | ✘ *explores more at a higher temperature* |

Both left the other 12 tests green, so the coverage is precise rather than incidental.

## One quiet behaviour pinned deliberately

`generateExampleConversations` swallows a log it can't parse. If that happened to *every* log, reflection would receive `[]` and regenerate every prompt from nothing — with no error anywhere, because an empty array is a perfectly ordinary answer to the caller. The behaviour is correct; the test makes it a decision rather than an accident.

Worth noting my first version of that test passed against a bug — my fixture used `?? defaultBody`, so an explicit `null` fell back to a *valid* body. Fixed to check by presence.

## Scope

This is the **selection** half. The **regeneration** half (`optimizer/system-prompt.ts`, `optimizer/evaluations.ts`) calls models through the internal skills, so it needs the stub provider from #238 plus configured system settings and the 5-request trigger — a meaty piece that deserves its own change rather than being half-done here.

| File | Before | After |
| --- | --- | --- |
| `utils/math.ts` | 0% | 97.8% |
| `middlewares/super-agents-configuration.ts` | 6% | 28.5% |
| `middlewares/optimizer/system-prompt.ts` | 2% | 11.1% |
| **repo total** | 41.07% | **41.57%** |

## Test notes

- `pnpm test` — 2497 passed (up 51); `pnpm typecheck`, `pnpm check` — 943 files clean
- Only source change is two `export` keywords plus comments explaining why

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wM59ecJTFbb3gZYDDva1Z
