### PR TITLE
fix(web): route the partitions breadcrumb instead of 404ing

### DIFF
--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as MainAgentsAgentNameSkillsSkillNameEvaluationsRouteImport } fro
 import { Route as MainAgentsAgentNameSkillsSkillNameEditRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.edit'
 import { Route as MainAgentsAgentNameSkillsSkillNameLogsIndexRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.logs.index'
 import { Route as MainAgentsAgentNameSkillsSkillNameEvaluationsIndexRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.evaluations.index'
+import { Route as MainAgentsAgentNameSkillsSkillNameClustersIndexRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.clusters.index'
 import { Route as MainAgentsAgentNameSkillsSkillNameLogsLogIdRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.logs.$logId'
 import { Route as MainAgentsAgentNameSkillsSkillNameClustersClusterIdRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.clusters.$clusterId'
 import { Route as MainAgentsAgentNameSkillsSkillNameEvaluationsEvaluationIdEditRouteImport } from './routes/_main/agents.$agentName.skills.$skillName.evaluations.$evaluationId.edit'
@@ -221,6 +222,12 @@ const MainAgentsAgentNameSkillsSkillNameEvaluationsIndexRoute =
       (d) => d.Route,
     ),
   )
+const MainAgentsAgentNameSkillsSkillNameClustersIndexRoute =
+  MainAgentsAgentNameSkillsSkillNameClustersIndexRouteImport.update({
+    id: '/clusters/',
+    path: '/clusters/',
+    getParentRoute: () => MainAgentsAgentNameSkillsSkillNameRoute,
+  } as any)
 const MainAgentsAgentNameSkillsSkillNameLogsLogIdRoute =
   MainAgentsAgentNameSkillsSkillNameLogsLogIdRouteImport.update({
     id: '/$logId',
@@ -309,6 +316,7 @@ export interface FileRoutesByFullPath {
   '/agents/$agentName/skills/$skillName/': typeof MainAgentsAgentNameSkillsSkillNameIndexRoute
   '/agents/$agentName/skills/$skillName/clusters/$clusterId': typeof MainAgentsAgentNameSkillsSkillNameClustersClusterIdRouteWithChildren
   '/agents/$agentName/skills/$skillName/logs/$logId': typeof MainAgentsAgentNameSkillsSkillNameLogsLogIdRoute
+  '/agents/$agentName/skills/$skillName/clusters': typeof MainAgentsAgentNameSkillsSkillNameClustersIndexRoute
   '/agents/$agentName/skills/$skillName/evaluations/': typeof MainAgentsAgentNameSkillsSkillNameEvaluationsIndexRoute
   '/agents/$agentName/skills/$skillName/logs/': typeof MainAgentsAgentNameSkillsSkillNameLogsIndexRoute
   '/agents/$agentName/skills/$skillName/clusters/$clusterId/configurations': typeof MainAgentsAgentNameSkillsSkillNameClustersClusterIdConfigurationsRouteWithChildren
@@ -336,6 +344,7 @@ export interface FileRoutesByTo {
   '/agents/$agentName/skills/$skillName': typeof MainAgentsAgentNameSkillsSkillNameIndexRoute
   '/agents/$agentName/skills/$skillName/clusters/$clusterId': typeof MainAgentsAgentNameSkillsSkillNameClustersClusterIdRouteWithChildren
   '/agents/$agentName/skills/$skillName/logs/$logId': typeof MainAgentsAgentNameSkillsSkillNameLogsLogIdRoute
+  '/agents/$agentName/skills/$skillName/clusters': typeof MainAgentsAgentNameSkillsSkillNameClustersIndexRoute
   '/agents/$agentName/skills/$skillName/evaluations': typeof MainAgentsAgentNameSkillsSkillNameEvaluationsIndexRoute
   '/agents/$agentName/skills/$skillName/logs': typeof MainAgentsAgentNameSkillsSkillNameLogsIndexRoute
   '/agents/$agentName/skills/$skillName/evaluations/$evaluationId/edit': typeof MainAgentsAgentNameSkillsSkillNameEvaluationsEvaluationIdEditRoute
@@ -368,6 +377,7 @@ export interface FileRoutesById {
   '/_main/agents/$agentName/skills/$skillName/': typeof MainAgentsAgentNameSkillsSkillNameIndexRoute
   '/_main/agents/$agentName/skills/$skillName/clusters/$clusterId': typeof MainAgentsAgentNameSkillsSkillNameClustersClusterIdRouteWithChildren
   '/_main/agents/$agentName/skills/$skillName/logs/$logId': typeof MainAgentsAgentNameSkillsSkillNameLogsLogIdRoute
+  '/_main/agents/$agentName/skills/$skillName/clusters/': typeof MainAgentsAgentNameSkillsSkillNameClustersIndexRoute
   '/_main/agents/$agentName/skills/$skillName/evaluations/': typeof MainAgentsAgentNameSkillsSkillNameEvaluationsIndexRoute
   '/_main/agents/$agentName/skills/$skillName/logs/': typeof MainAgentsAgentNameSkillsSkillNameLogsIndexRoute
   '/_main/agents/$agentName/skills/$skillName/clusters/$clusterId/configurations': typeof MainAgentsAgentNameSkillsSkillNameClustersClusterIdConfigurationsRouteWithChildren
@@ -401,6 +411,7 @@ export interface FileRouteTypes {
     | '/agents/$agentName/skills/$skillName/'
     | '/agents/$agentName/skills/$skillName/clusters/$clusterId'
     | '/agents/$agentName/skills/$skillName/logs/$logId'
+    | '/agents/$agentName/skills/$skillName/clusters'
     | '/agents/$agentName/skills/$skillName/evaluations/'
     | '/agents/$agentName/skills/$skillName/logs/'
     | '/agents/$agentName/skills/$skillName/clusters/$clusterId/configurations'
@@ -428,6 +439,7 @@ export interface FileRouteTypes {
     | '/agents/$agentName/skills/$skillName'
     | '/agents/$agentName/skills/$skillName/clusters/$clusterId'
     | '/agents/$agentName/skills/$skillName/logs/$logId'
+    | '/agents/$agentName/skills/$skillName/clusters'
     | '/agents/$agentName/skills/$skillName/evaluations'
     | '/agents/$agentName/skills/$skillName/logs'
     | '/agents/$agentName/skills/$skillName/evaluations/$evaluationId/edit'
@@ -459,6 +471,7 @@ export interface FileRouteTypes {
     | '/_main/agents/$agentName/skills/$skillName/'
     | '/_main/agents/$agentName/skills/$skillName/clusters/$clusterId'
     | '/_main/agents/$agentName/skills/$skillName/logs/$logId'
+    | '/_main/agents/$agentName/skills/$skillName/clusters/'
     | '/_main/agents/$agentName/skills/$skillName/evaluations/'
     | '/_main/agents/$agentName/skills/$skillName/logs/'
     | '/_main/agents/$agentName/skills/$skillName/clusters/$clusterId/configurations'
@@ -643,6 +656,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MainAgentsAgentNameSkillsSkillNameEvaluationsIndexRouteImport
       parentRoute: typeof MainAgentsAgentNameSkillsSkillNameEvaluationsRoute
     }
+    '/_main/agents/$agentName/skills/$skillName/clusters/': {
+      id: '/_main/agents/$agentName/skills/$skillName/clusters/'
+      path: '/clusters'
+      fullPath: '/agents/$agentName/skills/$skillName/clusters'
+      preLoaderRoute: typeof MainAgentsAgentNameSkillsSkillNameClustersIndexRouteImport
+      parentRoute: typeof MainAgentsAgentNameSkillsSkillNameRoute
+    }
     '/_main/agents/$agentName/skills/$skillName/logs/$logId': {
       id: '/_main/agents/$agentName/skills/$skillName/logs/$logId'
       path: '/$logId'
@@ -765,6 +785,7 @@ interface MainAgentsAgentNameSkillsSkillNameRouteChildren {
   MainAgentsAgentNameSkillsSkillNameSetupRoute: typeof MainAgentsAgentNameSkillsSkillNameSetupRoute
   MainAgentsAgentNameSkillsSkillNameIndexRoute: typeof MainAgentsAgentNameSkillsSkillNameIndexRoute
   MainAgentsAgentNameSkillsSkillNameClustersClusterIdRoute: typeof MainAgentsAgentNameSkillsSkillNameClustersClusterIdRouteWithChildren
+  MainAgentsAgentNameSkillsSkillNameClustersIndexRoute: typeof MainAgentsAgentNameSkillsSkillNameClustersIndexRoute
 }
 
 const MainAgentsAgentNameSkillsSkillNameRouteChildren: MainAgentsAgentNameSkillsSkillNameRouteChildren =
@@ -783,6 +804,8 @@ const MainAgentsAgentNameSkillsSkillNameRouteChildren: MainAgentsAgentNameSkills
       MainAgentsAgentNameSkillsSkillNameIndexRoute,
     MainAgentsAgentNameSkillsSkillNameClustersClusterIdRoute:
       MainAgentsAgentNameSkillsSkillNameClustersClusterIdRouteWithChildren,
+    MainAgentsAgentNameSkillsSkillNameClustersIndexRoute:
+      MainAgentsAgentNameSkillsSkillNameClustersIndexRoute,
   }
 
 const MainAgentsAgentNameSkillsSkillNameRouteWithChildren =

--- a/packages/web/src/routes/__tests__/route-registry.test.ts
+++ b/packages/web/src/routes/__tests__/route-registry.test.ts
@@ -32,6 +32,7 @@ const EXPECTED_ROUTE_IDS = [
   '/_main/agents/$agentName/skills/$skillName/evaluations',
   '/_main/agents/$agentName/skills/$skillName/evaluations/',
   '/_main/agents/$agentName/skills/$skillName/evaluations/$evaluationId/edit',
+  '/_main/agents/$agentName/skills/$skillName/clusters/',
   '/_main/agents/$agentName/skills/$skillName/clusters/$clusterId',
   '/_main/agents/$agentName/skills/$skillName/clusters/$clusterId/configurations',
   '/_main/agents/$agentName/skills/$skillName/clusters/$clusterId/configurations/',

--- a/packages/web/src/routes/__tests__/route-rendering.test.tsx
+++ b/packages/web/src/routes/__tests__/route-rendering.test.tsx
@@ -229,6 +229,11 @@ const ROUTE_TABLE: [string, string, string][] = [
     'page-evaluation-edit',
   ],
   [
+    'clusters index (redirects to the skill dashboard)',
+    '/agents/test-agent/skills/test-skill/clusters',
+    'page-skill-dashboard',
+  ],
+  [
     'cluster configurations',
     '/agents/test-agent/skills/test-skill/clusters/c1/configurations',
     'page-cluster-configurations',

--- a/packages/web/src/routes/_main/agents.$agentName.skills.$skillName.clusters.index.tsx
+++ b/packages/web/src/routes/_main/agents.$agentName.skills.$skillName.clusters.index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+// There is no standalone partitions list: the skill dashboard is where the
+// partitions are listed, and each card links into `/clusters/$clusterId/
+// configurations`. The breadcrumb still names `/clusters` as the parent of
+// those pages, so send the bare path to the dashboard instead of a 404.
+export const Route = createFileRoute(
+  '/_main/agents/$agentName/skills/$skillName/clusters/',
+)({
+  beforeLoad: ({ params }) => {
+    throw redirect({ to: '/agents/$agentName/skills/$skillName', params });
+  },
+  component: () => null,
+});


### PR DESCRIPTION
## Problem

The **Partitions** breadcrumb shown on every partition page links to `/agents/$agentName/skills/$skillName/clusters`, and clicking it lands on **Not Found**.

`providers/navigation/index.tsx:330` builds that crumb with `path: .../clusters`, and `RegularBreadcrumbItem` renders it as a real `<a href>`. But the TanStack Router migration (#203) ported the `clusters/[clusterName]/...` pages from the old Next.js app and not `clusters/page.tsx`, so the segment the breadcrumb names has had no route ever since — by that link or by URL. Same shape as the skill `setup` route restored in #246.

## Solution

Restoring the old page is not the fix. `ClustersView` was deleted back in #155, and the page it left behind rendered `<AgentsView />`, which has no `'clusters'` case and would have fallen through to `Unknown view`. The partitions list moved onto the skill dashboard (`skill-dashboard-view.tsx:573`), where each card links into `clusters/$clusterId/configurations`. The crumb's destination already exists; only the URL was unrouted.

So add an index route that redirects there, shaped like the other redirecting routes (`routes/index.tsx`, `login.tsx`) — `beforeLoad` throws `redirect`, the component renders nothing:

```tsx
export const Route = createFileRoute(
  '/_main/agents/$agentName/skills/$skillName/clusters/',
)({
  beforeLoad: ({ params }) => {
    throw redirect({ to: '/agents/$agentName/skills/$skillName', params });
  },
  component: () => null,
});
```

`routeTree.gen.ts` is regenerated with the router generator; the diff is additive.

## Test notes

The route registry only checks routes that *exist*, so a missing one is invisible to it — nothing caught this. The route therefore joins `EXPECTED_ROUTE_IDS`, and the rendering table gets a row that navigates to `/clusters` and asserts the skill dashboard renders, covering the redirect end to end and failing the suite if the route is dropped again.

`pnpm typecheck`, `pnpm check` and the route suites (60 tests) pass.

## Left alone

The bare `/clusters/$clusterId` (no `/configurations`) renders an empty page, since `clusters.$clusterId.tsx` is an `<Outlet />` with no index child — verified it is a blank shell rather than a 404. Nothing links to it, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHY4q7czpQVxm3cdLPPbSH