### PR TITLE
fix(api): unwrap structured output a provider wrapped in a code fence

### DIFF
--- a/e2e/contract/gateway.spec.ts
+++ b/e2e/contract/gateway.spec.ts
@@ -6,6 +6,7 @@ import {
   parseSSE,
   saConfig,
   stubFail,
+  stubFence,
   stubRequests,
   stubReset,
   uniqueModelName,
@@ -87,6 +88,59 @@ test.describe('gateway', () => {
       expect(forwarded.messages).toEqual([
         { role: 'user', content: 'what was forwarded?' },
       ]);
+    } finally {
+      await stubReset(request, model);
+      await deleteAgent(request, agent.id);
+    }
+  });
+
+  test('unwraps structured output the provider wrapped in a markdown fence', async ({
+    request,
+  }) => {
+    /**
+     * Providers that do not enforce `response_format` see it as prompt text and
+     * routinely answer with the JSON inside a ```json fence. A client that
+     * asked for `json_schema` runs `JSON.parse` on the content -- the OpenAI
+     * SDK's `.parse()` does exactly that -- so the gateway has to hand back
+     * content that parses. The internal skills are such a client: evaluation
+     * generation, judging and prompt seeding all break at once without this.
+     */
+    const agent = await withSkill(request, 'gwjson');
+    const model = uniqueModelName('fenced');
+
+    try {
+      await stubFence(request, model);
+
+      const response = await request.post(CHAT_COMPLETIONS_PATH, {
+        headers: {
+          'sa-config': saConfig(agent.name, 'gateway_skill', { model }),
+        },
+        data: {
+          ...chatBody('give me the parameters'),
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              name: 'params',
+              strict: true,
+              schema: {
+                type: 'object',
+                properties: { task: { type: 'string' } },
+                required: ['task'],
+                additionalProperties: false,
+              },
+            },
+          },
+        },
+      });
+
+      expect(response.status()).toBe(200);
+      const body = (await response.json()) as {
+        choices: { message: { content: string } }[];
+      };
+
+      const { content } = body.choices[0].message;
+      expect(content.startsWith('```')).toBe(false);
+      expect(JSON.parse(content)).toEqual({ task: 'stub: task' });
     } finally {
       await stubReset(request, model);
       await deleteAgent(request, agent.id);

--- a/e2e/fixtures/gateway.ts
+++ b/e2e/fixtures/gateway.ts
@@ -87,6 +87,18 @@ export const stubFail = async (
   });
 };
 
