### PR TITLE
fix(web): self-host the dashboard fonts, and actually apply them

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -1,16 +1,10 @@
 <!doctype html>
-<html lang="en" class="font-lato antialiased">
+<html lang="en" class="antialiased">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Super Agents</title>
     <meta name="description" content="AI management without existing knowledge" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Lato:wght@100;300;400;700;900&family=Ubuntu:wght@500&display=swap"
-      rel="stylesheet"
-    />
   </head>
   <body class="flex flex-col overflow-hidden overscroll-none w-screen h-screen">
     <div id="root" class="h-full w-full"></div>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@dicebear/collection": "^9.2.4",
     "@dicebear/core": "^9.2.4",
+    "@fontsource/lato": "^5.3.0",
+    "@fontsource/ubuntu": "^5.3.0",
     "@hookform/resolvers": "^5.2.1",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -9,6 +9,19 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { routeTree } from './routeTree.gen';
 
+// Self-hosted so the dashboard renders correctly with no network access and
+// makes no third-party request. Only the weights the app asks for are here:
+// Lato 300/400/700/900 for body text (`font-medium` and `font-semibold` have
+// no Lato cut, and match to 400 and 700 respectively), and Ubuntu 400/700 for
+// the logo, whose text is `font-bold`.
+import '@fontsource/lato/300.css';
+import '@fontsource/lato/400.css';
+import '@fontsource/lato/700.css';
+import '@fontsource/lato/900.css';
+// Latin only: the logo is the only thing set in Ubuntu, and it reads
+// "Super Agents".
+import '@fontsource/ubuntu/latin-400.css';
+import '@fontsource/ubuntu/latin-700.css';
 import '@web/styles/globals.css';
 import '@web/styles/editor.css';
 

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -202,6 +202,9 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    font-family: var(--font-lato);
+  }
   body {
     @apply bg-background text-foreground;
   }
