### PR TITLE
fix(api): check the evaluation parameters a model returns before storing them

### DIFF
--- a/packages/api/src/connectors/evaluations/conversation-completeness/types.ts
+++ b/packages/api/src/connectors/evaluations/conversation-completeness/types.ts
@@ -24,7 +24,7 @@ export const ConversationCompletenessEvaluationAIParameters = z
 // Note: model is configured via evaluation.model_id, not in parameters
 export const ConversationCompletenessEvaluationParameters =
   ConversationCompletenessEvaluationAIParameters.extend({
-    threshold: z.number().min(0).max(1),
+    threshold: z.number().min(0).max(1).default(0.7),
     temperature: z.number().min(0).max(2).default(0.1),
     max_tokens: z.number().int().positive().default(1000),
     include_reason: z.boolean().default(true),

--- a/packages/api/src/connectors/evaluations/knowledge-retention/types.ts
+++ b/packages/api/src/connectors/evaluations/knowledge-retention/types.ts
@@ -22,7 +22,7 @@ export const KnowledgeRetentionEvaluationAIParameters = z.object({}).strict();
 // Note: model is configured via evaluation.model_id, not in parameters
 export const KnowledgeRetentionEvaluationParameters =
   KnowledgeRetentionEvaluationAIParameters.extend({
-    threshold: z.number().min(0).max(1),
+    threshold: z.number().min(0).max(1).default(0.7),
     temperature: z.number().min(0).max(2).default(0.1),
     max_tokens: z.number().int().positive().default(1000),
     include_reason: z.boolean().default(true),

--- a/packages/api/src/connectors/evaluations/parameters.test.ts
+++ b/packages/api/src/connectors/evaluations/parameters.test.ts
@@ -1,0 +1,49 @@
+import { conversationCompletenessEvaluationConnector } from '@api/connectors/evaluations/conversation-completeness';
+import { knowledgeRetentionEvaluationConnector } from '@api/connectors/evaluations/knowledge-retention';
+import { latencyEvaluationConnector } from '@api/connectors/evaluations/latency/latency';
+import { taskCompletionEvaluationConnector } from '@api/connectors/evaluations/task-completion';
+import { toolCorrectnessEvaluationConnector } from '@api/connectors/evaluations/tool-correctness';
+import { turnRelevancyEvaluationConnector } from '@api/connectors/evaluations/turn-relevancy';
+import type { EvaluationMethodConnector } from '@api/types/connector';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+/** The connectors registered in `v1/index.ts`. */
+const connectors: EvaluationMethodConnector[] = [
+  conversationCompletenessEvaluationConnector,
+  knowledgeRetentionEvaluationConnector,
+  latencyEvaluationConnector,
+  taskCompletionEvaluationConnector,
+  toolCorrectnessEvaluationConnector,
+  turnRelevancyEvaluationConnector,
+];
+
+describe.each(
+  connectors.map((c) => [c.getDetails().method, c] as const),
+)('%s parameters', (method, connector) => {
+  const aiSchema = connector.getAIParameterSchema;
+  const generated =
+    aiSchema instanceof z.ZodObject ? Object.keys(aiSchema.shape) : [];
+
+  /**
+   * A method whose AI schema is empty is stored with `params: {}` -- nothing
+   * generates a value for it, and nothing else fills one in. Its own schema
+   * therefore has to be satisfied by its defaults alone, or the evaluation
+   * fails on every request it is asked to score, long after the evaluation
+   * was created:
+   *
+   *   [REALTIME_EVAL] Failed to evaluate log ... with method ...
+   */
+  it('evaluates with the parameters it is created with', () => {
+    const created = generated.length === 0 ? {} : undefined;
+    if (created === undefined) {
+      // Generated parameters are covered by the generator's own tests; the
+      // invariant here is about the methods that generate nothing.
+      expect(method).toBe('task_completion');
+      return;
+    }
+
+    const parsed = connector.getParameterSchema.safeParse(created);
+    expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+  });
+});

--- a/packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts
@@ -115,5 +115,19 @@ export async function extractTaskAndOutcome(
     );
   }
 
-  return structuredOutputResponse;
+  // Only a provider that enforces `response_format` guarantees the shape, so
+  // the reply is checked rather than trusted -- a missing outcome would
+  // otherwise reach the judge as `undefined` and be scored as if it were an
+  // answer.
+  const validated = StructuredOutputResponse.safeParse(
+    structuredOutputResponse,
+  );
+
+  if (!validated.success) {
+    throw new Error(
+      `[OPTIMIZER] can't extract task and outcome - the response does not match the schema: ${validated.error.message}`,
+    );
+  }
+
+  return validated.data;
 }

--- a/packages/api/src/optimization/utils/evaluations.test.ts
+++ b/packages/api/src/optimization/utils/evaluations.test.ts
@@ -1,0 +1,174 @@
+import { generateEvaluationCreateParams } from '@api/optimization/utils/evaluations';
+import { createMockContext } from '@api/test-utils/mock-context';
+import type {
+  EvaluationMethodConnector,
+  UserDataStorageConnector,
+} from '@api/types/connector';
+import { AIProvider } from '@shared/types/constants';
+import type { Skill } from '@shared/types/data';
+import { EvaluationMethodName } from '@shared/types/evaluations';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+const mockParse = vi.fn();
+
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    withOptions: () => ({ chat: { completions: { parse: mockParse } } }),
+  })),
+}));
+
+vi.mock('@api/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@api/constants')>()),
+  getApiUrl: () => 'http://localhost:8787',
+}));
+
+vi.mock('@api/utils/evaluation-model-resolver', () => ({
+  resolveSystemSettingsModel: vi.fn(async () => ({
+    model: 'glm-5.3-flash:cloud',
+    provider: AIProvider.OLLAMA,
+    apiKey: '',
+    customHost: 'http://localhost:11434',
+  })),
+}));
+
+const mockContext = createMockContext();
+
+const skill = {
+  id: 'skill-1',
+  agent_id: 'agent-1',
+  description: 'Review the code changes in my repo.',
+} as Skill;
+
+const storageConnector = {} as UserDataStorageConnector;
+
+/** Only the two members the generator reads. */
+const connectorFor = (
+  method: EvaluationMethodName,
+  aiParameterSchema?: z.ZodType,
+): EvaluationMethodConnector =>
+  ({
+    getDetails: () => ({
+      method,
+      name: method,
+      description: `the ${method} method`,
+    }),
+    getAIParameterSchema: aiParameterSchema,
+  }) as unknown as EvaluationMethodConnector;
+
+/** What the OpenAI SDK hands back once it has parsed the provider's content. */
+const parsedAs = (value: unknown) => ({
+  choices: [{ message: { parsed: value } }],
+});
+
+describe('generateEvaluationCreateParams', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('asks the model for the parameters a method actually declares', async () => {
+    mockParse.mockResolvedValue(parsedAs({ task: 'Review the diff' }));
+
+    const params = await generateEvaluationCreateParams(
+      mockContext,
+      skill,
+      connectorFor(
+        EvaluationMethodName.TASK_COMPLETION,
+        z.object({
+          task: z.string(),
+          threshold: z.number().min(0).max(1).default(0.7),
+        }),
+      ),
+      EvaluationMethodName.TASK_COMPLETION,
+      'an agent that maintains a website',
+      storageConnector,
+    );
+
+    expect(mockParse).toHaveBeenCalledTimes(1);
+    // The threshold the model left out comes from the schema's default.
+    expect(params.params).toEqual({ task: 'Review the diff', threshold: 0.7 });
+    expect(params.evaluation_method).toBe(EvaluationMethodName.TASK_COMPLETION);
+    expect(params.skill_id).toBe('skill-1');
+  });
+
+  it('does not call the model for a method with no AI parameters', async () => {
+    /**
+     * Every method but task_completion declares an empty AI schema. Asking a
+     * model to fill in nothing spends a request, and a provider that does not
+     * enforce the schema answers with a field the method's own parameter
+     * schema then rejects at evaluation time.
+     */
+    const params = await generateEvaluationCreateParams(
+      mockContext,
+      skill,
+      connectorFor(
+        EvaluationMethodName.TOOL_CORRECTNESS,
+        z.object({}).strict(),
+      ),
+      EvaluationMethodName.TOOL_CORRECTNESS,
+      'an agent that maintains a website',
+      storageConnector,
+    );
+
+    expect(mockParse).not.toHaveBeenCalled();
+    expect(params.params).toEqual({});
+  });
+
+  it('does not call the model for a method with no AI schema at all', async () => {
+    const params = await generateEvaluationCreateParams(
+      mockContext,
+      skill,
+      connectorFor(EvaluationMethodName.LATENCY),
+      EvaluationMethodName.LATENCY,
+      'an agent that maintains a website',
+      storageConnector,
+    );
+
+    expect(mockParse).not.toHaveBeenCalled();
+    expect(params.params).toEqual({});
+  });
+
+  it('refuses parameters that do not match the schema the model was given', async () => {
+    mockParse.mockResolvedValue(parsedAs({ threshold: 0.7 }));
+
+    await expect(
+      generateEvaluationCreateParams(
+        mockContext,
+        skill,
+        connectorFor(
+          EvaluationMethodName.TASK_COMPLETION,
+          z.object({ task: z.string(), threshold: z.number().default(0.7) }),
+        ),
+        EvaluationMethodName.TASK_COMPLETION,
+        'an agent that maintains a website',
+        storageConnector,
+      ),
+    ).rejects.toThrow(/task_completion parameters the model returned/);
+  });
+
+  it('drops fields the model volunteered beyond the schema', async () => {
+    mockParse.mockResolvedValue(
+      parsedAs({
+        task: 'Review the diff',
+        reasoning: 'because I felt like it',
+      }),
+    );
+
+    const params = await generateEvaluationCreateParams(
+      mockContext,
+      skill,
+      connectorFor(
+        EvaluationMethodName.TASK_COMPLETION,
+        z.object({
+          task: z.string(),
+          threshold: z.number().default(0.7),
+        }),
+      ),
+      EvaluationMethodName.TASK_COMPLETION,
+      'an agent that maintains a website',
+      storageConnector,
+    );
+
+    expect(params.params).toEqual({ task: 'Review the diff', threshold: 0.7 });
+  });
+});

