### PR TITLE
fix(api): let internal skills reach a self-hosted provider, and cover the loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,6 +378,24 @@ Set `SERVE_DASHBOARD=false` to run the all-in-one image as a gateway only.
   - Agent validation: `packages/shared/src/utils/agent-validation.ts`
   - Skill validation: `packages/shared/src/utils/skill-validation.ts`
 
+## Internal Skill Calls
+
+The internal skills in `SA_SKILLS` are not a separate code path: each one is a
+normal gateway request that the server sends to its own `/v1`, carrying an
+`sa-config` header that names `super-agents` as the agent and the internal skill
+by name. Two consequences worth remembering:
+
+- **`API_URL` must point at this process.** See the environment notes above.
+- **The target has to carry the provider's `custom_host`.** Internal skills
+  resolve a model through system settings, and `resolveSystemSettingsModel`
+  returns the provider's configured host alongside the model and key. Without
+  it a self-hosted provider is sent to its vendor default — Ollama to
+  `http://localhost:11434` — regardless of what the user configured.
+
+Both failures are quiet: the call cannot connect, the caller logs and continues,
+and optimization simply never happens. `e2e/contract/optimizer.spec.ts` covers
+the whole path against the stub provider.
+
 ## Skill Optimization System
 
 ### System Prompt Evolution
