### PR TITLE
feat(dev): run the API on Node against SQLite in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ docker-compose.override.yml
 /playwright-report
 /.e2e-data
 **/test-results
+/.local-data/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,13 +53,19 @@ pnpm check:fix  # Auto-fix linting and formatting issues
 pnpm install
 
 # Database
+#
+# `pnpm dev` needs neither of these: it uses an embedded SQLite database at
+# `.local-data/dev.db`, created on the first request. Supabase is only needed
+# to develop against that backend.
 supabase start  # Start local Supabase database
 supabase stop   # Stop local database
 
 # Development server (runs both web and API via Turborepo)
-pnpm dev        # Start all dev servers in parallel
-pnpm dev:web    # Start only web dev server (Vite on port 3000)
-pnpm dev:api    # Start only API dev server (Hono on port 8787)
+pnpm dev             # Start all dev servers in parallel
+pnpm dev:web         # Start only web dev server (Vite on port 3000)
+pnpm dev:api         # Start only API dev server (Node + SQLite, free port)
+pnpm dev:api:worker  # The same API on workerd; no `file:` database there
+LIBSQL_URL= pnpm dev # Develop against Supabase instead of SQLite
 
 # Testing
 pnpm test                      # Run all tests (excludes in-depth integration tests)
@@ -93,7 +99,8 @@ pnpm lint       # Run linter
 pnpm format     # Check formatting
 pnpm format:fix # Auto-fix formatting
 
-# API testing (all requests go through port 3000, proxied to API)
+# API testing. Always port 3000 -- Vite proxies /v1 on to the API, whose own
+# port is chosen at runtime and is not an address to send requests to.
 curl "http://localhost:3000/v1/endpoint" -H "Authorization: Bearer super-agents"
 ```
 
@@ -114,9 +121,18 @@ curl "http://localhost:3000/v1/endpoint" -H "Authorization: Bearer super-agents"
 
 #### The API runs on two runtimes
 
-`pnpm dev:api` runs `wrangler dev`, so **workerd is the development runtime**,
-while the Docker image runs the same code on Node through `src/server.ts`.
-Anything reachable from `src/index.ts` has to work on both. In practice:
+`pnpm dev:api` runs the Node entrypoint (`src/server.ts`), which is also what
+the Docker image runs; `src/index.ts` is the Cloudflare Workers entrypoint, and
+anything reachable from it has to work on both.
+
+Development runs on Node because a Worker has no filesystem: on workerd
+`@libsql/client` resolves to its HTTP-only build, so an embedded `file:`
+database cannot be opened there at all. A Workers deployment needs a remote
+libSQL (Turso) or Supabase instead.
+
+**So day-to-day development no longer exercises workerd.** Run
+`pnpm dev:api:worker` before merging anything that touches the Workers path.
+In practice:
 
 - **No module-scope I/O, timers, or randomness.** Workers reject these outright
   — `utils/sse-event-manager.ts` starts its ping interval on first use for this
@@ -126,17 +142,22 @@ Anything reachable from `src/index.ts` has to work on both. In practice:
   or a `workerd` export condition), use it.
 - **`node:` builtins are the quiet case.** Wrangler's unenv layer substitutes a
   stub, so the import resolves and the Worker boots — it throws only when the
-  stub is called. Neither CI check catches this; review does.
+  stub is called. Neither CI check catches this, and since development moved to
+  Node, neither does `pnpm dev`; review does.
 
 `pnpm verify:worker` bundles and boots the Worker, and runs in CI.
 
 ### Request Flow
 ```