@@ -217,6 +220,14 @@
 */
 
 :root {
+  /*
+    The families `tailwind.config.ts` names as `font-editor` and `font-logo`,
+    and the one applied to `html` above. Loaded from `@fontsource` in
+    `main.tsx`, so the fallbacks only apply before the files arrive.
+  */
+  --font-lato: "Lato", ui-sans-serif, system-ui, sans-serif;
+  --font-ubuntu: "Ubuntu", ui-sans-serif, system-ui, sans-serif;
+
   --radius: 0.625rem;
   --background: oklch(1 0 0); /* White */
   --foreground: oklch(0.147 0.004 49.25); /* Stone 950 */

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -86,6 +86,15 @@ export default defineConfig({
   build: {
     // TipTap rich text editor is ~515KB - this is expected for a full-featured editor
     chunkSizeWarningLimit: 520,
+    /**
+     * Never inline a font. `@fontsource` ships a WOFF1 fallback beside every
+     * WOFF2, and the small ones fall under the default 4KB limit -- which put
+     * 20KB of base64 into the render-blocking stylesheet for a format no
+     * browser this app supports has needed since 2016. Emitted as files they
+     * are simply never fetched.
+     */
+    assetsInlineLimit: (filePath: string) =>
+      /\.(woff2?|ttf|otf|eot)$/.test(filePath) ? false : undefined,
     rollupOptions: {
       output: {
         manualChunks: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,6 +444,12 @@ importers:
       '@dicebear/core':
         specifier: ^9.2.4
         version: 9.2.4
+      '@fontsource/lato':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/ubuntu':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@hookform/resolvers':
         specifier: ^5.2.1
         version: 5.2.2(react-hook-form@7.69.0(react@19.2.3))
@@ -1526,6 +1532,12 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@fontsource/lato@5.3.0':
+    resolution: {integrity: sha512-0WhF/4rhrw+ErIyneKvhHn2YAl+xf8GDtllgOgOzDmeaSlLQtjpChXaQOpWhG2BchQW0WJy2zLV12Hdg0ndOMw==}
+
+  '@fontsource/ubuntu@5.3.0':
+    resolution: {integrity: sha512-LsjJXgE430QLs8LKfn1RIFbbdGAiZBU1gao8ASa4Z2kGNGh7lMb7Rzx09v3bLLuuK+3XA/JSLgPWTAbLD6r1fg==}
 
   '@hono/node-server@1.19.7':
     resolution: {integrity: sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==}
@@ -5965,6 +5977,10 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@fontsource/lato@5.3.0': {}
+
+  '@fontsource/ubuntu@5.3.0': {}
 
   '@hono/node-server@1.19.7(hono@4.11.3)':
     dependencies:


### PR DESCRIPTION
## Problem

The dashboard requested Lato and Ubuntu from Google Fonts on every page load, and rendered in neither. Three things had to line up, and none did:

1. `tailwind.config.ts:167-168` maps `font-editor` → `var(--font-lato)` and `font-logo` → `var(--font-ubuntu)`, but **neither variable was declared anywhere** — not in `globals.css`, not injected at runtime. Both utilities resolved to an invalid value and inherited.
2. `<html class="font-lato">` was **not a real utility**. The config has no `lato` key, so Tailwind generated no `.font-lato` rule. The built CSS contained `.font-editor` and `.font-logo` and nothing for `font-lato`.
3. The only Ubuntu weight the `<link>` requested was 500, but the sole text set in Ubuntu is the logo, which is `font-bold` (700).

Net effect: every visitor downloaded two font families and got Tailwind preflight's `ui-sans-serif, system-ui` stack.

The production cost is the part that matters. The single-container image exists so people can self-host, and it made a third-party request per page load — leaking every dashboard visitor's IP to Google, for fonts with no visual effect, and blocking on a timeout wherever the host has no route out.

## Solution

- Load both families from `@fontsource` and drop the `preconnect`/stylesheet tags.
- Declare `--font-lato` / `--font-ubuntu` — the variables the Tailwind config already pointed at — and set the family on `html` in the base layer.
- Ship only the weights the app renders: **Lato 300/400/700/900**, **Ubuntu 400/700 (latin only)**, since the logo reads "Super Agents" and nothing else uses it.
- Exclude fonts from Vite asset inlining.

Two judgment calls worth review:

**Weights.** Lato has no 500 or 600 cut, so the 139 `font-medium` and 49 `font-semibold` usages match down to 400 and up to 700 respectively. That's CSS font matching doing the right thing rather than synthetic bolding — but this is the first time Lato has ever actually applied, so the dashboard's text does change appearance.

**Inlining.** `@fontsource` ships a WOFF1 fallback beside every WOFF2, and the small ones fell under Vite's default 4KB limit — putting 20KB of base64 into the render-blocking stylesheet for a format nothing has needed since 2016. Excluding fonts takes the CSS from **54.1KB → 38.4KB gzipped**. Font files total 196KB on disk; a page fetches three.

## Test notes

`pnpm typecheck`, `pnpm check`, and `pnpm test` (2532 passed, 13 skipped) all green.

The original bug was a stylesheet that read correctly but applied to nothing, so this was verified against the **built bundle in a real browser** rather than by inspecting CSS:

```
htmlFontFamily:  "Lato, ui-sans-serif, system-ui, sans-serif"
bodyFontFamily:  "Lato, ui-sans-serif, system-ui, sans-serif"
logoFamily:      "Ubuntu, ui-sans-serif, system-ui, sans-serif"   (weight 700)
loadedFaces:     ["Lato 400", "Lato 700", "Ubuntu 700"]
fontRequests:    3 files
googleRequests:  []
```

The three-file fetch confirms the weight and `unicode-range` matching works — 300, 900 and the `latin-ext` subsets ship but are not downloaded unless a page needs them.

## Not addressed

`font-title` and `font-default` (`text-viewer.tsx:22`, `jinja-system-prompt-editor.tsx:33`) are dead in the same way — undefined in the Tailwind config, generating no CSS. Fixing them means deciding what a "title" font should be, which is a design call rather than a repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e2oi9XTqtsERBj7bHVru2