+/**
+ * Make structured-output replies for this model come back inside a markdown
+ * fence -- what a provider does when `response_format` reached it as prompt
+ * text rather than as an enforced schema.
+ */
+export const stubFence = async (
+  request: APIRequestContext,
+  model: string,
+): Promise<void> => {
+  await request.post(`${STUB_URL}/__control/fence`, { data: { model } });
+};
+
 export const stubReset = async (
   request: APIRequestContext,
   model: string,

--- a/packages/api/src/handlers/handler-utils.ts
+++ b/packages/api/src/handlers/handler-utils.ts
@@ -222,6 +222,16 @@ export async function tryPost(
       ...overrideParams,
     } as SuperAgentsRequestBody;
 
+    // Anthropic has no `response_format`, so the gateway emulates it with the
+    // `__json_output` tool (see ai-providers/anthropic/chat-complete.ts). Every
+    // other provider has to put the JSON in the message itself, and telling one
+    // to call a tool it was never given is how answers end up narrated or
+    // wrapped in a ```json fence.
+    const jsonOutputInstruction =
+      saTarget.configuration.ai_provider === AIProvider.ANTHROPIC
+        ? 'Use the __json_output tool to provide your response.'
+        : 'Respond with the JSON object alone: no markdown code fences, no commentary, no other text.';
+
     // Helper to generate JSON schema instructions for response_format
     const getJsonSchemaInstructions = (
       responseFormat: ChatCompletionRequestBody['response_format'],
@@ -232,10 +242,10 @@ export async function tryPost(
         const schema =
           responseFormat.json_schema?.schema ?? responseFormat.json_schema;
         if (schema && typeof schema === 'object') {
-          return `\n\nIMPORTANT: You must output your response as a JSON object that strictly conforms to the following schema:\n\n${JSON.stringify(schema, null, 2)}\n\nEnsure every required field is present with the correct type and format. Use the __json_output tool to provide your response.`;
+          return `\n\nIMPORTANT: You must output your response as a JSON object that strictly conforms to the following schema:\n\n${JSON.stringify(schema, null, 2)}\n\nEnsure every required field is present with the correct type and format. ${jsonOutputInstruction}`;
         }
       } else if (responseFormat.type === 'json_object') {
-        return '\n\nIMPORTANT: You must output your response as a valid JSON object. Use the __json_output tool to provide your response.';
+        return `\n\nIMPORTANT: You must output your response as a valid JSON object. ${jsonOutputInstruction}`;
       }
 
       return '';

--- a/packages/api/src/handlers/stream-handler.ts
+++ b/packages/api/src/handlers/stream-handler.ts
@@ -2,6 +2,7 @@ import {
   getStreamModeSplitPattern,
   type SplitPatternType,
 } from '@api/utils/object';
+import { unwrapJsonResponseContent } from '@api/utils/structured-output';
 import { error, warn } from '@shared/console-logging';
 import type {
   JSONToStreamGeneratorTransformFunction,
@@ -341,6 +342,16 @@ export async function handleNonStreamingMode(
       aiProviderResponse.headers,
       strictOpenAiCompliance,
       saRequestData,
+    );
+  }
+
+  // A provider that only saw `response_format` as a prompt instruction may have
+  // answered with the JSON inside a markdown fence. Unwrap it before validation
+  // so the caller gets content it can parse.
+  if (transformedBodyJson && !(transformedBodyJson instanceof Blob)) {
+    transformedBodyJson = unwrapJsonResponseContent(
+      saRequestData,
+      transformedBodyJson,
     );
   }
 

--- a/packages/api/src/utils/structured-output.test.ts
+++ b/packages/api/src/utils/structured-output.test.ts
@@ -1,0 +1,168 @@
+import {
+  extractJsonFromContent,
+  unwrapJsonResponseContent,
+} from '@api/utils/structured-output';
+import { FunctionName } from '@shared/types/api/request';
+import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
+import { describe, expect, it } from 'vitest';
+
+function requestData(
+  responseFormat: unknown,
+  functionName: FunctionName = FunctionName.CHAT_COMPLETE,
+): SuperAgentsRequestData {
+  return {
+    functionName,
+    requestBody: {
+      model: 'glm-5.3-flash:cloud',
+      messages: [{ role: 'user', content: 'Hello' }],
+      ...(responseFormat ? { response_format: responseFormat } : {}),
+    },
+  } as unknown as SuperAgentsRequestData;
+}
+
+const jsonSchemaFormat = {
+  type: 'json_schema',
+  json_schema: {
+    name: 'params',
+    strict: true,
+    schema: { type: 'object', properties: { task: { type: 'string' } } },
+  },
+};
+
+function chatResponse(content: string): Record<string, unknown> {
+  return {
+    id: 'chatcmpl-1',
+    object: 'chat.completion',
+    created: 1,
+    model: 'glm-5.3-flash',
+    choices: [
+      {
+        index: 0,
+        finish_reason: 'stop',
+        message: { role: 'assistant', content },
+      },
+    ],
+  };
+}
+
+function contentOf(body: Record<string, unknown>): unknown {
+  const choices = body.choices as { message: { content: unknown } }[];
+  return choices[0].message.content;
+}
+
+describe('extractJsonFromContent', () => {
+  it('unwraps a ```json fence', () => {
+    expect(
+      extractJsonFromContent('```json\n{\n  "task": "review code"\n}\n```'),
+    ).toBe('{\n  "task": "review code"\n}');
+  });
+
+  it('unwraps an unlabelled fence', () => {
+    expect(extractJsonFromContent('```\n{"task": "review code"}\n```')).toBe(
+      '{"task": "review code"}',
+    );
+  });
+
+  it('unwraps a fence surrounded by commentary', () => {
+    expect(
+      extractJsonFromContent(
+        'Here you go:\n\n```json\n{"task": "a"}\n```\n\nHope that helps!',
+      ),
+    ).toBe('{"task": "a"}');
+  });
+
+  it('falls back to the outermost object when there is no fence', () => {
+    expect(extractJsonFromContent('Sure! {"task": "a"} Let me know.')).toBe(
+      '{"task": "a"}',
+    );
+  });
+
+  it('handles a top-level array', () => {
+    expect(extractJsonFromContent('```json\n[1, 2, 3]\n```')).toBe('[1, 2, 3]');
+  });
+
+  it('leaves content that is already JSON alone', () => {
+    expect(extractJsonFromContent('{"task": "a"}')).toBeNull();
+  });
+
+  it('gives up when nothing in the content parses', () => {
+    expect(extractJsonFromContent('I cannot answer that.')).toBeNull();
+    expect(extractJsonFromContent('```json\n{"task": \n```')).toBeNull();
+    expect(extractJsonFromContent('')).toBeNull();
+  });
+});
+
+describe('unwrapJsonResponseContent', () => {
+  it('unwraps fenced content when json_schema was requested', () => {
+    const body = unwrapJsonResponseContent(
+      requestData(jsonSchemaFormat),
+      chatResponse('```json\n{"task": "a", "threshold": 0.7}\n```'),
+    );
+
+    expect(contentOf(body)).toBe('{"task": "a", "threshold": 0.7}');
+    expect(JSON.parse(contentOf(body) as string)).toEqual({
+      task: 'a',
+      threshold: 0.7,
+    });
+  });
+
+  it('unwraps fenced content when json_object was requested', () => {
+    const body = unwrapJsonResponseContent(
+      requestData({ type: 'json_object' }),
+      chatResponse('```json\n{"task": "a"}\n```'),
+    );
+
+    expect(contentOf(body)).toBe('{"task": "a"}');
+  });
+
+  it('leaves the response untouched when no JSON format was requested', () => {
+    const original = chatResponse('```json\n{"task": "a"}\n```');
+    const body = unwrapJsonResponseContent(requestData(undefined), original);
+
+    expect(body).toBe(original);
+  });
+
+  it('leaves the response untouched for other endpoints', () => {
+    const original = chatResponse('```json\n{"task": "a"}\n```');
+    const body = unwrapJsonResponseContent(
+      requestData(jsonSchemaFormat, FunctionName.EMBED),
+      original,
+    );
+
+    expect(body).toBe(original);
+  });
+
+  it('leaves content that is already JSON untouched', () => {
+    const original = chatResponse('{"task": "a"}');
+    const body = unwrapJsonResponseContent(
+      requestData(jsonSchemaFormat),
+      original,
+    );
+
+    expect(body).toBe(original);
+  });
+
+  it('leaves a response the provider did not answer with JSON alone', () => {
+    const original = chatResponse('I cannot answer that.');
+    const body = unwrapJsonResponseContent(
+      requestData(jsonSchemaFormat),
+      original,
+    );
+
+    expect(body).toBe(original);
+  });
+
+  it('survives a body without usable choices', () => {
+    const original = { id: 'chatcmpl-1', object: 'chat.completion' };
+    expect(
+      unwrapJsonResponseContent(requestData(jsonSchemaFormat), original),
+    ).toBe(original);
+
+    const noContent = {
+      choices: [{ index: 0, message: { role: 'assistant', content: null } }],
+    };
+    expect(
+      unwrapJsonResponseContent(requestData(jsonSchemaFormat), noContent),
+    ).toBe(noContent);
+  });
+});

--- a/packages/api/src/utils/structured-output.ts
+++ b/packages/api/src/utils/structured-output.ts
@@ -1,0 +1,95 @@
+import { FunctionName } from '@shared/types/api/request';
+import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
+import type { ChatCompletionRequestBody } from '@shared/types/api/routes/chat-completions-api';
+
+/** Matches a markdown code fence and captures whatever sits inside it. */
+const FENCED_BLOCK = /```[a-zA-Z0-9_-]*\r?\n?([\s\S]*?)```/g;
+
+function isJson(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pulls the JSON out of a message that is *about* JSON rather than being JSON:
+ * a markdown fence, or an object with commentary around it. Returns null when
+ * the content is already valid JSON, or when nothing in it parses -- in both
+ * cases the caller should leave the content alone.
+ */
+export function extractJsonFromContent(content: string): string | null {
+  const trimmed = content.trim();
+  if (trimmed === '' || isJson(trimmed)) return null;
+
+  for (const match of trimmed.matchAll(FENCED_BLOCK)) {
+    const fenced = match[1].trim();
+    if (isJson(fenced)) return fenced;
+  }
+
+  // No usable fence: fall back to the outermost object or array in the text.
+  const objectStart = trimmed.indexOf('{');
+  const arrayStart = trimmed.indexOf('[');
+  const start =
+    objectStart === -1 || (arrayStart !== -1 && arrayStart < objectStart)
+      ? arrayStart
+      : objectStart;
+  if (start === -1) return null;
+
+  const end = trimmed.lastIndexOf(trimmed[start] === '{' ? '}' : ']');
+  if (end <= start) return null;
+
+  const candidate = trimmed.slice(start, end + 1);
+  return isJson(candidate) ? candidate : null;
+}
+
+/**
+ * Providers differ in how seriously they take `response_format`. The ones that
+ * enforce a schema return bare JSON; the ones that only see the instruction in
+ * the prompt -- self-hosted models through Ollama, most of all -- routinely
+ * wrap it in a ```json fence. A client that asked for `json_schema` is entitled
+ * to content it can hand to `JSON.parse` (the OpenAI SDK's `.parse()` does
+ * exactly that and throws on the backticks), so the fence is stripped here, at
+ * the boundary where the gateway makes providers look alike.
+ *
+ * Only chat completions that asked for a JSON response format are touched, and
+ * only when the extracted text really is JSON; anything else is passed through
+ * untouched so a provider's own reply still reaches the caller verbatim.
+ */
+export function unwrapJsonResponseContent(
+  saRequestData: SuperAgentsRequestData,
+  responseBody: Record<string, unknown>,
+): Record<string, unknown> {
+  if (saRequestData.functionName !== FunctionName.CHAT_COMPLETE) {
+    return responseBody;
+  }
+
+  const responseFormat = (
+    saRequestData.requestBody as ChatCompletionRequestBody
+  )?.response_format;
+  if (
+    responseFormat?.type !== 'json_schema' &&
+    responseFormat?.type !== 'json_object'
+  ) {
+    return responseBody;
+  }
+
+  const choices = responseBody.choices;
+  if (!Array.isArray(choices)) return responseBody;
+
+  let unwrapped = false;
+  const nextChoices = choices.map((choice) => {
+    const message = (choice as { message?: { content?: unknown } })?.message;
+    if (typeof message?.content !== 'string') return choice;
+
+    const json = extractJsonFromContent(message.content);
+    if (json === null) return choice;
+
+    unwrapped = true;
+    return { ...choice, message: { ...message, content: json } };
+  });
+
+  return unwrapped ? { ...responseBody, choices: nextChoices } : responseBody;
+}

--- a/scripts/start-stub-provider.mjs
+++ b/scripts/start-stub-provider.mjs
@@ -23,6 +23,7 @@
  *   POST /api/embeddings        ditto, for embeddings
  *   GET  /__control/requests?model=NAME   what the gateway sent for that model
  *   POST /__control/fail        {model, times, status} -- inject failures
+ *   POST /__control/fence       {model} -- wrap structured output in a fence
  *   POST /__control/reset       {model} -- forget everything for that model
  *
  * Configured with E2E_STUB_PORT (default 3103).
@@ -35,6 +36,12 @@ const port = Number(process.env.E2E_STUB_PORT ?? 3103);
 const received = new Map();
 /** model name -> queued failures, shifted one per request. */
 const failures = new Map();
+/**
+ * Models whose structured output comes back inside a markdown fence, the way a
+ * provider answers when it only saw `response_format` as a prompt instruction
+ * rather than enforcing it.
+ */
+const fenced = new Set();
 
 const recordFor = (model) => {
   if (!received.has(model)) {
@@ -223,10 +230,18 @@ const server = createServer(async (request, response) => {
     return;
   }
 
+  if (url.pathname === '/__control/fence') {
+    const { model } = JSON.parse((await readBody(request)) || '{}');
+    fenced.add(model);
+    sendJson(response, 200, { ok: true });
+    return;
+  }
+
   if (url.pathname === '/__control/reset') {
     const { model } = JSON.parse((await readBody(request)) || '{}');
     received.delete(model);
     failures.delete(model);
+    fenced.delete(model);
     sendJson(response, 200, { ok: true });
     return;
   }
@@ -262,8 +277,11 @@ const server = createServer(async (request, response) => {
 
   if (url.pathname === '/v1/chat/completions') {
     const schema = requestedSchema(body);
+    const structured = schema ? JSON.stringify(instanceOf(schema, schema)) : '';
     const text = schema
-      ? JSON.stringify(instanceOf(schema, schema))
+      ? fenced.has(model)
+        ? `Here is the JSON you asked for:\n\n\`\`\`json\n${structured}\n\`\`\``
+        : structured
       : replyText(body);
     if (body?.stream) {
       streamCompletion(response, body, text);


### PR DESCRIPTION
## Problem

Adding an evaluation returned a 500:

```
Error generating evaluations: SyntaxError: Unexpected token '`', "```json
{
"... is not valid JSON
    at parseChatCompletion
    at async generateEvaluationCreateParams
```

The internal skills ask for `response_format: json_schema` and read the answer with the OpenAI SDK's `.chat.completions.parse()`, which runs `JSON.parse` on `message.content`. Providers that enforce the schema return bare JSON; the ones that only see `response_format` as prompt text — Ollama serving a cloud model, here — answer with the JSON inside a ```json fence, and the parse throws.

The logged provider exchange showed a second thing worth fixing. The gateway had appended this to the system prompt:

> …Ensure every required field is present with the correct type and format. **Use the `__json_output` tool to provide your response.**

`__json_output` exists only on the Anthropic path, where the gateway emulates `response_format` with a tool (`ai-providers/anthropic/chat-complete.ts`). Every other provider was being told to call a tool it was never given — which is how an answer ends up narrated inside a fence in the first place.

## Solution

- **`utils/structured-output.ts`** (new). `extractJsonFromContent` unwraps a fenced block, or an object/array embedded in commentary, and returns it only when it really parses. `unwrapJsonResponseContent` applies that to chat completions that asked for `json_schema` or `json_object`; everything else is returned untouched, so a provider's own reply still reaches the caller verbatim.
- **`handlers/stream-handler.ts`**. `handleNonStreamingMode` unwraps before response-schema validation, so the client, the logs and the cache all see the same parseable content.
- **`handlers/handler-utils.ts`**. The injected JSON instruction is now provider-aware: Anthropic keeps the `__json_output` sentence, everyone else gets *"Respond with the JSON object alone: no markdown code fences, no commentary, no other text."*

One fix at the gateway covers all four internal-skill call sites — evaluation generation, judging, task/outcome extraction and prompt seeding — since they are all ordinary gateway requests.

**Streaming is deliberately untouched.** Unwrapping a fence mid-stream would mean buffering the whole content, which defeats streaming; the internal skills never stream. A streaming client asking for `json_schema` against a non-enforcing provider still sees the fence.

## Test notes

- `packages/api/src/utils/structured-output.test.ts` — 14 cases: fences labelled and bare, prose around a fence, top-level arrays, content that is already JSON, content that parses nowhere, non-chat endpoints, bodies without usable choices.
- `e2e/contract/gateway.spec.ts` — a new contract spec, with a `/__control/fence` knob on the stub provider so it can answer the way a non-enforcing provider does. It fails without the fix (`SyntaxError: Unexpected token 'H', "Here is th"...`) and passes with it.
- Verified against the reporter's actual setup: a `json_schema` request through the dev gateway to `glm-5.3-flash:cloud` on Ollama now comes back as bare, parseable JSON, and the logged system prompt carries the new instruction.
- `pnpm typecheck`, `pnpm check`, `pnpm test` (2550 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PW13To1Lt4yC3mEqksfTck
