### PR TITLE
fix(web): restore the skill setup route dropped in the router migration

### DIFF
--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as MainAgentsAgentNameEditRouteImport } from './routes/_main/agen
 import { Route as MainAgentsAgentNameSkillsCreateRouteImport } from './routes/_main/agents.$agentName.skills.create'
 import { Route as MainAgentsAgentNameSkillsSkillNameRouteImport } from './routes/_main/agents.$agentName.skills.$skillName'
 import { Route as MainAgentsAgentNameSkillsSkillNameIndexRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.index'
+import { Route as MainAgentsAgentNameSkillsSkillNameSetupRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.setup'
 import { Route as MainAgentsAgentNameSkillsSkillNameLogsRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.logs'
 import { Route as MainAgentsAgentNameSkillsSkillNameEventsRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.events'
 import { Route as MainAgentsAgentNameSkillsSkillNameEvaluationsRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.evaluations'
@@ -155,6 +156,16 @@ const MainAgentsAgentNameSkillsSkillNameIndexRoute =
     getParentRoute: () => MainAgentsAgentNameSkillsSkillNameRoute,
   } as any).lazy(() =>
     import('./routes/_main/agents.$agentName.skills.$skillName.index.lazy').then(
+      (d) => d.Route,
+    ),
+  )
+const MainAgentsAgentNameSkillsSkillNameSetupRoute =
+  MainAgentsAgentNameSkillsSkillNameSetupRouteImport.update({
+    id: '/setup',
+    path: '/setup',
+    getParentRoute: () => MainAgentsAgentNameSkillsSkillNameRoute,
+  } as any).lazy(() =>
+    import('./routes/_main/agents.$agentName.skills.$skillName.setup.lazy').then(
       (d) => d.Route,
     ),
   )
@@ -294,6 +305,7 @@ export interface FileRoutesByFullPath {
   '/agents/$agentName/skills/$skillName/evaluations': typeof MainAgentsAgentNameSkillsSkillNameEvaluationsRouteWithChildren
   '/agents/$agentName/skills/$skillName/events': typeof MainAgentsAgentNameSkillsSkillNameEventsRoute
   '/agents/$agentName/skills/$skillName/logs': typeof MainAgentsAgentNameSkillsSkillNameLogsRouteWithChildren
+  '/agents/$agentName/skills/$skillName/setup': typeof MainAgentsAgentNameSkillsSkillNameSetupRoute
   '/agents/$agentName/skills/$skillName/': typeof MainAgentsAgentNameSkillsSkillNameIndexRoute
   '/agents/$agentName/skills/$skillName/clusters/$clusterId': typeof MainAgentsAgentNameSkillsSkillNameClustersClusterIdRouteWithChildren
   '/agents/$agentName/skills/$skillName/logs/$logId': typeof MainAgentsAgentNameSkillsSkillNameLogsLogIdRoute
@@ -320,6 +332,7 @@ export interface FileRoutesByTo {
   '/agents/$agentName/skills/create': typeof MainAgentsAgentNameSkillsCreateRoute
   '/agents/$agentName/skills/$skillName/edit': typeof MainAgentsAgentNameSkillsSkillNameEditRoute
   '/agents/$agentName/skills/$skillName/events': typeof MainAgentsAgentNameSkillsSkillNameEventsRoute
+  '/agents/$agentName/skills/$skillName/setup': typeof MainAgentsAgentNameSkillsSkillNameSetupRoute
   '/agents/$agentName/skills/$skillName': typeof MainAgentsAgentNameSkillsSkillNameIndexRoute
   '/agents/$agentName/skills/$skillName/clusters/$clusterId': typeof MainAgentsAgentNameSkillsSkillNameClustersClusterIdRouteWithChildren
   '/agents/$agentName/skills/$skillName/logs/$logId': typeof MainAgentsAgentNameSkillsSkillNameLogsLogIdRoute
@@ -351,6 +364,7 @@ export interface FileRoutesById {
   '/_main/agents/$agentName/skills/$skillName/evaluations': typeof MainAgentsAgentNameSkillsSkillNameEvaluationsRouteWithChildren
   '/_main/agents/$agentName/skills/$skillName/events': typeof MainAgentsAgentNameSkillsSkillNameEventsRoute
   '/_main/agents/$agentName/skills/$skillName/logs': typeof MainAgentsAgentNameSkillsSkillNameLogsRouteWithChildren
+  '/_main/agents/$agentName/skills/$skillName/setup': typeof MainAgentsAgentNameSkillsSkillNameSetupRoute
   '/_main/agents/$agentName/skills/$skillName/': typeof MainAgentsAgentNameSkillsSkillNameIndexRoute
   '/_main/agents/$agentName/skills/$skillName/clusters/$clusterId': typeof MainAgentsAgentNameSkillsSkillNameClustersClusterIdRouteWithChildren
   '/_main/agents/$agentName/skills/$skillName/logs/$logId': typeof MainAgentsAgentNameSkillsSkillNameLogsLogIdRoute
@@ -383,6 +397,7 @@ export interface FileRouteTypes {
     | '/agents/$agentName/skills/$skillName/evaluations'
     | '/agents/$agentName/skills/$skillName/events'
     | '/agents/$agentName/skills/$skillName/logs'
+    | '/agents/$agentName/skills/$skillName/setup'
     | '/agents/$agentName/skills/$skillName/'
     | '/agents/$agentName/skills/$skillName/clusters/$clusterId'
     | '/agents/$agentName/skills/$skillName/logs/$logId'
@@ -409,6 +424,7 @@ export interface FileRouteTypes {
     | '/agents/$agentName/skills/create'
     | '/agents/$agentName/skills/$skillName/edit'
     | '/agents/$agentName/skills/$skillName/events'
+    | '/agents/$agentName/skills/$skillName/setup'
     | '/agents/$agentName/skills/$skillName'
     | '/agents/$agentName/skills/$skillName/clusters/$clusterId'
     | '/agents/$agentName/skills/$skillName/logs/$logId'
@@ -439,6 +455,7 @@ export interface FileRouteTypes {
     | '/_main/agents/$agentName/skills/$skillName/evaluations'
     | '/_main/agents/$agentName/skills/$skillName/events'
     | '/_main/agents/$agentName/skills/$skillName/logs'
+    | '/_main/agents/$agentName/skills/$skillName/setup'
     | '/_main/agents/$agentName/skills/$skillName/'
     | '/_main/agents/$agentName/skills/$skillName/clusters/$clusterId'
     | '/_main/agents/$agentName/skills/$skillName/logs/$logId'
@@ -575,6 +592,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/agents/$agentName/skills/$skillName/'
       preLoaderRoute: typeof MainAgentsAgentNameSkillsSkillNameIndexRouteImport
+      parentRoute: typeof MainAgentsAgentNameSkillsSkillNameRoute
+    }
+    '/_main/agents/$agentName/skills/$skillName/setup': {
+      id: '/_main/agents/$agentName/skills/$skillName/setup'
+      path: '/setup'
+      fullPath: '/agents/$agentName/skills/$skillName/setup'
+      preLoaderRoute: typeof MainAgentsAgentNameSkillsSkillNameSetupRouteImport
       parentRoute: typeof MainAgentsAgentNameSkillsSkillNameRoute
     }
     '/_main/agents/$agentName/skills/$skillName/logs': {
@@ -738,6 +762,7 @@ interface MainAgentsAgentNameSkillsSkillNameRouteChildren {
   MainAgentsAgentNameSkillsSkillNameEvaluationsRoute: typeof MainAgentsAgentNameSkillsSkillNameEvaluationsRouteWithChildren
   MainAgentsAgentNameSkillsSkillNameEventsRoute: typeof MainAgentsAgentNameSkillsSkillNameEventsRoute
   MainAgentsAgentNameSkillsSkillNameLogsRoute: typeof MainAgentsAgentNameSkillsSkillNameLogsRouteWithChildren
+  MainAgentsAgentNameSkillsSkillNameSetupRoute: typeof MainAgentsAgentNameSkillsSkillNameSetupRoute
   MainAgentsAgentNameSkillsSkillNameIndexRoute: typeof MainAgentsAgentNameSkillsSkillNameIndexRoute
   MainAgentsAgentNameSkillsSkillNameClustersClusterIdRoute: typeof MainAgentsAgentNameSkillsSkillNameClustersClusterIdRouteWithChildren
 }
@@ -752,6 +777,8 @@ const MainAgentsAgentNameSkillsSkillNameRouteChildren: MainAgentsAgentNameSkills
       MainAgentsAgentNameSkillsSkillNameEventsRoute,
     MainAgentsAgentNameSkillsSkillNameLogsRoute:
       MainAgentsAgentNameSkillsSkillNameLogsRouteWithChildren,
+    MainAgentsAgentNameSkillsSkillNameSetupRoute:
+      MainAgentsAgentNameSkillsSkillNameSetupRoute,
     MainAgentsAgentNameSkillsSkillNameIndexRoute:
       MainAgentsAgentNameSkillsSkillNameIndexRoute,
     MainAgentsAgentNameSkillsSkillNameClustersClusterIdRoute:

--- a/packages/web/src/routes/__tests__/route-registry.test.ts
+++ b/packages/web/src/routes/__tests__/route-registry.test.ts
@@ -24,6 +24,7 @@ const EXPECTED_ROUTE_IDS = [
   '/_main/agents/$agentName/skills/$skillName',
   '/_main/agents/$agentName/skills/$skillName/',
   '/_main/agents/$agentName/skills/$skillName/edit',
+  '/_main/agents/$agentName/skills/$skillName/setup',
   '/_main/agents/$agentName/skills/$skillName/logs',
   '/_main/agents/$agentName/skills/$skillName/logs/',
   '/_main/agents/$agentName/skills/$skillName/logs/$logId',

--- a/packages/web/src/routes/__tests__/route-rendering.test.tsx
+++ b/packages/web/src/routes/__tests__/route-rendering.test.tsx
@@ -75,6 +75,10 @@ vi.mock('@web/components/agents/skills/edit-skill-view', () => ({
   EditSkillView: () => <div data-testid="page-skill-edit" />,
 }));
 
+vi.mock('@web/components/agents/skills/create-skill-complete-view', () => ({
+  CreateSkillCompleteView: () => <div data-testid="page-skill-setup" />,
+}));
+
 vi.mock('@web/components/agents/skills/logs/logs-view', () => ({
   LogsView: () => <div data-testid="page-skill-logs" />,
 }));
@@ -193,6 +197,11 @@ const ROUTE_TABLE: [string, string, string][] = [
     'edit skill',
     '/agents/test-agent/skills/test-skill/edit',
     'page-skill-edit',
+  ],
+  [
+    'skill setup',
+    '/agents/test-agent/skills/test-skill/setup',
+    'page-skill-setup',
   ],
   [
     'skill logs',

--- a/packages/web/src/routes/_main/agents.$agentName.skills.$skillName.setup.lazy.tsx
+++ b/packages/web/src/routes/_main/agents.$agentName.skills.$skillName.setup.lazy.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { createLazyFileRoute } from '@tanstack/react-router';
+import { CreateSkillCompleteView } from '@web/components/agents/skills/create-skill-complete-view';
+
+export const Route = createLazyFileRoute(
+  '/_main/agents/$agentName/skills/$skillName/setup',
+)({
+  component: CreateSkillCompleteView,
+});

--- a/packages/web/src/routes/_main/agents.$agentName.skills.$skillName.setup.tsx
+++ b/packages/web/src/routes/_main/agents.$agentName.skills.$skillName.setup.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute(
+  '/_main/agents/$agentName/skills/$skillName/setup',
+)({});


### PR DESCRIPTION
## Problem

Creating a skill lands on a **Not Found** page.

`create-skill-view.tsx:195` navigates to `/agents/$agentName/skills/$skillName/setup` after a successful create, but no such route exists. The TanStack Router migration (#203) ported every route from the old Next.js app except `app/(main)/agents/[agentName]/skills/[skillName]/setup/page.tsx`. The component that page rendered, `CreateSkillCompleteView`, survived the migration with nothing routing to it.

So the setup step — where you pick the skill's models and evaluations right after creating it — has been unreachable since #203, whether you follow the post-create redirect or type the URL:

```
http://localhost:3000/agents/<agent>/skills/<skill>/setup   →   Not Found
```

## Solution

Add the missing route pair, shaped like its `edit` sibling:

- `agents.$agentName.skills.$skillName.setup.tsx`
- `agents.$agentName.skills.$skillName.setup.lazy.tsx` → `CreateSkillCompleteView`

`selectedSkill` resolves from the URL param through the navigation provider, so visiting the URL directly renders the page rather than falling into its "No skill selected" branch. `routeTree.gen.ts` is regenerated.

## Why nothing caught it

`create-skill-view.test.tsx`'s "navigates to setup page after successful skill creation" asserts on a `navigate` mock that the test itself calls, so it passes against a route that does not exist. The route registry only checks routes that do exist.

The route now joins `EXPECTED_ROUTE_IDS` in `route-registry.test.ts` and the `ROUTE_TABLE` in `route-rendering.test.tsx`, so dropping it again fails the suite.

## Test notes

`pnpm typecheck`, `pnpm check`, and `pnpm test packages/web/src/routes/__tests__` (58 tests) all pass. Not yet exercised against the running dev server — worth a manual pass through create-skill → setup before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfS92jFQtr5LNk5y3U1Nud