-Development:  Browser (:3000) → Vite proxy → API (:8787)
+Development:  Browser (:3000) → Vite proxy → API (a free port)
 Production:   Browser (:3000) → Hono (:3000)
 ```
 
-In development, Vite proxies `/v1/*` requests to the API server on port 8787.
+In development the browser only ever talks to Vite, which proxies `/v1/*` on to
+the API. The API's port is not fixed: it takes whatever the operating system
+has free and publishes it to `.local-data/api-port`, which Vite reads per
+request. Nothing has to be configured, and no other project on the machine can
+collide with it. `PORT` pins it if you need a stable address.
 
 In production there is no proxy: a single Hono process serves both. Because the
 API carries a `/v1` base path, `/v1/*` reaches the API routes and every other

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,33 +36,62 @@ Other directories:
 
 ## Setup
 
-1. Install the [Supabase CLI](https://supabase.com/docs/guides/cli)
-2. Start the local services:
-   ```sh
-   supabase start
-   ```
-3. Install dependencies:
+1. Install dependencies:
    ```sh
    pnpm install
    ```
-4. Run the development server:
+2. Run the development server:
    ```sh
    pnpm dev
    ```
 
-To run without Supabase (and without Docker), build once and start the same
-single process the published image runs, backed by an embedded libSQL file:
+That is the whole setup. The dashboard is on `http://localhost:3000` and the
+API runs behind it on Node, against an embedded SQLite database at
+`.local-data/dev.db` created on the first request — no Supabase, no Docker,
+nothing to install beyond the workspace itself. Deleting that file resets the
+database.
+
+Send API requests to port 3000 as well — Vite proxies `/v1` on to the API:
+
+```sh
+curl http://localhost:3000/v1/models -H "Authorization: Bearer super-agents"
+```
+
+The API's own port is chosen at runtime, since only Vite talks to it; it is
+printed at startup and published to `.local-data/api-port` for the proxy, but
+it is not an address to send requests to. Set `PORT` to pin it.
+
+To develop against **Supabase** instead, install the
+[Supabase CLI](https://supabase.com/docs/guides/cli), run `supabase start`, and
+start with an empty `LIBSQL_URL`, which selects the other backend:
+
+```sh
+LIBSQL_URL= pnpm dev
+```
+
+To run the API on **workerd**, the way a Cloudflare Workers deployment does:
+
+```sh
+pnpm dev:api:worker
+```
+
+That is worth doing before merging anything on the Workers path, because
+`pnpm dev` no longer covers it. It uses Supabase by default; put a
+`LIBSQL_URL` in `packages/api/.dev.vars` to point it at a remote libSQL
+instead. A `file:` URL cannot be used here — a Worker has no filesystem, so
+`@libsql/client` resolves to its HTTP-only build and rejects the scheme.
+
+To run the **production shape** — one process serving both the API and the
+built dashboard, as the published image does:
 
 ```sh
 pnpm build
-LIBSQL_URL="file:$PWD/.data/dev.db" DASHBOARD_ROOT=./packages/web/dist \
-  node packages/api/dist/server.js
+PORT=3000 LIBSQL_URL="file:$PWD/.local-data/dev.db" \
+  DASHBOARD_ROOT=./packages/web/dist node packages/api/dist/server.js
 ```
 
-The dashboard and the API are then both on `http://localhost:3000`. Note that
-this is a build-and-run loop, not hot reload — `pnpm dev` remains the way to
-iterate. It is also the only way to exercise a `file:` database locally, since
-`pnpm dev:api` runs on workerd, where `@libsql/client` is HTTP-only.
+Both halves are then on `http://localhost:3000`. This is a build-and-run loop,
+not hot reload; `pnpm dev` remains the way to iterate.
 
 ## Development Commands
 
@@ -73,7 +102,8 @@ pnpm build:web      # Build only web package
 pnpm build:api      # Build only API package
 pnpm dev            # Start all dev servers in parallel
 pnpm dev:web        # Start only web dev server (Vite on port 3000)
-pnpm dev:api        # Start only API dev server (Hono on port 8787)
+pnpm dev:api        # Start only API dev server (Node + SQLite, free port)
+pnpm dev:api:worker # The same API on workerd (needs a non-file: database)
 pnpm start          # Serve production build
 ```
 
@@ -102,6 +132,9 @@ The end-to-end suite (`e2e/`) runs the built app against an embedded libSQL
 database, so it needs no Supabase and no Docker — see `e2e/README.md`.
 
 **Database:**
+
+`pnpm dev` needs none of these; they are for developing against Supabase.
+
 ```sh
 supabase start      # Start local Supabase
 supabase stop       # Stop local Supabase

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ COPY tsconfig.base.json tsconfig.json ./
 COPY packages/api ./packages/api
 COPY packages/web ./packages/web
 COPY packages/shared ./packages/shared
+# `vite.config.ts` imports scripts/dev-api-port.mjs, and Vite loads its config
+# for `vite build` as well as for the dev server, so the file has to resolve
+# here even though nothing in the image ever runs it. It stays in this stage --
+# the runner below copies only the two dist directories.
+COPY scripts ./scripts
 
 ENV NODE_ENV=production
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -51,9 +51,10 @@ under `.e2e-data/`. Migrations run on the first request, so deleting the file
 is a full reset, and that half of the suite needs no Postgres, no PostgREST and
 no container runtime at all. Only the Supabase parity pass does.
 
-It has to be the built server rather than `pnpm dev`: `pnpm dev:api` runs
-wrangler, and on workerd `@libsql/client` resolves to its HTTP-only build, so
-an embedded database cannot be opened there at all.
+It has to be the built server rather than `pnpm dev`, which is a Vite/API
+pair: Vite serves the dashboard and proxies `/v1` away, so the static serving,
+the SPA fallback and the `/v1` 404 boundary above never execute there. They
+exist only in `server.ts`.
 
 Three servers run, because two things are fixed per process and decided from
 the environment — the storage backend and whether the dashboard needs a login:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "turbo dev",
     "dev:api": "pnpm --filter @super-agents/api dev",
+    "dev:api:worker": "pnpm --filter @super-agents/api dev:worker",
     "dev:web": "pnpm --filter @super-agents/web dev",
     "build": "turbo build",
     "build:api": "pnpm --filter @super-agents/api build",

--- a/packages/api/build.js
+++ b/packages/api/build.js
@@ -1,34 +1,6 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
+import { buildOptions } from './esbuild.config.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-await esbuild.build({
-  entryPoints: [path.join(__dirname, 'src/server.ts')],
-  bundle: true,
-  platform: 'node',
-  target: 'node22',
-  format: 'esm',
-  outfile: path.join(__dirname, 'dist/server.js'),
-  alias: {
-    '@server': path.join(__dirname, 'src'),
-    '@shared': path.join(__dirname, '../shared/src'),
-  },
-  /**
-   * `libsql` loads a platform-specific native addon with a runtime `require`,
-   * which cannot be bundled. Leaving it external means Node resolves it from
-   * node_modules instead, so the runtime image has to carry it -- see the
-   * runner stage of the root Dockerfile.
-   *
-   * Only the local-file path needs it. A deployment using remote libSQL, or
-   * Supabase, never loads it.
-   */
-  external: ['libsql'],
-  sourcemap: true,
-  banner: {
-    js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
-  },
-});
+await esbuild.build(buildOptions);
 
 console.log('Build complete');

