### PR TITLE
fix(web): hide the log out button when the dashboard has no password

### DIFF
--- a/packages/web/src/components/side-bar/app-sidebar.tsx
+++ b/packages/web/src/components/side-bar/app-sidebar.tsx
@@ -7,7 +7,6 @@ import { NavUser } from '@web/components/side-bar/nav-user';
 import {
   Sidebar,
   SidebarContent,
-  SidebarFooter,
   SidebarHeader,
   SidebarRail,
 } from '@web/components/ui/sidebar';
@@ -34,9 +33,7 @@ export function AppSidebar({
       <SidebarContent>
         <NavMain sections={SideBarData.sections} />
       </SidebarContent>
-      <SidebarFooter>
-        <NavUser />
-      </SidebarFooter>
+      <NavUser />
       <SidebarRail />
     </Sidebar>
   );

--- a/packages/web/src/components/side-bar/nav-user.test.tsx
+++ b/packages/web/src/components/side-bar/nav-user.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NavUser } from '@web/components/side-bar/nav-user';
@@ -5,10 +6,11 @@ import { SidebarProvider } from '@web/providers/side-bar';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Create mock navigate using vi.hoisted
-const { mockNavigate, mockLogout } = vi.hoisted(() => {
+const { mockNavigate, mockLogout, mockGetAuthStatus } = vi.hoisted(() => {
   return {
     mockNavigate: vi.fn(),
     mockLogout: vi.fn(),
+    mockGetAuthStatus: vi.fn(),
   };
 });
 
@@ -28,6 +30,7 @@ vi.mock('@tanstack/react-router', () => ({
 // Mock auth API
 vi.mock('@web/api/v1/super-agents/auth', () => ({
   logout: mockLogout,
+  getAuthStatus: mockGetAuthStatus,
 }));
 
 // Mock window.matchMedia
@@ -46,33 +49,47 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 describe('NavUser', () => {
+  let queryClient: QueryClient;
+
+  function renderNavUser(): void {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SidebarProvider>
+          <NavUser />
+        </SidebarProvider>
+      </QueryClientProvider>,
+    );
+  }
+
+  /** The button only exists once the auth status has arrived. */
+  function findLogoutButton(): Promise<HTMLElement> {
+    return screen.findByRole('button', { name: /log out/i });
+  }
+
   beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     vi.clearAllMocks();
+    mockGetAuthStatus.mockResolvedValue({
+      authRequired: true,
+      authenticated: true,
+    });
   });
 
-  it('should render logout button', () => {
-    render(
-      <SidebarProvider>
-        <NavUser />
-      </SidebarProvider>,
-    );
+  it('should render logout button', async () => {
+    renderNavUser();
 
-    const button = screen.getByRole('button', { name: /log out/i });
-    expect(button).toBeInTheDocument();
+    expect(await findLogoutButton()).toBeInTheDocument();
   });
 
   it('should call logout when button is clicked', async () => {
     const user = userEvent.setup();
     mockLogout.mockResolvedValueOnce(true);
 
-    render(
-      <SidebarProvider>
-        <NavUser />
-      </SidebarProvider>,
-    );
+    renderNavUser();
 
-    const button = screen.getByRole('button', { name: /log out/i });
-    await user.click(button);
+    await user.click(await findLogoutButton());
 
     expect(mockLogout).toHaveBeenCalled();
   });
@@ -81,14 +98,9 @@ describe('NavUser', () => {
     const user = userEvent.setup();
     mockLogout.mockResolvedValueOnce(true);
 
-    render(
-      <SidebarProvider>
-        <NavUser />
-      </SidebarProvider>,
-    );
+    renderNavUser();
 
-    const button = screen.getByRole('button', { name: /log out/i });
-    await user.click(button);
+    await user.click(await findLogoutButton());
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: '/login' });
@@ -99,17 +111,44 @@ describe('NavUser', () => {
     const user = userEvent.setup();
     mockLogout.mockResolvedValueOnce(false);
 
-    render(
-      <SidebarProvider>
-        <NavUser />
-      </SidebarProvider>,
-    );
+    renderNavUser();
 
-    const button = screen.getByRole('button', { name: /log out/i });
-    await user.click(button);
+    await user.click(await findLogoutButton());
 
     // Wait a bit to ensure no redirect happens
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  // Without ACCESS_PASSWORD there is no session: `/login` would redirect
+  // straight back here, so the button would look like it did nothing.
+  it('renders nothing when the server does not require authentication', async () => {
+    mockGetAuthStatus.mockResolvedValue({
+      authRequired: false,
+      authenticated: true,
+    });
+
+    renderNavUser();
+
+    await waitFor(() => {
+      expect(mockGetAuthStatus).toHaveBeenCalled();
+    });
+    expect(
+      screen.queryByRole('button', { name: /log out/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders nothing while the auth status is unknown', () => {
+    mockGetAuthStatus.mockReturnValue(
+      new Promise(() => {
+        // Never resolves - the status is still in flight
+      }),
+    );
+
+    renderNavUser();
+
+    expect(
+      screen.queryByRole('button', { name: /log out/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/side-bar/nav-user.tsx
+++ b/packages/web/src/components/side-bar/nav-user.tsx
@@ -2,15 +2,26 @@
 
 import { logout } from '@web/api/v1/super-agents/auth';
 import {
+  SidebarFooter,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@web/components/ui/sidebar';
+import { useAuthStatus } from '@web/hooks/use-auth-status';
 import { usePermissiveNavigate } from '@web/hooks/use-permissive-navigate';
 import { LogOut } from 'lucide-react';
 
-export function NavUser(): React.ReactElement {
+/**
+ * The sidebar footer, which offers to log out.
+ *
+ * It renders nothing when the server has no ACCESS_PASSWORD set. There is no
+ * session to end then, and `/login` redirects an arriving visitor back to the
+ * dashboard, so the button would swallow the click and appear broken.
+ */
+export function NavUser(): React.ReactElement | null {
   const navigate = usePermissiveNavigate();
+  const authStatus = useAuthStatus();
+
   async function signOut(): Promise<void> {
     const success = await logout();
     if (success) {
@@ -18,14 +29,20 @@ export function NavUser(): React.ReactElement {
     }
   }
 
+  if (!authStatus?.authRequired) {
+    return null;
+  }
+
   return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <SidebarMenuButton onClick={(): Promise<void> => signOut()}>
-          <LogOut />
-          Log Out
-        </SidebarMenuButton>
-      </SidebarMenuItem>
-    </SidebarMenu>
+    <SidebarFooter>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton onClick={(): Promise<void> => signOut()}>
+            <LogOut />
+            Log Out
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarFooter>
   );
 }

--- a/packages/web/src/hooks/use-auth-status.test.tsx
+++ b/packages/web/src/hooks/use-auth-status.test.tsx
@@ -1,0 +1,77 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@web/api/v1/super-agents/auth', () => ({
+  getAuthStatus: vi.fn(),
+}));
+
+import { getAuthStatus } from '@web/api/v1/super-agents/auth';
+import { useAuthStatus } from '@web/hooks/use-auth-status';
+
+const mockGetAuthStatus = vi.mocked(getAuthStatus);
+
+describe('useAuthStatus', () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    return ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.clearAllMocks();
+  });
+
+  it('is null until the status arrives', () => {
+    mockGetAuthStatus.mockReturnValue(
+      new Promise(() => {
+        // Never resolves - the status is still in flight
+      }),
+    );
+
+    const { result } = renderHook(() => useAuthStatus(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns the status the server reported', async () => {
+    mockGetAuthStatus.mockResolvedValue({
+      authRequired: true,
+      authenticated: false,
+    });
+
+    const { result } = renderHook(() => useAuthStatus(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        authRequired: true,
+        authenticated: false,
+      });
+    });
+  });
+
+  // The status endpoint is how the dashboard learns whether a session exists,
+  // so an unreachable server has to read as "unknown", not as "no auth".
+  it('is null when the server could not be reached', async () => {
+    mockGetAuthStatus.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAuthStatus(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(mockGetAuthStatus).toHaveBeenCalled();
+    });
+    expect(result.current).toBeNull();
+  });
+});

--- a/packages/web/src/hooks/use-auth-status.ts
+++ b/packages/web/src/hooks/use-auth-status.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { type AuthStatus, getAuthStatus } from '@web/api/v1/super-agents/auth';
+
+export const authStatusQueryKeys = {
+  all: ['auth-status'] as const,
+  detail: () => [...authStatusQueryKeys.all, 'detail'] as const,
+};
+
+/**
+ * The dashboard's authentication status, or null while it loads and whenever
+ * the server could not be reached.
+ *
+ * `authRequired` is false when the server has no ACCESS_PASSWORD set. Nothing
+ * that offers to end a session should render in that case: there is no session
+ * to end, and `/login` sends an arriving visitor straight back to the
+ * dashboard.
+ */
+export function useAuthStatus(): AuthStatus | null {
+  const { data = null } = useQuery({
+    queryKey: authStatusQueryKeys.detail(),
+    queryFn: getAuthStatus,
+  });
+
+  return data;
+}


### PR DESCRIPTION
## Problem

The sidebar's **Log Out** button appears to do nothing.

It is not broken so much as pointless. Without `ACCESS_PASSWORD` set, the server reports that no session exists:

```
$ curl localhost:3000/v1/super-agents/auth/status
{"authRequired":false,"authenticated":true}
```

So a click runs `POST /v1/super-agents/auth/logout` (200, clearing a cookie that was never set), then navigates to `/login` — where `login.tsx`'s `beforeLoad` sees `authRequired: false` and immediately redirects back to `/agents`. You land exactly where you started, with nothing to show for the click.

The server half is correct and already covered by `packages/api/src/v1/super-agents/auth.test.ts`; the bug is that the dashboard offers a control that cannot do anything.

## Solution

Ask the server whether a session exists, and render the control only when one can be ended.

- **`hooks/use-auth-status.ts`** (new) — a react-query wrapper over `getAuthStatus()`. It returns `null` while the status is in flight *and* when the server could not be reached, so an unreachable server reads as "unknown" rather than "no auth".
- **`side-bar/nav-user.tsx`** — returns `null` unless `authRequired`. It now owns the `SidebarFooter` too, so a sidebar with nothing to log out of is not left with an empty, padded footer.
- **`side-bar/app-sidebar.tsx`** — renders `<NavUser />` directly instead of wrapping it in a footer.

With `ACCESS_PASSWORD` set the button is unchanged: it logs out and lands on the login page.

## Test notes

- `nav-user.test.tsx` gains the case that reproduces the report — auth not required, so nothing renders — plus one for the in-flight status. The existing four cases now resolve the status first.
- `use-auth-status.test.tsx` (new) covers loading, a reported status, and an unreachable server.
- `pnpm typecheck`, `pnpm check`, and the affected suites (nav-user, use-auth-status, side-bar, route guards — 85 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVSSLPbMonQLiD5LQPfdC8