@@ -426,7 +444,15 @@ The system uses special auto-generated skills in the `super-agents` agent (defin
 
 - **Secrets**: Never commit secrets; use `.env` for local development
 - **Environment variables**:
-  - `API_URL` - API server URL (server-side)
+  - `API_URL` - the URL the API uses to call *itself*. The internal skills
+    (judging, embedding, prompt generation) are ordinary gateway requests sent
+    back to this server's own `/v1`, so it has to name the port the process is
+    listening on. It defaults to `http://localhost:$PORT`, which is correct for
+    every packaged deployment; set it explicitly only when the API is reachable
+    at some other address (behind a proxy, or on Workers, where `localhost`
+    means nothing). Getting it wrong is silent — each internal call fails to
+    connect, every caller swallows the error, and optimization stops happening
+    while ordinary requests carry on being served
   - `BEARER_TOKEN` - API authentication token
   - `ACCESS_PASSWORD` - Dashboard password (optional)
   - `AUTH_JWT_SECRET` - JWT signing secret for the dashboard session cookie (required in production)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -121,6 +121,14 @@ POST /__control/fail                  {model, times, status}
 POST /__control/reset                 {model}
 ```
 
+The stub also answers **structured output**: when a request carries a
+`response_format` JSON schema it synthesises the smallest conforming value
+rather than echoing text. That is what makes the internal skills testable —
+prompt seeding, evaluation generation and judging all parse their replies
+against the schema they sent, so an echo would fail. String fields come back as
+`stub: <property>`, which is how `optimizer.spec.ts` can tell a generated prompt
+apart from anything the system produced itself.
+
 Cache behaviour is asserted by **counting provider calls**, not by reading a
 response header — no header distinguishes a hit from a miss, and the call count
 is the behaviour that actually matters. That test is the end-to-end half of the

--- a/e2e/contract/optimizer.spec.ts
+++ b/e2e/contract/optimizer.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from '@playwright/test';
+import {
+  CHAT_COMPLETIONS_PATH,
+  chatBody,
+  stubRequests,
+} from '../fixtures/gateway';
+import {
+  getArms,
+  getClusters,
+  type OptimizedSkill,
+  optimizedConfig,
+  STUB_SYSTEM_PROMPT,
+  setUpOptimizedSkill,
+} from '../fixtures/optimizer';
+
+/**
+ * The self-optimization loop, running for real against the stub provider.
+ *
+ * The internal skills -- prompt seeding, embedding, judging, evaluation
+ * generation -- are ordinary gateway requests the server sends back to its own
+ * `/v1`, resolved through system settings. Nothing about that path is
+ * observable from unit tests, and until now nothing exercised it end to end:
+ * the loop could stop working entirely and every ordinary request would carry
+ * on being served, because each internal call swallows its own errors.
+ *
+ * Serial, because system settings are a single global row that the whole
+ * deployment shares.
+ */
+test.describe.configure({ mode: 'serial' });
+
+test.describe('optimization loop', () => {
+  let configured: OptimizedSkill;
+
+  test.beforeAll(async ({ request }, testInfo) => {
+    /**
+     * Scoped by project: both storage backends run this file against their own
+     * server but share one stub, which buckets traffic by model name. The
+     * project name is sanitised because it becomes part of an agent name, and
+     * those permit only lowercase letters, digits, `_` and `-`.
+     */
+    const scope = `opt-${testInfo.project.name.replace(/[^a-z0-9]+/gi, '-')}`;
+    configured = await setUpOptimizedSkill(request, scope.toLowerCase());
+  });
+
+  test('generates a cluster per configuration', async ({ request }) => {
+    // `configuration_count` is what the skill asked for, and the clusters are
+    // what the request router later picks between.
+    expect(await getClusters(request, configured.skillId)).toHaveLength(3);
+  });
+
+  test('generates arms carrying a prompt written by the internal skill', async ({
+    request,
+  }) => {
+    /**
+     * The end-to-end proof that the internal skills are wired up. That prompt
+     * text can only exist if the seeding skill resolved a model from system
+     * settings, called back into this server's own `/v1`, reached the stub
+     * through the provider's `custom_host`, and had its structured output
+     * parsed and stored.
+     */
+    const arms = await getArms(request, configured.skillId);
+
+    expect(arms.length).toBeGreaterThan(0);
+    for (const arm of arms) {
+      expect(arm.params.system_prompt).toBe(STUB_SYSTEM_PROMPT);
+    }
+  });
+
+  test('spreads arms across every cluster', async ({ request }) => {
+    // An arm belongs to exactly one cluster; a cluster with none would be
+    // unusable, and requests routed to it would have nothing to select.
+    const clusters = await getClusters(request, configured.skillId);
+    const arms = await getArms(request, configured.skillId);
+
+    const populated = new Set(arms.map((arm) => arm.cluster_id));
+    expect(populated.size).toBe(clusters.length);
+  });
+
+  test('serves an optimized request with the generated prompt', async ({
+    request,
+  }) => {
+    /**
+     * The whole loop in one request: embed the input, route it to a cluster,
+     * sample an arm, and send that arm's generated system prompt to the
+     * provider. The prompt is asserted at the provider, because the client
+     * never sees which configuration served it.
+     */
+    const response = await request.post(CHAT_COMPLETIONS_PATH, {
+      headers: {
+        'sa-config': optimizedConfig(
+          configured.agentName,
+          configured.skillName,
+        ),
+      },
+      data: chatBody('plan a trip to Lisbon'),
+    });
+
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as {
+      choices: { message: { content: string } }[];
+    };
+    expect(body.choices[0].message.content).toBe('echo: plan a trip to Lisbon');
+
+    const forwarded = await stubRequests(request, configured.textModel);
+    const served = forwarded[forwarded.length - 1] as {
+      messages: { role: string; content: string }[];
+    };
+    expect(served.messages[0]).toEqual({
+      role: 'system',
+      content: STUB_SYSTEM_PROMPT,
+    });
+    expect(served.messages[1].content).toBe('plan a trip to Lisbon');
+  });
+
+  test('embeds the request through the embedding skill', async ({
+    request,
+  }) => {
+    // Routing to a cluster is a cosine comparison against the request's
+    // embedding, so without this call the optimized path cannot run at all --
+    // it falls back and reports that no provider was configured.
+    expect(
+      await stubRequests(request, configured.embeddingModel),
+    ).not.toHaveLength(0);
+  });
+});

--- a/e2e/fixtures/optimizer.ts
+++ b/e2e/fixtures/optimizer.ts
@@ -1,0 +1,144 @@
+import type { APIRequestContext } from '@playwright/test';
+import { createAgent, uniqueAgentName } from './agents';
+import { STUB_URL, uniqueModelName } from './gateway';
+import { createSkill, SKILLS_PATH } from './skills';
+
+const PROVIDERS_PATH = '/v1/super-agents/ai-providers';
+const MODELS_PATH = '/v1/super-agents/models';
+const SETTINGS_PATH = '/v1/super-agents/system-settings';
+
+/** What the stub answers with for a `string` field named `system_prompt`. */
+export const STUB_SYSTEM_PROMPT = 'stub: system_prompt';
+
+export interface OptimizedSkill {
+  agentId: string;
+  agentName: string;
+  skillId: string;
+  skillName: string;
+  textModel: string;
+  embeddingModel: string;
+}
+
+const post = async <T>(
+  request: APIRequestContext,
+  path: string,
+  data: unknown,
+  expected = 201,
+): Promise<T> => {
+  const response = await request.post(path, { data });
+  if (response.status() !== expected) {
+    throw new Error(
+      `POST ${path} -> ${response.status()} ${await response.text()}`,
+    );
+  }
+  return response.json() as Promise<T>;
+};
+
+/**
+ * Stands up everything the optimizer needs before it will do anything at all:
+ * a provider pointed at the stub, a text and an embedding model, the four
+ * system-settings slots that the internal skills resolve through, an agent, an
+ * optimizing skill, and the models attached to that skill.
+ *
+ * Attaching the models is what triggers arm generation, so by the time this
+ * returns the internal seeding skill has already run and the skill has its
+ * clusters and arms.
+ *
+ * `scope` separates one caller's stub traffic from another's: the model name is
+ * how the stub buckets requests, and one stub process serves every project.
+ */
+export const setUpOptimizedSkill = async (
+  request: APIRequestContext,
+  scope: string,
+): Promise<OptimizedSkill> => {
+  const textModel = uniqueModelName(`${scope}-text`);
+  const embeddingModel = uniqueModelName(`${scope}-embed`);
+
+  const provider = await post<{ id: string }>(request, PROVIDERS_PATH, {
+    ai_provider: 'ollama',
+    name: uniqueModelName(`${scope}-provider`),
+    // The stub ignores it, but the resolver refuses a provider without one.
+    api_key: 'unused-by-the-stub',
+    // How the internal skills find the stub instead of Ollama's default host.
+    custom_fields: { custom_host: STUB_URL },
+  });
+
+  const text = await post<{ id: string }>(request, MODELS_PATH, {
+    ai_provider_id: provider.id,
+    model_name: textModel,
+    model_type: 'text',
+  });
+
+  const embedding = await post<{ id: string }>(request, MODELS_PATH, {
+    ai_provider_id: provider.id,
+    model_name: embeddingModel,
+    model_type: 'embed',
+    embedding_dimensions: 8,
+  });
+
+  // System settings are a single global row, so these tests run serially.
+  const settings = await request.patch(SETTINGS_PATH, {
+    data: {
+      judge_model_id: text.id,
+      embedding_model_id: embedding.id,
+      system_prompt_reflection_model_id: text.id,
+      evaluation_generation_model_id: text.id,
+    },
+  });
+  if (settings.status() !== 200) {
+    throw new Error(`PATCH ${SETTINGS_PATH} -> ${settings.status()}`);
+  }
+
+  const agent = await createAgent(request, uniqueAgentName(scope));
+  const skill = await createSkill(request, agent.id, 'optimized_skill', {
+    optimize: true,
+    configuration_count: 3,
+  });
+
+  // Attaching a model is what generates the clusters and arms.
+  await post(
+    request,
+    `${SKILLS_PATH}/${skill.id}/models`,
+    { modelIds: [text.id] },
+    201,
+  );
+
+  return {
+    agentId: agent.id,
+    agentName: agent.name,
+    skillId: skill.id,
+    skillName: skill.name,
+    textModel,
+    embeddingModel,
+  };
+};
+
+export interface Arm {
+  id: string;
+  cluster_id: string;
+  params: { system_prompt: string | null };
+}
+
+export const getArms = async (
+  request: APIRequestContext,
+  skillId: string,
+): Promise<Arm[]> => {
+  const response = await request.get(`${SKILLS_PATH}/${skillId}/arms`);
+  return response.json() as Promise<Arm[]>;
+};
+
+export const getClusters = async (
+  request: APIRequestContext,
+  skillId: string,
+): Promise<{ id: string }[]> => {
+  const response = await request.get(`${SKILLS_PATH}/${skillId}/clusters`);
+  return response.json() as Promise<{ id: string }[]>;
+};
+
+/** An `sa-config` header asking for the optimized configuration. */
+export const optimizedConfig = (agentName: string, skillName: string): string =>
+  JSON.stringify({
+    agent_name: agentName,
+    skill_name: skillName,
+    targets: [{ optimization: 'auto' }],
+  });

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -1,8 +1,21 @@
 import type { AppContext } from '@api/types/hono';
 
 const DUMMY_JWT_SECRET = 'default-dev-jwt-secret';
+/**
+ * Base URL the API uses to call *itself*.
+ *
+ * The internal skills (judging, embedding, prompt generation) are ordinary
+ * gateway requests that the server sends back to its own `/v1`, so this has to
+ * name the port it is actually listening on. Deriving it from `PORT` rather
+ * than hardcoding one keeps the all-in-one image (3000), the gateway-only image
+ * (8787) and `wrangler dev` (8787) all correct without configuration.
+ *
+ * Getting this wrong is invisible: every internal call fails to connect, each
+ * caller swallows the error, and optimization simply stops happening while
+ * ordinary requests carry on being served.
+ */
 export const getApiUrl = (c: AppContext) =>
-  c.env.API_URL ?? 'http://localhost:8787';
+  c.env.API_URL ?? `http://localhost:${c.env.PORT ?? 8787}`;
 
 export const AUTH_COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 1 week in seconds
 

--- a/packages/api/src/evaluations/llm-judge.ts
+++ b/packages/api/src/evaluations/llm-judge.ts
@@ -116,6 +116,8 @@ export interface LLMJudgeModelConfig {
   model: string;
   provider: AIProvider;
   apiKey: string;
+  /** The provider's configured base URL, where it has one. */
+  customHost?: string;
 }
 
 export function createLLMJudge(
@@ -134,6 +136,7 @@ export function createLLMJudge(
   // Provider and API key from model config or defaults
   const provider = modelConfig?.provider || AIProviderEnum.OPENAI;
   const apiKey = modelConfig?.apiKey || '';
+  const customHost = modelConfig?.customHost;
 
   // Create OpenAI client once (or use injected client for testing)
   const client =
@@ -215,6 +218,7 @@ Provide a score between 0 and 1 with detailed reasoning for your evaluation.`;
             mode: CacheMode.SIMPLE,
           },
           api_key: apiKey,
+          ...(customHost ? { custom_host: customHost } : {}),
         },
       ],
       agent_name: 'super-agents',

--- a/packages/api/src/optimization/utils/evaluations.ts
+++ b/packages/api/src/optimization/utils/evaluations.ts
@@ -129,6 +129,9 @@ export async function generateEvaluationCreateParams(
         provider: modelConfig.provider,
         model: modelConfig.model,
         api_key: modelConfig.apiKey,
+        ...(modelConfig.customHost
+          ? { custom_host: modelConfig.customHost }
+          : {}),
       },
     ],
     agent_name: 'super-agents',

--- a/packages/api/src/optimization/utils/system-prompt.ts
+++ b/packages/api/src/optimization/utils/system-prompt.ts
@@ -104,6 +104,9 @@ async function createSystemPromptClient(
         provider: modelConfig.provider,
         model: modelConfig.model,
         api_key: modelConfig.apiKey,
+        ...(modelConfig.customHost
+          ? { custom_host: modelConfig.customHost }
+          : {}),
       },
     ],
     agent_name: 'super-agents',

--- a/packages/api/src/types/hono.ts
+++ b/packages/api/src/types/hono.ts
@@ -36,6 +36,8 @@ export interface AppEnv {
     BEARER_TOKEN?: string;
     LIBSQL_AUTH_TOKEN?: string;
     LIBSQL_URL?: string;
+    /** Set by the Node entrypoint; absent on Workers. */
+    PORT?: string;
     NODE_ENV?: string;
     POSTGREST_SERVICE_ROLE_KEY?: string;
     POSTGREST_URL?: string;

--- a/packages/api/src/utils/embeddings.ts
+++ b/packages/api/src/utils/embeddings.ts
@@ -248,6 +248,11 @@ export async function generateEmbeddingForRequest(
           provider: providerConfig.ai_provider,
           model: embeddingConfig.model.model_name,
           api_key: providerConfig.api_key,
+          // Same reason as the other internal skills: without this a
+          // self-hosted embedding provider is sent to its vendor default.
+          ...(providerConfig.custom_fields?.custom_host
+            ? { custom_host: providerConfig.custom_fields.custom_host }
+            : {}),
         },
       ],
       agent_name: 'super-agents',

--- a/packages/api/src/utils/evaluation-model-resolver.ts
+++ b/packages/api/src/utils/evaluation-model-resolver.ts
@@ -12,6 +12,16 @@ export interface ResolvedModelConfig {
   model: string;
   provider: AIProvider;
   apiKey: string;
+  /**
+   * The provider's configured base URL, where it has one.
+   *
+   * Internal skills call back through the gateway with a target naming only a
+   * provider and a model, so without this a self-hosted provider is sent to its
+   * vendor default -- Ollama to `http://localhost:11434` -- no matter what the
+   * user configured. The failure is quiet: the call cannot connect, the error
+   * is logged, and optimization simply stops happening.
+   */
+  customHost?: string;
 }
 
 /**
@@ -69,6 +79,7 @@ async function resolveModelById(
     model: model.model_name,
     provider: providerConfig.ai_provider as AIProvider,
     apiKey: providerConfig.api_key,
+    customHost: providerConfig.custom_fields?.custom_host as string | undefined,
   };
 }
 

--- a/scripts/start-stub-provider.mjs
+++ b/scripts/start-stub-provider.mjs
@@ -73,6 +73,81 @@ const replyText = (body) => {
   return `echo: ${content}`;
 };
 
+/**
+ * Build the smallest value satisfying a JSON Schema.
+ *
+ * The internal skills -- prompt seeding, reflection, evaluation generation,
+ * judging -- all ask for structured output and parse the reply against the
+ * schema they sent. Echoing text back would fail that parse, so the stub reads
+ * the schema off the request and answers in its shape instead. That keeps the
+ * stub generic: it needs no knowledge of any particular internal skill.
+ *
+ * Strings carry the property name so a test can tell a stubbed value apart from
+ * anything the system might have produced itself.
+ */
+const instanceOf = (schema, root, name = 'value') => {
+  if (!schema || typeof schema !== 'object') {
+    return null;
+  }
+
+  if (typeof schema.$ref === 'string') {
+    const key = schema.$ref.replace('#/$defs/', '');
+    return instanceOf(root?.$defs?.[key], root, name);
+  }
+
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+
+  // A union: the first branch is as good as any for a stub.
+  for (const branches of [schema.anyOf, schema.oneOf, schema.allOf]) {
+    if (Array.isArray(branches) && branches.length > 0) {
+      return instanceOf(branches[0], root, name);
+    }
+  }
+
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+
+  switch (type) {
+    case 'object': {
+      const properties = schema.properties ?? {};
+      const required = Array.isArray(schema.required)
+        ? schema.required
+        : Object.keys(properties);
+      const built = {};
+      for (const key of required) {
+        built[key] = instanceOf(properties[key], root, key);
+      }
+      return built;
+    }
+    case 'array': {
+      const count = Math.max(schema.minItems ?? 1, 1);
+      return Array.from({ length: count }, () =>
+        instanceOf(schema.items, root, name),
+      );
+    }
+    case 'number':
+    case 'integer':
+      // Mid-range where one is given, so a score lands inside its bounds.
+      return typeof schema.minimum === 'number' &&
+        typeof schema.maximum === 'number'
+        ? (schema.minimum + schema.maximum) / 2
+        : 1;
+    case 'boolean':
+      return true;
+    case 'null':
+      return null;
+    default:
+      return `stub: ${name}`;
+  }
+};
+
+/** The schema an OpenAI-style structured-output request is asking for. */
+const requestedSchema = (body) =>
+  body?.response_format?.type === 'json_schema'
+    ? (body.response_format.json_schema?.schema ?? null)
+    : null;
+
 const completionPayload = (body, text) => ({
   id: 'chatcmpl-stub',
   object: 'chat.completion',
@@ -186,7 +261,10 @@ const server = createServer(async (request, response) => {
   }
 
   if (url.pathname === '/v1/chat/completions') {
-    const text = replyText(body);
+    const schema = requestedSchema(body);
+    const text = schema
+      ? JSON.stringify(instanceOf(schema, schema))
+      : replyText(body);
     if (body?.stream) {
       streamCompletion(response, body, text);
     } else {


### PR DESCRIPTION
Wiring the internal skills to the stub turned up **two bugs that stopped them working at all** in the packaged deployment. Both are fixed here, and the loop is now covered end to end on both storage backends.

## Bug 1 — the API could not call itself

The internal skills (prompt seeding, embedding, judging, evaluation generation) are ordinary gateway requests the server sends back to its own `/v1`. `getApiUrl` returned `http://localhost:8787` whenever `API_URL` was unset — and **nothing sets it**:

| | listens on | `getApiUrl` returned |
| --- | --- | --- |
| all-in-one image (`Dockerfile`) | **3000** | `localhost:8787` ❌ |
| gateway-only image (`packages/api/Dockerfile`) | 8787 | `localhost:8787` ✓ |
| `wrangler dev` | 8787 | `localhost:8787` ✓ |

So in the deployment the README tells people to run, every internal call went to a port with nothing behind it. Now derived from `PORT`, which is correct for all three without configuration.

## Bug 2 — a configured provider host was discarded

`ResolvedModelConfig` carried `{model, provider, apiKey}` and dropped the provider record's `custom_host`. Internal skills build a target naming only a provider and a model, so a self-hosted provider was sent to its **vendor default** — Ollama to `http://localhost:11434` — regardless of what the user configured. Anyone running Ollama on another host or port simply could not use it for the internal skills.

The host now travels with the model and key through all four call sites: system prompt generation, evaluation generation, the judge, and embeddings.

## Both failed the same silent way

The call can't connect, each caller logs and carries on, and optimization never happens while ordinary requests keep being served normally. The visible symptom is misleading — an optimized request fails with `"No configuration_name or provider defined"`, because the embedding it needed to pick a cluster came back null.

That's exactly what I hit, and chasing it is what surfaced both bugs.

## The stub now answers structured output

Given a `response_format` JSON schema it synthesises the smallest conforming value instead of echoing text. Every internal skill parses its reply against the schema it sent, so an echo could never have worked. The generator handles `$ref`/`$defs`, enums, unions, and numeric bounds, so it needs no knowledge of any particular skill.

String fields come back as `stub: <property>` — which is how a test can tell a generated prompt apart from anything the system produced itself.

## What the test proves

`e2e/contract/optimizer.spec.ts`, on **both** storage backends:

- configuring a skill produces a cluster per `configuration_count`
- every generated arm carries `system_prompt: "stub: system_prompt"` — that text can only exist if the seeding skill resolved a model from system settings, called back into this server's own `/v1`, reached the stub through `custom_host`, and had its structured output parsed and stored
- arms are spread across every cluster
- an optimized request is embedded, routed, sampled and served **with that generated prompt**, asserted at the provider since the client never sees which configuration answered it

Reverting either fix breaks it:

| Mutation | Result |
| --- | --- |
| `getApiUrl` back to hardcoded 8787 | ✘ optimization loop |
| resolver drops `custom_host` | ✘ optimization loop |

## Test notes

- `pnpm test:e2e:all` — **70/70** across both backends (was 60)
- `pnpm test` — 2527 passed; `pnpm typecheck`, `pnpm check` — 947 files clean
- The suite runs serially for this file: system settings are a single global row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wM59ecJTFbb3gZYDDva1Z