--- a/packages/api/dev.js
+++ b/packages/api/dev.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Development server for the API, on Node.
+ *
+ * The API has two entrypoints -- `src/index.ts` for Cloudflare Workers and
+ * `src/server.ts` for Node -- and this runs the Node one, which is also what
+ * the published image runs. That choice is what lets development use an
+ * embedded SQLite database: a Worker has no filesystem, so on workerd
+ * `@libsql/client` resolves to its HTTP-only build and a `file:` URL is
+ * rejected outright. Nothing else about the two runtimes differs here; both
+ * wrap the same Hono app.
+ *
+ * Use `pnpm dev:api:worker` to run the same code on workerd instead. That is
+ * still the only way to catch a `node:` builtin that Workers does not
+ * implement, because wrangler's unenv layer stubs those at bundle time and the
+ * stub throws only when it is called -- see `scripts/check-worker-runtime.sh`.
+ *
+ * Rebuilds on change and restarts the server; a build that fails leaves the
+ * previous one running, so a typo mid-edit does not take the API down.
+ *
+ * Overridable through the environment:
+ *
+ *   PORT        what to listen on (default: a free port chosen at startup and
+ *               published for Vite to proxy to -- see scripts/dev-api-port.mjs)
+ *   LIBSQL_URL  the database (default `.local-data/dev.db` in the repo root).
+ *               Set it empty to develop against Supabase instead.
+ */
+import { spawn } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { connect } from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as esbuild from 'esbuild';
+import {
+  pickFreePort,
+  publishApiPort,
+  unpublishApiPort,
+} from '../../scripts/dev-api-port.mjs';
+import { buildOptions, outfile } from './esbuild.config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, '../..');
+
+// SQLite creates the database file but not the directory above it, and
+// migrations run lazily on the first request, so a missing directory would
+// surface as a failed query rather than a failed startup.
+const dataDir = path.join(repoRoot, '.local-data');
+mkdirSync(dataDir, { recursive: true });
+
+/**
+ * A concrete port, chosen once for the whole session so that restarts on
+ * rebuild keep the same address. Vite reads it from the file published below,
+ * and `getApiUrl` derives the address the internal skills call this process
+ * back on from the same value.
+ */
+const port = process.env.PORT ?? String(await pickFreePort());
+publishApiPort(port);
+
+const childEnv = {
+  ...process.env,
+  PORT: port,
+  // `??` rather than `||` on purpose: an explicitly empty LIBSQL_URL selects
+  // Supabase, which is how you develop against the other backend.
+  LIBSQL_URL: process.env.LIBSQL_URL ?? `file:${path.join(dataDir, 'dev.db')}`,
+  // Vite serves the dashboard in development, so this process is API-only.
+  SERVE_DASHBOARD: 'false',
+  // The runtime port is not an address anyone should use, so the server does
+  // not print it. Vite prints where to send requests instead, once it knows
+  // which port it took.
+  SA_QUIET_BANNER: 'true',
+};
+
+let child;
+
+const stopChild = () =>
+  new Promise((resolve) => {
+    if (!child) {
+      resolve();
+      return;
+    }
+    const dying = child;
+    child = undefined;
+    dying.once('exit', resolve);
+    dying.kill('SIGTERM');
+  });
+
+const startChild = () => {
+  child = spawn(process.execPath, [outfile], {
+    stdio: 'inherit',
+    env: childEnv,
+  });
+  const started = child;
+  child.once('exit', (code, signal) => {
+    // Only report a crash. A restart kills the previous process itself, and
+    // `stopChild` has already cleared `child` by the time that exit arrives.
+    if (child === started && code !== 0) {
+      console.error(
+        `API exited (${signal ?? `code ${code}`}). Waiting for the next change.`,
+      );
+      child = undefined;
+    }
+  });
+};
+
+/**
+ * Restarts are serialised through a promise chain because esbuild can finish
+ * two builds in quick succession, and overlapping restarts would race to bind
+ * the port -- the second server would then die with EADDRINUSE.
+ */
+let pending = Promise.resolve();
+const restart = () => {
+  pending = pending
+    .then(stopChild)
+    .then(startChild)
+    .catch((error) => {
+      console.error('Could not restart the API:', error);
+    });
+};
+
+const context = await esbuild.context({
+  ...buildOptions,
+  logLevel: 'silent',
+  plugins: [
+    {
+      name: 'restart-api',
+      setup(build) {
+        build.onEnd((result) => {
+          if (result.errors.length > 0) {
+            for (const message of result.errors) {
+              console.error(`${message.text}`);
+            }
+            console.error(`Build failed; the previous API is still running.`);
+            return;
+          }
+          restart();
+        });
+      },
+    },
+  ],
+});
+
+const shutdown = async () => {
+  await stopChild();
+  await context.dispose();
+  // Leaving the file behind would point the next Vite at a port nothing is
+  // listening on, and the wait on startup would never fire.
+  unpublishApiPort();
+  process.exit(0);
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+/**
+ * The port below is deliberately not the one to send requests to. Vite serves
+ * the dashboard and proxies `/v1` on to this process, so a request made
+ * against the dashboard's origin reaches the API with no CORS and no second
+ * address to remember -- which is also the shape production has, where one
+ * process serves both. Vite says so itself once it has a port; labelling this
+ * one "internal" keeps it from reading like an endpoint in the meantime.
+ */
+console.log(`API process on port ${port} (internal; Vite proxies /v1 to it)`);
+console.log(
+  `Database ${childEnv.LIBSQL_URL || '(none set -- using Supabase)'}`,
+);
+
+await context.watch();

--- a/packages/api/esbuild.config.js
+++ b/packages/api/esbuild.config.js
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** The bundle both `build.js` and `dev.js` produce and run. */
+export const outfile = path.join(__dirname, 'dist/server.js');
+
+/**
+ * esbuild options for the Node build of the API.
+ *
+ * Shared so that the development server runs the same bundle the image ships
+ * rather than a second configuration that can drift from it -- the `external`
+ * entry below in particular is not something a dev build can safely omit.
+ */
+export const buildOptions = {
+  entryPoints: [path.join(__dirname, 'src/server.ts')],
+  bundle: true,
+  platform: 'node',
+  target: 'node22',
+  format: 'esm',
+  outfile,
+  alias: {
+    '@server': path.join(__dirname, 'src'),
+    '@shared': path.join(__dirname, '../shared/src'),
+  },
+  /**
+   * `libsql` loads a platform-specific native addon with a runtime `require`,
+   * which cannot be bundled. Leaving it external means Node resolves it from
+   * node_modules instead, so the runtime image has to carry it -- see the
+   * runner stage of the root Dockerfile.
+   *
+   * Only the local-file path needs it. A deployment using remote libSQL, or
+   * Supabase, never loads it.
+   */
+  external: ['libsql'],
+  sourcemap: true,
+  banner: {
+    js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url);`,
+  },
+};

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,8 @@
     "./routers/*": "./src/api/v1/super-agents/*.ts"
   },
   "scripts": {
-    "dev": "wrangler dev --env-file ../../.dev.vars",
+    "dev": "node dev.js",
+    "dev:worker": "wrangler dev",
     "build": "node build.js",
     "start": "node dist/server.js",
     "deploy": "wrangler deploy",

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -104,7 +104,17 @@ if (libsqlUrl?.startsWith('file:')) {
   }
 }
 
-console.log(`Starting server on port ${port}...`);
+/**
+ * Under `pnpm dev` the port is chosen at runtime and nobody sends requests to
+ * it directly, so naming it here would only invite someone to try. The dev
+ * runner sets this and prints its own summary instead; every other deployment
+ * wants the address it is actually reachable on.
+ */
+const quietBanner = process.env.SA_QUIET_BANNER === 'true';
+
+if (!quietBanner) {
+  console.log(`Starting server on port ${port}...`);
+}
 
 serve({
   /**
@@ -117,9 +127,13 @@ serve({
   port,
 });
 
-console.log(`Server is running on http://0.0.0.0:${port}`);
-console.log(
-  serveDashboard
-    ? `Dashboard served from ${dashboardRoot}`
-    : 'Dashboard not served (API only)',
-);
+if (quietBanner) {
+  console.log('Internal API Server is running');
+} else {
+  console.log(`Server is running on http://0.0.0.0:${port}`);
+  console.log(
+    serveDashboard
+      ? `Dashboard served from ${dashboardRoot}`
+      : 'Dashboard not served (API only)',
+  );
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,15 +1,82 @@
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 import viteReact from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin, type ProxyOptions } from 'vite';
 import tsConfigPaths from 'vite-tsconfig-paths';
+import { readApiPort, waitForApiPort } from '../../scripts/dev-api-port.mjs';
+
+/** Stands in for the API's address until the first request resolves it. */
+const PLACEHOLDER_TARGET = 'http://127.0.0.1:1';
+
+/**
+ * Says where to send API requests, immediately after Vite's own URL block.
+ *
+ * It belongs here rather than with the API for two reasons: this is the origin
+ * in question, and Vite is the only side that knows which port it actually
+ * took -- 3000 may already be in use, in which case it quietly moves to 3001
+ * and any address the API printed would be wrong.
+ */
+const apiEntrypointNotice = (): Plugin => ({
+  name: 'super-agents:api-entrypoint-notice',
+  apply: 'serve',
+  configureServer(server) {
+    const printUrls = server.printUrls.bind(server);
+    server.printUrls = () => {
+      printUrls();
+      const address = server.httpServer?.address();
+      const port =
+        typeof address === 'object' && address !== null
+          ? address.port
+          : server.config.server.port;
+      console.log(
+        `  \u001b[32m\u279c\u001b[0m  \u001b[1mAPI\u001b[0m:      send requests here, e.g. http://localhost:${port}/v1/models`,
+      );
+    };
+  },
+});
+
+/**
+ * The proxy's own options object, captured in `configure` below so that the
+ * target can be pointed at the API's runtime port.
+ */
+let liveProxyOptions: ProxyOptions | undefined;
 
 export default defineConfig({
   server: {
     port: 3000,
     proxy: {
       '/v1': {
-        target: 'http://localhost:8787',
         changeOrigin: true,
+        /**
+         * A placeholder, replaced per request below. The API takes whatever
+         * port the operating system has free rather than claiming a fixed one,
+         * so there is nothing correct to write here; this value only survives
+         * if the API never starts, and then it fails loudly instead of
+         * reaching something unrelated.
+         */
+        target: PLACEHOLDER_TARGET,
+        /**
+         * `configure` is the only hook handed the options object the proxy
+         * actually reads its target from. The one `bypass` receives is a
+         * shallow copy Vite makes when it builds its proxy table, so mutating
+         * that has no effect -- the request still goes to the placeholder.
+         */
+        configure: (_proxy, options) => {
+          liveProxyOptions = options;
+        },
+        /**
+         * Resolved per request rather than once at startup, so Vite need not
+         * wait for the API and an API restarting on a different port is
+         * followed rather than proxied into a void.
+         */
+        bypass: async () => {
+          if (!liveProxyOptions) {
+            return;
+          }
+          const port = readApiPort() ?? (await waitForApiPort());
+          if (port !== undefined) {
+            liveProxyOptions.target = `http://127.0.0.1:${port}`;
+          }
+        },
       },
     },
   },
@@ -93,6 +160,7 @@ export default defineConfig({
     },
   },
   plugins: [
+    apiEntrypointNotice(),
     tsConfigPaths({
       root: '../..',
       projects: [

--- a/scripts/check-container-image.sh
+++ b/scripts/check-container-image.sh
@@ -3,7 +3,7 @@
 # Builds the all-in-one image and checks that the container serves both halves.
 #
 # The API and the dashboard share one process now, and that static-serving path
-# runs in neither `pnpm dev` (wrangler for the API, vite for the dashboard) nor
+# runs in neither `pnpm dev` (a Node API and vite for the dashboard) nor
 # the unit tests. The built image is the only place it executes, so without this
 # a break in it would first appear in a published release.
 #

--- a/scripts/check-worker-runtime.sh
+++ b/scripts/check-worker-runtime.sh
@@ -2,10 +2,10 @@
 #
 # Verifies that the Cloudflare Workers build of the API still works.
 #
-# `pnpm dev:api` runs `wrangler dev`, so workerd is the runtime every developer
-# uses day to day -- but nothing built or booted it outside a developer's
-# machine. These two checks cover the failure modes that gap allows, and they
-# catch different things:
+# `pnpm dev:api` runs the API on Node, so workerd is no longer exercised by
+# day-to-day development -- this is the only check that runs it automatically.
+# These two checks cover the failure modes that gap allows, and they catch
+# different things:
 #
 #   1. `wrangler deploy --dry-run` fails on imports that cannot be bundled.
 #      A driver package with native bindings (`@libsql/client` rather than

--- a/scripts/dev-api-port.mjs
+++ b/scripts/dev-api-port.mjs
@@ -1,0 +1,116 @@
+/**
+ * How `pnpm dev` agrees on the API's port.
+ *
+ * In development the browser only ever talks to Vite, which proxies `/v1`
+ * onwards -- the API's own port is an implementation detail nobody types. So
+ * it is allocated from whatever the operating system has free rather than
+ * hardcoded, which removes a whole class of failure: an unrelated project on
+ * the same machine having already taken the port we assumed. (The previous
+ * default, 8787, is Cloudflare's, so any other Workers project collided.)
+ *
+ * The cost is that Vite cannot know the target in advance. The two processes
+ * start independently under Turborepo, so they agree through this file instead:
+ * the API publishes the port it took, and Vite reads it per request.
+ */
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Written by `packages/api/dev.js`, read by `packages/web/vite.config.ts`. */
+export const apiPortFile = path.join(repoRoot, '.local-data', 'api-port');
+
+/**
+ * Ports to choose from: above the registered range, and below the ephemeral
+ * range this kernel hands out (`/proc/sys/net/ipv4/ip_local_port_range`, 32768
+ * upwards on Linux). Staying out of that range is the point -- see below.
+ */
+const PORT_FLOOR = 20000;
+const PORT_CEILING = 32000;
+
+/**
+ * Is this port bindable the way the server will bind it?
+ *
+ * Listening without a host is what `@hono/node-server` does, which takes the
+ * dual-stack wildcard (`::`). Probing `127.0.0.1` instead would report a port
+ * free that then fails with `EADDRINUSE ... :::<port>`, because something else
+ * holds the same port on another address.
+ */
+const isPortFree = (port) =>
+  new Promise((resolve) => {
+    const probe = createServer();
+    probe.once('error', () => resolve(false));
+    probe.listen(port, () => {
+      probe.close(() => resolve(true));
+    });
+  });
+
+/**
+ * Find a free port for the API.
+ *
+ * Deliberately not `listen(0)`: the kernel draws those from the ephemeral
+ * range, which is the same pool it assigns source ports for outgoing
+ * connections from. A port free at the moment it is probed can therefore be
+ * taken by an unrelated connection before the server binds it -- a race that
+ * shows up as an intermittent `EADDRINUSE` on a port nothing is listening on.
+ * Choosing from below that range avoids competing with the kernel.
+ *
+ * A concrete port rather than letting the server take 0, because the server
+ * needs one: `getApiUrl` builds the address the internal skills call this
+ * process back on out of `PORT`, and a server told to listen on 0 would
+ * advertise `localhost:0`.
+ */
+export const pickFreePort = async () => {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const candidate =
+      PORT_FLOOR + Math.floor(Math.random() * (PORT_CEILING - PORT_FLOOR));
+    if (await isPortFree(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `Could not find a free port between ${PORT_FLOOR} and ${PORT_CEILING}. Set PORT to choose one.`,
+  );
+};
+
+export const publishApiPort = (port) => {
+  mkdirSync(path.dirname(apiPortFile), { recursive: true });
+  writeFileSync(apiPortFile, `${port}\n`);
+};
+
+export const unpublishApiPort = () => {
+  rmSync(apiPortFile, { force: true });
+};
+
+/** The published port, or undefined if the API has not started yet. */
+export const readApiPort = () => {
+  try {
+    const port = Number(readFileSync(apiPortFile, 'utf8').trim());
+    return Number.isInteger(port) && port > 0 ? port : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Wait for the API to publish a port.
+ *
+ * Vite usually wins the startup race -- it has far less to do than a first
+ * esbuild bundle -- so without this the first `/v1` request of a session would
+ * fail with a proxy error rather than simply waiting a moment.
+ */
+export const waitForApiPort = async (timeoutMs = 30_000) => {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const port = readApiPort();
+    if (port !== undefined) {
+      return port;
+    }
+    if (Date.now() >= deadline) {
+      return undefined;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+};

--- a/scripts/start-e2e-server.mjs
+++ b/scripts/start-e2e-server.mjs
@@ -4,10 +4,10 @@
  *
  * This starts the same single Node process the published image runs -- one Hono
  * app serving `/v1` and the dashboard's static build -- rather than the split
- * Vite/wrangler pair behind `pnpm dev`. That split is also why a dev-server
- * suite would not work here: `pnpm dev:api` runs wrangler, and on workerd
- * `@libsql/client` resolves to its HTTP-only build, so the embedded database
- * these tests rely on cannot be opened at all.
+ * Vite/API pair behind `pnpm dev`. That split is also why a dev-server suite
+ * would not work here: under `pnpm dev` it is Vite that answers everything
+ * outside `/v1`, so the static serving, the SPA fallback and the `/v1` 404
+ * boundary these tests cover never execute at all.
  *
  * Storage defaults to a throwaway libSQL file, which is what keeps the suite
  * hermetic: no Postgres, no PostgREST, nothing to orchestrate. Migrations run

--- a/turbo.json
+++ b/turbo.json
@@ -24,7 +24,18 @@
     },
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      // Turborepo 2 filters the environment by default. Without this a
+      // `PORT=... pnpm dev` or `LIBSQL_URL= pnpm dev` is silently ignored and
+      // the task runs with the defaults instead.
+      "passThroughEnv": [
+        "PORT",
+        "LIBSQL_URL",
+        "LIBSQL_AUTH_TOKEN",
+        "ACCESS_PASSWORD",
+        "BEARER_TOKEN",
+        "API_URL"
+      ]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
## Problem

`pnpm dev` required a running Supabase. It could not use the embedded SQLite
database the container ships with, because `dev:api` ran wrangler: a Worker has
no filesystem, so on workerd `@libsql/client` resolves to its HTTP-only build
and rejects a `file:` URL outright.

```
LibsqlError: URL_SCHEME_NOT_SUPPORTED: ... got "file:".
    at createLibsqlClient (packages/api/src/connectors/libsql/client.ts:39)
    at ensureStorageReady (packages/api/src/connectors/index.ts:70)
```

## Solution

Development runs the Node entrypoint — the same `src/server.ts` the published
image runs — against `.local-data/dev.db`, created on the first request. A
fresh clone needs `pnpm install && pnpm dev` and nothing else: no Supabase, no
Docker, no CLI to install. Deleting the file resets the database.

```
pnpm dev             # vite + Node API on SQLite
pnpm dev:api:worker  # the same API on workerd, for the Workers path
LIBSQL_URL= pnpm dev # develop against Supabase instead
```

`packages/api/dev.js` watches through the same esbuild options `build.js` uses,
now shared in `esbuild.config.js` so the two cannot drift — `external:
['libsql']` is not something a dev build can safely omit. A failed build leaves
the previous API serving instead of taking it down.

### The API's port is now chosen at runtime

Only Vite talks to it, so it takes whatever is free and publishes it to
`.local-data/api-port` for the proxy. The old default, 8787, is *Cloudflare's* —
any other Workers project on the same machine collided with it, which is how
this came up.

Two details are load-bearing, both found by hitting them:

- **Ports come from below the ephemeral range.** `listen(0)` draws from
  `ip_local_port_range` (32768–60999 here), the same pool the kernel assigns as
  source ports for outgoing connections — so a port verified free can be taken
  before the server binds it. That surfaced as an intermittent `EADDRINUSE` on
  a port nothing was listening on.
- **The probe binds the same wildcard address the server does.** Probing
  `127.0.0.1` reports free a port held on another address, giving
  `EADDRINUSE ... :::<port>`.

Vite resolves the target per request, so an API restarting on a different port
is followed rather than proxied into a void. That needs `configure`, not
`bypass`: Vite stores `proxies[context] = [proxy, { ...opts }]`, so the object
`bypass` receives is a shallow copy and mutating it has no effect.

### Three fixes fall out of this

- **Turborepo 2 filters the environment**, so `PORT=… pnpm dev` was silently
  ignored and the task ran with defaults. Fixed with `passThroughEnv`.
- **`dev:api` was broken on a fresh clone.** It ran `wrangler dev --env-file
  ../../.dev.vars`, which fails outright when that file is missing — and it is
  gitignored and absent. Wrangler already loads `packages/api/.dev.vars` itself.
- **Stale rationale in the docs.** `e2e/README.md`, `start-e2e-server.mjs` and
  both verify scripts gave wrangler as the reason the e2e suite uses the built
  server. The real reason is that under `pnpm dev` Vite serves the dashboard and
  proxies `/v1` away, so the static serving, SPA fallback and `/v1` 404 boundary
  never execute there.

## Trade-off

Day-to-day development no longer exercises workerd. `verify:worker` in CI
catches bundling and boot, but not a `node:` builtin — unenv stubs it and the
stub throws only when called. `pnpm dev:api:worker` is the way to check that
before merging Workers-path changes, and AGENTS.md and CONTRIBUTING.md now say
so where they previously described workerd as the development runtime.

## Startup output

```
API process on port 25679 (internal; Vite proxies /v1 to it)
Database file:/…/.local-data/dev.db
Internal API Server is running
  VITE v7.3.0  ready in 522 ms
  ➜  Local:   http://localhost:3000/
  ➜  API:      send requests here, e.g. http://localhost:3000/v1/models
```

The request line comes from Vite because it is the only side that knows which
port it took — 3000 may be in use, in which case it moves to 3001 and anything
the API printed would be wrong. Verified on `--port 3007`.

## Test notes

- `pnpm test` — 2527 passed
- `pnpm test:e2e` — 44/44
- `pnpm verify:worker` — bundles and boots
- `pnpm check`, `pnpm typecheck` — clean
- Ran `pnpm dev` repeatedly with an unrelated workerd holding 8787: comes up
  clean each time, `GET`/`POST` through `localhost:3000/v1/…` reach the API,
  a source edit rebuilds and restarts on the same port, a syntax error keeps
  the previous server serving, `PORT=8788 pnpm dev` pins it with the proxy
  following, and the port file is removed on shutdown.
