### PR TITLE
test(api): cover the optimizer's regeneration guards and conservative update

### DIFF
--- a/packages/api/src/middlewares/optimizer/early-regeneration.test.ts
+++ b/packages/api/src/middlewares/optimizer/early-regeneration.test.ts
@@ -1,0 +1,315 @@
+import { checkAndRegenerateEvaluationsEarly } from '@api/middlewares/optimizer/evaluations';
+import { createMockContext } from '@api/test-utils/mock-context';
+import type {
+  EvaluationMethodConnector,
+  LogsStorageConnector,
+  UserDataStorageConnector,
+} from '@api/types/connector';
+import { FunctionName } from '@shared/types/api/request';
+import type { Skill } from '@shared/types/data';
+import type { Log } from '@shared/types/data/log';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The guards on early regeneration -- the one-off pass that rewrites a skill's
+ * evaluations once it has served its first handful of real requests.
+ *
+ * Everything here is a reason *not* to proceed, and that is the point. The pass
+ * is meant to happen exactly once per skill, and it calls models when it does,
+ * so a guard that fails open regenerates repeatedly: the skill's evaluations
+ * churn, tokens are spent on every request, and nothing reports an error.
+ *
+ * Only the early-return paths are exercised. Everything past them reaches the
+ * model calls, which belong to an end-to-end test rather than this one.
+ */
+
+const mockContext = createMockContext();
+
+const uuid = (n: number): string =>
+  `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`;
+
+const skill = { id: uuid(1), agent_id: uuid(2) } as Skill;
+
+const storedSkill = (overrides: Partial<Skill> = {}): Skill =>
+  ({
+    ...skill,
+    evaluations_regenerated_at: null,
+    evaluation_lock_acquired_at: null,
+    ...overrides,
+  }) as Skill;
+
+/** A log that extracts cleanly into one example conversation. */
+const usableLog = (): Log =>
+  ({
+    id: uuid(4),
+    ai_provider_request_log: {
+      method: 'POST',
+      request_url: 'https://api.openai.com/v1/chat/completions',
+      request_body: {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Book a flight to Paris' }],
+      },
+      response_body: {
+        id: 'chatcmpl-123',
+        object: 'chat.completion',
+        created: 1677652288,
+        model: 'gpt-4',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'Booked.' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+    },
+  }) as unknown as Log;
+
+/** A log the conversation extractor cannot parse, so it yields no example. */
+const unusableLog = (): Log =>
+  ({
+    id: uuid(5),
+    ai_provider_request_log: {
+      method: 'POST',
+      request_url: 'https://api.openai.com/v1/chat/completions',
+      request_body: { model: 'gpt-4', messages: [] },
+      response_body: { nonsense: true },
+    },
+  }) as unknown as Log;
+
+const connectors = (
+  skillReads: Skill[][],
+  logs: Log[] = [],
+): {
+  userData: UserDataStorageConnector;
+  logsStore: LogsStorageConnector;
+} => {
+  const getSkills = vi.fn();
+  for (const read of skillReads) {
+    getSkills.mockResolvedValueOnce(read);
+  }
+  getSkills.mockResolvedValue(skillReads[skillReads.length - 1] ?? []);
+
+  return {
+    userData: {
+      getSkills,
+      updateSkill: vi.fn().mockResolvedValue(undefined),
+    } as unknown as UserDataStorageConnector,
+    logsStore: {
+      getLogs: vi.fn().mockResolvedValue(logs),
+    } as unknown as LogsStorageConnector,
+  };
+};
+
+const run = (
+  userData: UserDataStorageConnector,
+  logsStore: LogsStorageConnector,
+  functionName: FunctionName = FunctionName.CHAT_COMPLETE,
+): Promise<void> =>
+  checkAndRegenerateEvaluationsEarly(
+    mockContext,
+    functionName,
+    userData,
+    logsStore,
+    skill,
+    'an agent that does something useful',
+    {} as Record<string, EvaluationMethodConnector>,
+  );
+
+/** Lock writes, in call order: the timestamp set, or null for a release. */
+const lockWrites = (c: UserDataStorageConnector): (string | null)[] =>
+  vi
+    .mocked(c.updateSkill)
+    .mock.calls.map(
+      ([, , update]) =>
+        (update as { evaluation_lock_acquired_at?: string | null })
+          .evaluation_lock_acquired_at ?? null,
+    );
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(new Date('2026-03-01T12:00:00.000Z'));
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('checkAndRegenerateEvaluationsEarly', () => {
+  it('ignores a request that is not a chat completion', async () => {
+    // Embeddings and the like carry no conversation to learn from.
+    const { userData, logsStore } = connectors([[storedSkill()]]);
+
+    await run(userData, logsStore, FunctionName.EMBED);
+
+    expect(userData.getSkills).not.toHaveBeenCalled();
+  });
+
+  it('runs for each conversational endpoint', async () => {
+    for (const functionName of [
+      FunctionName.CHAT_COMPLETE,
+      FunctionName.STREAM_CHAT_COMPLETE,
+      FunctionName.CREATE_MODEL_RESPONSE,
+    ]) {
+      const { userData, logsStore } = connectors([[]]);
+      await run(userData, logsStore, functionName);
+      expect(userData.getSkills).toHaveBeenCalled();
+    }
+  });
+
+  it('stops when the skill no longer exists', async () => {
+    const { userData, logsStore } = connectors([[]]);
+
+    await run(userData, logsStore);
+
+    expect(userData.updateSkill).not.toHaveBeenCalled();
+  });
+
+  it('never regenerates a skill twice', async () => {
+    /**
+     * The one-off guarantee. `evaluations_regenerated_at` is the record that
+     * the pass already happened; ignoring it would rewrite the skill's
+     * evaluations on every subsequent request and spend a model call each time.
+     */
+    const { userData, logsStore } = connectors([
+      [storedSkill({ evaluations_regenerated_at: '2026-02-01T00:00:00.000Z' })],
+    ]);
+
+    await run(userData, logsStore);
+
+    expect(userData.updateSkill).not.toHaveBeenCalled();
+    expect(logsStore.getLogs).not.toHaveBeenCalled();
+  });
+
+  it('stands down while another request holds a fresh lock', async () => {
+    const heldAt = new Date(Date.now() - 60_000).toISOString();
+    const { userData, logsStore } = connectors([
+      [storedSkill({ evaluation_lock_acquired_at: heldAt })],
+    ]);
+
+    await run(userData, logsStore);
+
+    expect(userData.updateSkill).not.toHaveBeenCalled();
+  });
+
+  it('holds off on a lock taken just under the timeout', async () => {
+    const justInside = new Date(Date.now() - 4 * 60_000).toISOString();
+    const { userData, logsStore } = connectors([
+      [storedSkill({ evaluation_lock_acquired_at: justInside })],
+    ]);
+
+    await run(userData, logsStore);
+
+    expect(userData.updateSkill).not.toHaveBeenCalled();
+  });
+
+  it('takes over a lock abandoned more than five minutes ago', async () => {
+    // Without an expiry a process that died mid-pass would block the skill from
+    // ever regenerating. It backs off again at the read-back here, which keeps
+    // the test clear of the model calls further down.
+    const stale = new Date(Date.now() - 6 * 60_000).toISOString();
+    const { userData, logsStore } = connectors([
+      [storedSkill({ evaluation_lock_acquired_at: stale })],
+      [storedSkill({ evaluation_lock_acquired_at: 'someone-elses-lock' })],
+    ]);
+
+    await run(userData, logsStore);
+
+    expect(lockWrites(userData)).toEqual([new Date().toISOString()]);
+  });
+
+  it('releases the lock when another request finished first', async () => {
+    // Two requests can both pass the first check; the one that reads back a
+    // completed skill has to release rather than proceed.
+    const { userData, logsStore } = connectors([
+      [storedSkill()],
+      [
+        storedSkill({
+          evaluations_regenerated_at: '2026-03-01T11:59:59.000Z',
+          evaluation_lock_acquired_at: new Date().toISOString(),
+        }),
+      ],
+    ]);
+
+    await run(userData, logsStore);
+
+    expect(lockWrites(userData)).toEqual([new Date().toISOString(), null]);
+    expect(logsStore.getLogs).not.toHaveBeenCalled();
+  });
+
+  it('backs off when its lock was overwritten in between', async () => {
+    /**
+     * The genuine race: both requests write a lock, and the one whose timestamp
+     * did not survive must stand down. Note it returns *without* releasing --
+     * releasing here would clear the winner's lock.
+     */
+    const someoneElse = new Date(Date.now() + 5).toISOString();
+    const { userData, logsStore } = connectors([
+      [storedSkill()],
+      [storedSkill({ evaluation_lock_acquired_at: someoneElse })],
+    ]);
+
+    await run(userData, logsStore);
+
+    expect(lockWrites(userData)).toEqual([new Date().toISOString()]);
+    expect(logsStore.getLogs).not.toHaveBeenCalled();
+  });
+
+  it('stops when the lock write fails', async () => {
+    const { userData, logsStore } = connectors([[storedSkill()]]);
+    vi.mocked(userData.updateSkill).mockRejectedValueOnce(
+      new Error('conflict'),
+    );
+
+    await run(userData, logsStore);
+
+    expect(logsStore.getLogs).not.toHaveBeenCalled();
+  });
+
+  it('waits for five logs before regenerating', async () => {
+    /**
+     * The documented trigger. Regenerating from one or two examples would
+     * rewrite the evaluations from a sample too small to be representative --
+     * and it only gets one chance, since the pass never runs again.
+     *
+     * The logs are deliberately *usable*: with unparseable ones the next guard
+     * down would release the lock too, and the test could not tell which of the
+     * two stopped it.
+     */
+    const now = new Date().toISOString();
+    const { userData, logsStore } = connectors(
+      [[storedSkill()], [storedSkill({ evaluation_lock_acquired_at: now })]],
+      [usableLog(), usableLog(), usableLog(), usableLog()],
+    );
+
+    await run(userData, logsStore);
+
+    expect(logsStore.getLogs).toHaveBeenCalled();
+    // Lock taken, then released, so the next request can try again later.
+    expect(lockWrites(userData)).toEqual([now, null]);
+    /**
+     * And it stopped *here*, rather than proceeding into generation and failing
+     * there. The catch block releases the lock too, so the lock writes alone
+     * cannot tell a clean guard from a crash -- the absence of a logged error
+     * is what distinguishes them.
+     */
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('releases the lock when no log yields a usable example', async () => {
+    // Enough logs to pass the threshold, none of them parseable. Proceeding
+    // would regenerate the evaluations from an empty example set and burn the
+    // skill's single chance at the early pass.
+    const now = new Date().toISOString();
+    const { userData, logsStore } = connectors(
+      [[storedSkill()], [storedSkill({ evaluation_lock_acquired_at: now })]],
+      Array.from({ length: 5 }, unusableLog),
+    );
+
+    await run(userData, logsStore);
+
+    expect(lockWrites(userData)).toEqual([now, null]);
+  });
+});

--- a/packages/api/src/middlewares/optimizer/reflection.test.ts
+++ b/packages/api/src/middlewares/optimizer/reflection.test.ts
@@ -1,0 +1,487 @@
+import {
+  acquireReflectionLock,
+  performReflection,
+} from '@api/middlewares/optimizer/system-prompt';
+import { createMockContext } from '@api/test-utils/mock-context';
+import type { UserDataStorageConnector } from '@api/types/connector';
+import type {
+  Skill,
+  SkillOptimizationArm,
+  SkillOptimizationCluster,
+} from '@shared/types/data';
+import { SkillEventType } from '@shared/types/data/skill-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Reflection: the step that rewrites a cluster's arms once enough requests have
+ * been served.
+ *
+ * Two things here are load-bearing and silent. The update is deliberately
+ * conservative -- the best-performing arm is left completely intact, so a
+ * regeneration can never destroy the configuration that is currently winning --
+ * and the whole cycle is guarded by a lock, because two concurrent requests
+ * regenerating the same cluster would each overwrite the other's work. Break
+ * either and the system still answers every request; it just stops improving.
+ */
+
+const mockContext = createMockContext();
+
+const uuid = (n: number): string =>
+  `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`;
+
+const skill = {
+  id: uuid(1),
+  agent_id: uuid(2),
+} as Skill;
+
+const cluster = (
+  overrides: Partial<SkillOptimizationCluster> = {},
+): SkillOptimizationCluster =>
+  ({
+    id: uuid(3),
+    skill_id: skill.id,
+    agent_id: skill.agent_id,
+    total_steps: 99,
+    reflection_lock_acquired_at: null,
+    ...overrides,
+  }) as SkillOptimizationCluster;
+
+const arm = (id: string, systemPrompt: string, temperature: number) =>
+  ({
+    id,
+    skill_id: skill.id,
+    cluster_id: uuid(3),
+    params: {
+      system_prompt: systemPrompt,
+      temperature_min: temperature,
+      temperature_max: temperature,
+      model_id: uuid(9),
+    },
+  }) as unknown as SkillOptimizationArm;
+
+/** Maps arms to their weighted means, which is what reflection sorts on. */
+const statsFor = (
+  entries: [SkillOptimizationArm, number, number][],
+): Map<
+  string,
+  { n: number; weighted_mean: number; arm: SkillOptimizationArm }
+> =>
+  new Map(
+    entries.map(([a, weightedMean, n]) => [
+      a.id,
+      { n, weighted_mean: weightedMean, arm: a },
+    ]),
+  );
+
+const connector = () =>
+  ({
+    updateSkillOptimizationArm: vi.fn().mockResolvedValue(undefined),
+    deleteSkillOptimizationArmStats: vi.fn().mockResolvedValue(undefined),
+    updateSkillOptimizationCluster: vi.fn().mockResolvedValue(undefined),
+    createSkillEvent: vi.fn().mockResolvedValue(undefined),
+    getSkillOptimizationClusters: vi.fn(),
+  }) as unknown as UserDataStorageConnector;
+
+/** Arm ids passed to `updateSkillOptimizationArm`, in call order. */
+const updatedArmIds = (c: UserDataStorageConnector): string[] =>
+  vi
+    .mocked(c.updateSkillOptimizationArm)
+    .mock.calls.map(([, armId]) => armId as string);
+
+const updateFor = (
+  c: UserDataStorageConnector,
+  armId: string,
+): { params: Record<string, unknown> } | undefined =>
+  vi
+    .mocked(c.updateSkillOptimizationArm)
+    .mock.calls.find(([, id]) => id === armId)?.[2] as
+    | { params: Record<string, unknown> }
+    | undefined;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('performReflection', () => {
+  const best = arm('best', 'the winning prompt', 0.2);
+  const middle = arm('middle', 'a mediocre prompt', 0.5);
+  const worst = arm('worst', 'a losing prompt', 0.9);
+  const arms = [worst, best, middle];
+  const stats = statsFor([
+    [best, 0.9, 40],
+    [middle, 0.5, 30],
+    [worst, 0.1, 20],
+  ]);
+
+  it('leaves the best arm completely untouched', async () => {
+    /**
+     * The guarantee the whole algorithm rests on. If the winning configuration
+     * were rewritten on every cycle, the optimizer would keep discarding what
+     * it had learned and never converge -- while still answering every request,
+     * so nothing would look wrong.
+     */
+    const c = connector();
+
+    await performReflection(
+      mockContext,
+      c,
+      cluster(),
+      skill,
+      arms,
+      stats,
+      'a freshly written prompt',
+      best,
+    );
+
+    expect(updatedArmIds(c)).not.toContain('best');
+    const deleted = vi
+      .mocked(c.deleteSkillOptimizationArmStats)
+      .mock.calls.map(([, query]) => (query as { arm_id: string }).arm_id);
+    expect(deleted).not.toContain('best');
+  });
+
+  it('gives the worst arm the best arm’s parameters and the new prompt', async () => {
+    // The worst arm is the one being abandoned, so it restarts from what is
+    // currently working rather than from its own losing configuration.
+    const c = connector();
+
+    await performReflection(
+      mockContext,
+      c,
+      cluster(),
+      skill,
+      arms,
+      stats,
+      'a freshly written prompt',
+      best,
+    );
+
+    const update = updateFor(c, 'worst');
+    expect(update?.params.system_prompt).toBe('a freshly written prompt');
+    expect(update?.params.temperature_min).toBe(0.2);
+    expect(update?.params.temperature_max).toBe(0.2);
+  });
+
+  it('changes only the prompt on a middle arm, keeping its own parameters', async () => {
+    // Middle arms are still contributing information about their own
+    // hyperparameters, so only the prompt is replaced.
+    const c = connector();
+
+    await performReflection(
+      mockContext,
+      c,
+      cluster(),
+      skill,
+      arms,
+      stats,
+      'a freshly written prompt',
+      best,
+    );
+
+    const update = updateFor(c, 'middle');
+    expect(update?.params.system_prompt).toBe('a freshly written prompt');
+    expect(update?.params.temperature_min).toBe(0.5);
+  });
+
+  it('clears the history of every arm it rewrites', async () => {
+    // A rewritten arm's past rewards were earned by a different prompt, so
+    // keeping them would let a stale record decide future selections.
+    const c = connector();
+
+    await performReflection(
+      mockContext,
+      c,
+      cluster(),
+      skill,
+      arms,
+      stats,
+      'a freshly written prompt',
+      best,
+    );
+
+    const deleted = vi
+      .mocked(c.deleteSkillOptimizationArmStats)
+      .mock.calls.map(([, query]) => (query as { arm_id: string }).arm_id);
+    expect(deleted.sort()).toEqual(['middle', 'worst']);
+  });
+
+  it('ranks by weighted mean rather than by the order it was given', async () => {
+    // The input order here is deliberately the reverse of the ranking.
+    const c = connector();
+
+    await performReflection(
+      mockContext,
+      c,
+      cluster(),
+      skill,
+      [best, middle, worst],
+      statsFor([
+        [best, 0.1, 40],
+        [middle, 0.5, 30],
+        [worst, 0.9, 20],
+      ]),
+      'a freshly written prompt',
+      worst,
+    );
+
+    // `worst` now has the highest mean, so it is the one left alone.
+    expect(updatedArmIds(c)).not.toContain('worst');
+    expect(updatedArmIds(c).sort()).toEqual(['best', 'middle']);
+  });
+
+  it('resets the cluster step count to the best arm’s request count', async () => {
+    // Steps drive the next reflection's threshold; leaving the old total would
+    // schedule the following cycle against work that no longer exists.
+    const c = connector();
+
+    await performReflection(
+      mockContext,
+      c,
+      cluster({ total_steps: 99 }),
+      skill,
+      arms,
+      stats,
+      'a freshly written prompt',
+      best,
+    );
+
+    expect(c.updateSkillOptimizationCluster).toHaveBeenCalledWith(
+      mockContext,
+      uuid(3),
+      { total_steps: 40 },
+    );
+  });
+
+  it('records a reflection event', async () => {
+    const c = connector();
+
+    await performReflection(
+      mockContext,
+      c,
+      cluster(),
+      skill,
+      arms,
+      stats,
+      'a freshly written prompt',
+      best,
+    );
+
+    expect(c.createSkillEvent).toHaveBeenCalledWith(
+      mockContext,
+      expect.objectContaining({
+        skill_id: skill.id,
+        agent_id: skill.agent_id,
+        cluster_id: uuid(3),
+        event_type: SkillEventType.REFLECTION,
+      }),
+    );
+  });
+
+  it('treats the second of two arms as the worst', async () => {
+    // With two arms there is no middle: one is kept, one is reset onto the
+    // winner's configuration.
+    const c = connector();
+    const pair = [best, worst];
+
+    await performReflection(
+      mockContext,
+      c,
+      cluster(),
+      skill,
+      pair,
+      statsFor([
+        [best, 0.8, 10],
+        [worst, 0.2, 10],
+      ]),
+      'a freshly written prompt',
+      best,
+    );
+
+    expect(updatedArmIds(c)).toEqual(['worst']);
+    expect(updateFor(c, 'worst')?.params.temperature_min).toBe(0.2);
+  });
+
+  it('updates nothing when the cluster holds a single arm', async () => {
+    // That arm is simultaneously best and worst; "best" wins, so it survives.
+    const c = connector();
+
+    await performReflection(
+      mockContext,
+      c,
+      cluster(),
+      skill,
+      [best],
+      statsFor([[best, 0.7, 15]]),
+      'a freshly written prompt',
+      best,
+    );
+
+    expect(c.updateSkillOptimizationArm).not.toHaveBeenCalled();
+    expect(c.deleteSkillOptimizationArmStats).not.toHaveBeenCalled();
+    // The cycle still closes: steps are reset and the event is recorded.
+    expect(c.updateSkillOptimizationCluster).toHaveBeenCalled();
+    expect(c.createSkillEvent).toHaveBeenCalled();
+  });
+
+  it('protects the top-ranked arm even when told a different one is best', async () => {
+    /**
+     * `bestArm` arrives as an argument while the ranking is recomputed here
+     * from the stats, so the two could disagree. Pinned to document which wins:
+     * the arm left intact is the top of the ranking, while the parameters
+     * copied onto the worst arm come from the argument.
+     */
+    const c = connector();
+
+    await performReflection(
+      mockContext,
+      c,
+      cluster(),
+      skill,
+      arms,
+      stats,
+      'a freshly written prompt',
+      // `middle` is not the top-ranked arm.
+      middle,
+    );
+
+    expect(updatedArmIds(c)).not.toContain('best');
+    expect(updatedArmIds(c)).toContain('middle');
+    expect(updateFor(c, 'worst')?.params.temperature_min).toBe(0.5);
+  });
+});
+
+describe('acquireReflectionLock', () => {
+  const clusterId = uuid(3);
+
+  const lockConnector = (
+    reads: (SkillOptimizationCluster[] | undefined)[],
+  ): UserDataStorageConnector => {
+    const getClusters = vi.fn();
+    for (const read of reads) {
+      getClusters.mockResolvedValueOnce(read ?? []);
+    }
+    return {
+      getSkillOptimizationClusters: getClusters,
+      updateSkillOptimizationCluster: vi.fn().mockResolvedValue(undefined),
+    } as unknown as UserDataStorageConnector;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-03-01T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('acquires the lock when the cluster is unlocked', async () => {
+    const now = new Date().toISOString();
+    const c = lockConnector([
+      [cluster({ reflection_lock_acquired_at: null })],
+      [cluster({ reflection_lock_acquired_at: now })],
+    ]);
+
+    expect(await acquireReflectionLock(mockContext, c, skill, clusterId)).toBe(
+      now,
+    );
+    expect(c.updateSkillOptimizationCluster).toHaveBeenCalledWith(
+      mockContext,
+      clusterId,
+      { reflection_lock_acquired_at: now },
+    );
+  });
+
+  it('refuses when another run holds a fresh lock', async () => {
+    // The case the lock exists for: a second concurrent request must not start
+    // its own regeneration of the same cluster.
+    const heldAt = new Date(Date.now() - 60_000).toISOString();
+    const c = lockConnector([
+      [cluster({ reflection_lock_acquired_at: heldAt })],
+    ]);
+
+    expect(
+      await acquireReflectionLock(mockContext, c, skill, clusterId),
+    ).toBeNull();
+    expect(c.updateSkillOptimizationCluster).not.toHaveBeenCalled();
+  });
+
+  it('takes over a lock left behind more than ten minutes ago', async () => {
+    // Without an expiry, a process that died mid-reflection would block the
+    // cluster from ever being regenerated again.
+    const now = new Date().toISOString();
+    const stale = new Date(Date.now() - 11 * 60_000).toISOString();
+    const c = lockConnector([
+      [cluster({ reflection_lock_acquired_at: stale })],
+      [cluster({ reflection_lock_acquired_at: now })],
+    ]);
+
+    expect(await acquireReflectionLock(mockContext, c, skill, clusterId)).toBe(
+      now,
+    );
+  });
+
+  it('holds a lock taken just under the timeout', async () => {
+    const justInside = new Date(Date.now() - 9 * 60_000).toISOString();
+    const c = lockConnector([
+      [cluster({ reflection_lock_acquired_at: justInside })],
+    ]);
+
+    expect(
+      await acquireReflectionLock(mockContext, c, skill, clusterId),
+    ).toBeNull();
+  });
+
+  it('backs off when another run overwrote the lock in between', async () => {
+    /**
+     * The read-back after writing is what catches a genuine race: both runs
+     * write, and the one whose timestamp did not survive has to stand down.
+     * Without this check both would proceed and overwrite each other's arms.
+     */
+    const someoneElse = new Date(Date.now() + 5).toISOString();
+    const c = lockConnector([
+      [cluster({ reflection_lock_acquired_at: null })],
+      [cluster({ reflection_lock_acquired_at: someoneElse })],
+    ]);
+
+    expect(
+      await acquireReflectionLock(mockContext, c, skill, clusterId),
+    ).toBeNull();
+  });
+
+  it('refuses when the cluster no longer exists', async () => {
+    const c = lockConnector([[]]);
+
+    expect(
+      await acquireReflectionLock(mockContext, c, skill, clusterId),
+    ).toBeNull();
+  });
+
+  it('refuses when the cluster disappears mid-acquisition', async () => {
+    const c = lockConnector([
+      [cluster({ reflection_lock_acquired_at: null })],
+      [],
+    ]);
+
+    expect(
+      await acquireReflectionLock(mockContext, c, skill, clusterId),
+    ).toBeNull();
+  });
+
+  it('refuses when the write fails', async () => {
+    // A rejected update means someone else won; proceeding would regenerate
+    // without holding the lock at all.
+    const c = {
+      getSkillOptimizationClusters: vi
+        .fn()
+        .mockResolvedValue([cluster({ reflection_lock_acquired_at: null })]),
+      updateSkillOptimizationCluster: vi
+        .fn()
+        .mockRejectedValue(new Error('conflict')),
+    } as unknown as UserDataStorageConnector;
+
+    expect(
+      await acquireReflectionLock(mockContext, c, skill, clusterId),
+    ).toBeNull();
+  });
+});

--- a/packages/api/src/middlewares/optimizer/system-prompt.ts
+++ b/packages/api/src/middlewares/optimizer/system-prompt.ts
@@ -84,7 +84,12 @@ function extractRequestConstraints(
  * Attempts to acquire a reflection lock for a cluster
  * Returns the lock timestamp if successful, null otherwise
  */
-async function acquireReflectionLock(
+/**
+ * Exported for tests. Reached only from inside a regeneration cycle that needs
+ * a database, a model and a live cluster before it gets here, so the locking
+ * behaviour itself is only reachable directly.
+ */
+export async function acquireReflectionLock(
   c: AppContext,
   userDataStorageConnector: UserDataStorageConnector,
   _skill: Skill,
@@ -314,7 +319,12 @@ async function fetchReflectionExamples(
 /**
  * Performs reflection: updates arms with new prompt and resets stats
  */
-async function performReflection(
+/**
+ * Exported for tests. This is the conservative update the whole optimizer rests
+ * on -- the best arm is deliberately left alone -- and it is otherwise reachable
+ * only after a model call has produced a new prompt.
+ */
+export async function performReflection(
   c: AppContext,
   userDataStorageConnector: UserDataStorageConnector,
   cluster: SkillOptimizationCluster,


### PR DESCRIPTION
Completes the optimizer work started in #240. That covered how a configuration is *chosen*; this covers how configurations are *rewritten* — the half where a mistake is destructive rather than merely suboptimal.

## The conservative update

`performReflection`'s central promise is a negative one: **the best-performing arm is left completely intact.** If a regeneration ever rewrote the winner, the optimizer would discard what it had learned on every cycle and never converge — while still answering every request normally, so nothing would look wrong.

The tests pin the whole shape:

- the best arm is neither updated nor has its history cleared
- the worst arm restarts from the **best arm's** parameters plus the new prompt
- middle arms keep their own parameters and change only the prompt
- every rewritten arm has its stats deleted — they were earned by a different prompt, so keeping them would let a stale record decide future selections
- the cluster's step count resets to the best arm's request count
- ranking is by weighted mean, not input order
- a single-arm cluster updates nothing at all

One latent inconsistency is documented rather than changed: `bestArm` arrives as an argument while the ranking is recomputed inside the function, so the two *could* disagree. The test pins which wins — the arm left intact is the top of the ranking, while the parameters copied onto the worst arm come from the argument.

## Both locks

Two concurrent requests regenerating the same cluster would each overwrite the other's work. Covered for both the reflection lock and the evaluation lock: acquisition, refusal while one is held, takeover once it expires (without which a process that died mid-pass would block the cluster forever), and the read-back that catches a genuine race between two writers.

## The early-regeneration guards

`checkAndRegenerateEvaluationsEarly` runs once per skill, and calls models when it does — so a guard that fails open regenerates on every request and spends a model call each time. Covered: the once-only flag, the five-log threshold, the lock in all its states, and the two paths that release the lock rather than proceed.

## Every claim was mutation-checked — and one failed

| Mutation | Caught by |
| --- | --- |
| best arm no longer skipped | 6 tests |
| worst arm keeps its own params | 3 tests |
| reflection lock expires after 1s | 2 lock-timing tests |
| once-only guard removed | *never regenerates a skill twice* |
| five-log threshold → one | **nothing, at first** |

That last one is worth reading. My threshold test used *unparseable* logs, so with the threshold lowered the next guard down caught it and released the lock anyway — and since the `catch` block *also* releases the lock, the lock writes could never have distinguished a clean stop from a crash. The test looked precise and asserted nothing.

Fixed by using usable logs and asserting no error was logged, which is what actually separates "stopped at the guard" from "proceeded and blew up". Now caught.

This is the third time in this sequence that reverting the fix has caught a test that passed against the bug it was written for (after #237 and #240). It's cheap, and it keeps finding things.

## Coverage

| File | Before | After |
| --- | --- | --- |
| `optimizer/system-prompt.ts` | 11.1% | 32.2% |
| `optimizer/evaluations.ts` | 3% | 39.7% |
| **repo total** | 41.57% | **41.92%** |

## Scope

Left for its own change: the generation itself — `generateSeedSystemPromptWithContext` and `regenerateEvaluationsWithExamples` call models through the internal skills, so they want the stub provider from #238 and configured system settings, not a unit test. What's here is every decision made *around* those calls.

## Test notes

- `pnpm test` — 2527 passed (up 30); `pnpm typecheck`, `pnpm check` — 945 files clean
- Only source change is two `export` keywords plus comments explaining why

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wM59ecJTFbb3gZYDDva1Z