--- a/packages/api/src/optimization/utils/evaluations.ts
+++ b/packages/api/src/optimization/utils/evaluations.ts
@@ -92,6 +92,27 @@ Your task description will guide the extraction AI to understand what users are 
   return firstMessage;
 }
 
+/**
+ * Whether the method has any parameter for a model to fill in.
+ *
+ * Most methods declare an empty AI schema: they are configured entirely by
+ * their own defaults, and `task_completion` is the only one that asks for
+ * anything. Sending the model a schema with no properties spends a request to
+ * be told `{}`, and a provider that does not enforce the schema -- a
+ * self-hosted model, most of all -- answers with whatever it thought was
+ * wanted. That reply used to be stored verbatim, and the method's own
+ * parameter schema then rejected it at evaluation time, long after the fact:
+ *
+ *   [REALTIME_EVAL] Failed to evaluate log ... with method tool_correctness:
+ *   Unrecognized key: "task"
+ */
+function hasGeneratableParameters(schema: z.ZodType): boolean {
+  if (schema instanceof z.ZodObject) {
+    return Object.keys(schema.shape).length > 0;
+  }
+  return true;
+}
+
 export async function generateEvaluationCreateParams(
   c: AppContext,
   skill: Skill,
@@ -142,7 +163,7 @@ export async function generateEvaluationCreateParams(
 
   // If the evaluation method doesn't use AI for parameter generation,
   // use default parameters from the parameter schema
-  if (!schema) {
+  if (!schema || !hasGeneratableParameters(schema)) {
     const params: SkillOptimizationEvaluationCreateParams = {
       agent_id: skill.agent_id,
       skill_id: skill.id,
@@ -197,11 +218,24 @@ export async function generateEvaluationCreateParams(
     );
   }
 
+  // The model's answer is checked against the schema it was given rather than
+  // trusted: only a provider that enforces `response_format` guarantees the
+  // shape, and these parameters are read back much later, by the evaluation
+  // that runs on every request. Parsing also fills in the defaults the model
+  // left out, such as `task_completion`'s threshold.
+  const validated = schema.safeParse(structuredOutputResponse);
+
+  if (!validated.success) {
+    throw new Error(
+      `[OPTIMIZER] can't generate evaluations for skill - the ${method} parameters the model returned do not match its schema: ${validated.error.message}`,
+    );
+  }
+
   const params: SkillOptimizationEvaluationCreateParams = {
     agent_id: skill.agent_id,
     skill_id: skill.id,
     evaluation_method: method,
-    params: structuredOutputResponse as unknown as Record<string, unknown>,
+    params: validated.data as Record<string, unknown>,
     weight: 1.0, // Default weight - can be adjusted by user
   };
 

--- a/packages/api/src/optimization/utils/system-prompt.ts
+++ b/packages/api/src/optimization/utils/system-prompt.ts
@@ -159,7 +159,20 @@ async function callSystemPromptAPI(
     );
   }
 
-  return structuredOutputResponse.system_prompt;
+  // Only a provider that enforces `response_format` guarantees the shape, so
+  // the reply is checked rather than trusted -- otherwise a model that answered
+  // in some other shape stores `undefined` as the arm's system prompt.
+  const validated = StructuredOutputResponse.safeParse(
+    structuredOutputResponse,
+  );
+
+  if (!validated.success) {
+    throw new Error(
+      `[OPTIMIZER] can't generate system prompt - the response does not match the schema: ${validated.error.message}`,
+    );
+  }
+
+  return validated.data.system_prompt;
 }
 
 function getSeederSystemPrompt() {


### PR DESCRIPTION
## Problem

Every request against a skill with evaluations logged this:

```
[REALTIME_EVAL] Failed to evaluate log … with method tool_correctness: [
  { "code": "unrecognized_keys", "keys": ["task"], "message": "Unrecognized key: \"task\"" }
]
[REALTIME_EVAL] Failed to evaluate log … with method turn_relevancy: [ … ]
```

`tool_correctness` and `turn_relevancy` declare `z.object({}).strict()` as their AI parameter schema — they have no AI-generatable parameters at all, and `task_completion` is the only method that does. `generateEvaluationCreateParams` asked a model to fill them in anyway, and stored the answer with a bare cast:

```ts
params: structuredOutputResponse as unknown as Record<string, unknown>,
```

Only a provider that enforces `response_format` answers `{}` to an empty schema. A self-hosted one answers with what it thought was wanted — `{"task": "…"}` — and that went into the database, where the method's own parameter schema rejected it on every request it was later asked to score. The failure is as far from its cause as it can get: a bad write at evaluation-creation time, surfacing as noise on the request path.

## Solution

- **Skip the call when there is nothing to generate.** A schema with no properties spends a request to be told `{}` and invites exactly this. `hasGeneratableParameters` gates it, and the method falls through to the existing "use the schema defaults" path.
- **Parse instead of cast.** The reply is checked against the schema the model was given; on a mismatch the method fails loudly at creation time, where the user is standing, instead of writing something that breaks later. Parsing also fills in the defaults the model omitted, which is where `task_completion`'s `threshold` comes from.

### Two neighbours found on the way

- `conversation_completeness` and `knowledge_retention` required a `threshold` with **no default**. Their AI schema is empty, so `{}` is the only thing that can ever be stored for them — neither method could parse its own parameters, whatever the model returned. They now default to `0.7`, like every other LLM-judge method.
- System prompt generation and task/outcome extraction cast the same unchecked reply. A malformed answer stored `undefined` as an arm's system prompt, or handed the judge an empty outcome to score as though it were an answer. Both now validate.

## Test notes

- `optimization/utils/evaluations.test.ts` — 5 cases: no model call for an empty AI schema or none at all, defaults applied to what the model does return, schema-violating output rejected, volunteered extra fields dropped.
- `connectors/evaluations/parameters.test.ts` — the invariant, per registered connector: a method must be able to evaluate with the parameters it is created with. Confirmed it fails on both threshold schemas when the new defaults are reverted.
- Verified against a real Ollama-backed setup: after repairing the three rows the old code had written, one request through the skill scored all six evaluations — `latency 1 · turn_relevancy 1 · tool_correctness 1 · task_completion 0.5 · knowledge_retention 0.85 · conversation_completeness 1`.
- `pnpm typecheck`, `pnpm check`, `pnpm test` (2561 passing) all green.

**Note on existing data:** the fix does not reach backwards. A deployment that already generated evaluations with a non-enforcing provider has rows whose `params` carry a stray field; they stay broken until re-created or reset to `{}`.

Independent of #249 — same family of failure (a provider that does not enforce structured output), no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PW13To1Lt4yC3mEqksfTck
