### PR TITLE
fix(api): let keyless providers serve the internal skills

### DIFF
--- a/packages/api/src/ai-providers/index.ts
+++ b/packages/api/src/ai-providers/index.ts
@@ -87,3 +87,17 @@ export const providerConfigs: {
   [AIProvider.XAI]: xaiConfig,
   [AIProvider.ZHIPU]: undefined,
 };
+
+/**
+ * Whether a provider needs an API key before it can be called.
+ *
+ * Self-hosted providers carry no key -- Ollama sets `isAPIKeyRequired: false`
+ * -- so treating a missing key as a misconfiguration would make every internal
+ * skill call refuse to run against them. Providers we have no config for are
+ * assumed to need one, matching what `/v1/super-agents/ai-providers/schemas`
+ * reports to the dashboard.
+ */
+export function isAPIKeyRequiredForProvider(provider: string): boolean {
+  const config = providerConfigs[provider as AIProvider];
+  return config?.api.isAPIKeyRequired ?? true;
+}

--- a/packages/api/src/connectors/evaluations/llm-judge.test.ts
+++ b/packages/api/src/connectors/evaluations/llm-judge.test.ts
@@ -149,6 +149,35 @@ describe('LLM Judge', () => {
     });
   });
 
+  it('should evaluate against a provider that needs no API key', async () => {
+    const ollamaJudge = createLLMJudge(
+      mockContext,
+      {},
+      {
+        model: 'qwen3.8b27b',
+        provider: AIProvider.OLLAMA,
+        customHost: 'http://localhost:11434',
+      },
+    );
+
+    mockParse.mockResolvedValueOnce({
+      choices: [{ message: { parsed: { score: 0.9, reasoning: 'Good' } } }],
+    });
+
+    const result = await ollamaJudge.evaluate({
+      text: 'This is a test evaluation.',
+    });
+
+    expect(result.score).toBe(0.9);
+    expect(result.metadata).toBeUndefined();
+
+    const config = JSON.parse(
+      vi.mocked(mockWithOptions).mock.calls[0][0].defaultHeaders['sa-config'],
+    );
+    expect(config.targets[0]).not.toHaveProperty('api_key');
+    expect(config.targets[0].custom_host).toBe('http://localhost:11434');
+  });
+
   it('should handle API errors gracefully', async () => {
     mockParse.mockRejectedValue(
       new Error('OpenAI API error: 500 Internal Server Error - API Error'),

--- a/packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts
@@ -66,7 +66,12 @@ export async function extractTaskAndOutcome(
       {
         provider: modelConfig.provider,
         model: modelConfig.model,
-        api_key: modelConfig.apiKey,
+        ...(modelConfig.apiKey ? { api_key: modelConfig.apiKey } : {}),
+        // Same reason as the other internal skills: without this a self-hosted
+        // provider is sent to its vendor default.
+        ...(modelConfig.customHost
+          ? { custom_host: modelConfig.customHost }
+          : {}),
       },
     ],
     agent_name: 'super-agents',

--- a/packages/api/src/evaluations/llm-judge.ts
+++ b/packages/api/src/evaluations/llm-judge.ts
@@ -1,3 +1,4 @@
+import { isAPIKeyRequiredForProvider } from '@api/ai-providers';
 import { getApiUrl } from '@api/constants';
 import {
   evaluationCriteria,
@@ -115,7 +116,8 @@ const EvaluationResultSchema = z.object({
 export interface LLMJudgeModelConfig {
   model: string;
   provider: AIProvider;
-  apiKey: string;
+  /** The provider's API key, where it needs one. */
+  apiKey?: string;
   /** The provider's configured base URL, where it has one. */
   customHost?: string;
 }
@@ -201,7 +203,9 @@ Provide a score between 0 and 1 with detailed reasoning for your evaluation.`;
    * Core evaluation method using OpenAI library
    */
   async function evaluate(input: EvaluationInput): Promise<LLMJudgeResult> {
-    if (!apiKey || apiKey.trim() === '') {
+    // Self-hosted providers such as Ollama are called without a key, so only
+    // the providers that need one are held to it.
+    if (apiKey.trim() === '' && isAPIKeyRequiredForProvider(provider)) {
       warn('[LLM_JUDGE] API key not configured for evaluation model');
       return getFallbackResult('no_api_key', undefined, {
         retryCount: 0,
@@ -217,7 +221,7 @@ Provide a score between 0 and 1 with detailed reasoning for your evaluation.`;
           cache: {
             mode: CacheMode.SIMPLE,
           },
-          api_key: apiKey,
+          ...(apiKey ? { api_key: apiKey } : {}),
           ...(customHost ? { custom_host: customHost } : {}),
         },
       ],

--- a/packages/api/src/optimization/utils/evaluations.ts
+++ b/packages/api/src/optimization/utils/evaluations.ts
@@ -128,7 +128,7 @@ export async function generateEvaluationCreateParams(
       {
         provider: modelConfig.provider,
         model: modelConfig.model,
-        api_key: modelConfig.apiKey,
+        ...(modelConfig.apiKey ? { api_key: modelConfig.apiKey } : {}),
         ...(modelConfig.customHost
           ? { custom_host: modelConfig.customHost }
           : {}),

--- a/packages/api/src/optimization/utils/system-prompt.ts
+++ b/packages/api/src/optimization/utils/system-prompt.ts
@@ -103,7 +103,7 @@ async function createSystemPromptClient(
       {
         provider: modelConfig.provider,
         model: modelConfig.model,
-        api_key: modelConfig.apiKey,
+        ...(modelConfig.apiKey ? { api_key: modelConfig.apiKey } : {}),
         ...(modelConfig.customHost
           ? { custom_host: modelConfig.customHost }
           : {}),

--- a/packages/api/src/utils/embeddings.ts
+++ b/packages/api/src/utils/embeddings.ts
@@ -1,3 +1,4 @@
+import { isAPIKeyRequiredForProvider } from '@api/ai-providers';
 import { getApiUrl, getBearerToken } from '@api/constants';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
@@ -223,7 +224,12 @@ export async function generateEmbeddingForRequest(
   }
   const providerConfig = providers[0];
 
-  if (!providerConfig.api_key) {
+  // Self-hosted providers such as Ollama are configured without a key, so only
+  // the providers that need one are held to it.
+  if (
+    !providerConfig.api_key &&
+    isAPIKeyRequiredForProvider(providerConfig.ai_provider)
+  ) {
     warn(
       `[EMBEDDING] No API key configured for provider: ${embeddingConfig.model.ai_provider_id}`,
     );
@@ -247,7 +253,9 @@ export async function generateEmbeddingForRequest(
         {
           provider: providerConfig.ai_provider,
           model: embeddingConfig.model.model_name,
-          api_key: providerConfig.api_key,
+          ...(providerConfig.api_key
+            ? { api_key: providerConfig.api_key }
+            : {}),
           // Same reason as the other internal skills: without this a
           // self-hosted embedding provider is sent to its vendor default.
           ...(providerConfig.custom_fields?.custom_host

--- a/packages/api/src/utils/evaluation-model-resolver.test.ts
+++ b/packages/api/src/utils/evaluation-model-resolver.test.ts
@@ -237,6 +237,37 @@ describe('Evaluation Model Resolver', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should resolve a keyless provider that needs no API key', async () => {
+      vi.mocked(mockConnector.getSystemSettings).mockResolvedValue(
+        mockSystemSettings,
+      );
+      vi.mocked(mockConnector.getModels).mockResolvedValue([
+        { ...mockModel, model_name: 'qwen3.8b27b' },
+      ]);
+      vi.mocked(mockConnector.getAIProviderAPIKeys).mockResolvedValue([
+        {
+          ...mockProvider,
+          ai_provider: 'ollama',
+          name: 'Ollama',
+          api_key: null,
+          custom_fields: { custom_host: 'http://localhost:11434' },
+        },
+      ]);
+
+      const result = await resolveSystemSettingsModel(
+        mockContext,
+        'evaluation_generation',
+        mockConnector,
+      );
+
+      expect(result).toEqual({
+        model: 'qwen3.8b27b',
+        provider: 'ollama',
+        apiKey: undefined,
+        customHost: 'http://localhost:11434',
+      });
+    });
   });
 
   describe('resolveEvaluationModelConfig', () => {

--- a/packages/api/src/utils/evaluation-model-resolver.ts
+++ b/packages/api/src/utils/evaluation-model-resolver.ts
@@ -1,3 +1,4 @@
+import { isAPIKeyRequiredForProvider } from '@api/ai-providers';
 import type { LLMJudgeModelConfig } from '@api/evaluations/llm-judge';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
@@ -11,7 +12,11 @@ import type { Model, SkillOptimizationEvaluation } from '@shared/types/data';
 export interface ResolvedModelConfig {
   model: string;
   provider: AIProvider;
-  apiKey: string;
+  /**
+   * The provider's API key, where it has one. Self-hosted providers such as
+   * Ollama are configured without a key and are called without one.
+   */
+  apiKey?: string;
   /**
    * The provider's configured base URL, where it has one.
    *
@@ -67,8 +72,11 @@ async function resolveModelById(
   }
   const providerConfig = providers[0];
 
-  // Ensure we have an API key
-  if (!providerConfig.api_key) {
+  // Ensure we have an API key, for the providers that need one
+  if (
+    !providerConfig.api_key &&
+    isAPIKeyRequiredForProvider(providerConfig.ai_provider)
+  ) {
     warn(
       `[${logPrefix}] No API key configured for provider: ${model.ai_provider_id}`,
     );
@@ -78,7 +86,7 @@ async function resolveModelById(
   return {
     model: model.model_name,
     provider: providerConfig.ai_provider as AIProvider,
-    apiKey: providerConfig.api_key,
+    apiKey: providerConfig.api_key ?? undefined,
     customHost: providerConfig.custom_fields?.custom_host as string | undefined,
   };
 }


### PR DESCRIPTION
## Problem

Configuring Ollama as the **Evaluation Generation** model in Settings and then creating a skill evaluation fails:

```
[OPTIMIZER] No evaluation generation model configured in system settings
Error generating evaluations: Error: No evaluation generation model configured in system settings
--> POST /v1/super-agents/skills/<id>/evaluations 500
```

The model *is* configured. The real reason sits one line above in the log:

```
[MODEL_RESOLVER_EVALUATION_GENERATION] No API key configured for provider: <uuid>
```

`resolveModelById` required an API key from every provider and returned `null` without one, and the caller reported that as "no model configured".

A self-hosted provider has no key, and the rest of the codebase already knows it: `ollama/api.ts` sets `isAPIKeyRequired: false`, its header builder only sends `x-ollama-api-key` when a key exists, the target schema has `api_key` optional, and the main gateway path tolerates a missing one (`super-agents-configuration.ts`, `apiKeyRecord.api_key || undefined`). Only the internal-skill resolvers didn't.

The same guard would have blocked the next steps of the loop too — the LLM judge bailed with `no_api_key` before ever calling, and `generateEmbeddingForRequest` threw. All three failures are quiet in the way `AGENTS.md` warns about: optimization simply never happens.

## Solution

- **`ai-providers/index.ts`** — new `isAPIKeyRequiredForProvider()` reading each provider's own `api.isAPIKeyRequired`, the same flag `/v1/super-agents/ai-providers/schemas` reports to the dashboard. Providers with no config still default to requiring a key.
- **`utils/evaluation-model-resolver.ts`** — only fail on a missing key when the provider needs one; `apiKey` is now optional on `ResolvedModelConfig`. Fixes evaluation generation, system-prompt reflection and task/outcome extraction.
- **`utils/embeddings.ts`** — same guard, same fix, for request clustering.
- **`evaluations/llm-judge.ts`** — the `no_api_key` fallback now applies only to providers that require a key.
- Internal skill `sa-config` targets omit `api_key` rather than sending an empty string.
- **`task-and-outcome.ts`** was also building its target without the provider's `custom_host` — the quiet failure the other internal skills were fixed for in #242 — so its judge calls went to `http://localhost:11434` no matter what host was configured. Now forwarded like the others.

## Test notes

- New case in `evaluation-model-resolver.test.ts`: a keyless Ollama provider resolves, carrying its `custom_host`.
- New case in `llm-judge.test.ts`: the judge evaluates against a keyless provider and the emitted `sa-config` target has no `api_key` and does carry `custom_host`. Both fail without this change.
- `pnpm typecheck`, `pnpm check`, and `pnpm test` (146 files, 2536 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km46Dj7ZWhkjeUHG3kuWPF