### PR TITLE
fix(web): restore the models routes dropped in the router migration

### DIFF
--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -13,13 +13,16 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as MainRouteImport } from './routes/_main'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as MainSettingsRouteImport } from './routes/_main/settings'
+import { Route as MainModelsIndexRouteImport } from './routes/_main/models.index'
 import { Route as MainAiProvidersIndexRouteImport } from './routes/_main/ai-providers.index'
 import { Route as MainAgentsIndexRouteImport } from './routes/_main/agents.index'
+import { Route as MainModelsCreateRouteImport } from './routes/_main/models.create'
 import { Route as MainModelsAddRouteImport } from './routes/_main/models.add'
 import { Route as MainAiProvidersCreateRouteImport } from './routes/_main/ai-providers.create'
 import { Route as MainAgentsCreateRouteImport } from './routes/_main/agents.create'
 import { Route as MainAgentsAgentNameRouteImport } from './routes/_main/agents.$agentName'
 import { Route as MainAgentsAgentNameIndexRouteImport } from './routes/_main/agents.$agentName.index'
+import { Route as MainModelsIdEditRouteImport } from './routes/_main/models.$id.edit'
 import { Route as MainAiProvidersIdEditRouteImport } from './routes/_main/ai-providers.$id.edit'
 import { Route as MainAiProvidersIdAddModelsRouteImport } from './routes/_main/ai-providers.$id.add-models'
 import { Route as MainAgentsAgentNameEditRouteImport } from './routes/_main/agents.$agentName.edit'
@@ -62,6 +65,13 @@ const MainSettingsRoute = MainSettingsRouteImport.update({
 } as any).lazy(() =>
   import('./routes/_main/settings.lazy').then((d) => d.Route),
 )
+const MainModelsIndexRoute = MainModelsIndexRouteImport.update({
+  id: '/models/',
+  path: '/models/',
+  getParentRoute: () => MainRoute,
+} as any).lazy(() =>
+  import('./routes/_main/models.index.lazy').then((d) => d.Route),
+)
 const MainAiProvidersIndexRoute = MainAiProvidersIndexRouteImport.update({
   id: '/ai-providers/',
   path: '/ai-providers/',
@@ -75,6 +85,13 @@ const MainAgentsIndexRoute = MainAgentsIndexRouteImport.update({
   getParentRoute: () => MainRoute,
 } as any).lazy(() =>
   import('./routes/_main/agents.index.lazy').then((d) => d.Route),
+)
+const MainModelsCreateRoute = MainModelsCreateRouteImport.update({
+  id: '/models/create',
+  path: '/models/create',
+  getParentRoute: () => MainRoute,
+} as any).lazy(() =>
+  import('./routes/_main/models.create.lazy').then((d) => d.Route),
 )
 const MainModelsAddRoute = MainModelsAddRouteImport.update({
   id: '/models/add',
@@ -110,6 +127,13 @@ const MainAgentsAgentNameIndexRoute =
   } as any).lazy(() =>
     import('./routes/_main/agents.$agentName.index.lazy').then((d) => d.Route),
   )
+const MainModelsIdEditRoute = MainModelsIdEditRouteImport.update({
+  id: '/models/$id/edit',
+  path: '/models/$id/edit',
+  getParentRoute: () => MainRoute,
+} as any).lazy(() =>
+  import('./routes/_main/models.$id.edit.lazy').then((d) => d.Route),
+)
 const MainAiProvidersIdEditRoute = MainAiProvidersIdEditRouteImport.update({
   id: '/ai-providers/$id/edit',
   path: '/ai-providers/$id/edit',
@@ -300,11 +324,14 @@ export interface FileRoutesByFullPath {
   '/agents/create': typeof MainAgentsCreateRoute
   '/ai-providers/create': typeof MainAiProvidersCreateRoute
   '/models/add': typeof MainModelsAddRoute
+  '/models/create': typeof MainModelsCreateRoute
   '/agents': typeof MainAgentsIndexRoute
   '/ai-providers': typeof MainAiProvidersIndexRoute
+  '/models': typeof MainModelsIndexRoute
   '/agents/$agentName/edit': typeof MainAgentsAgentNameEditRoute
   '/ai-providers/$id/add-models': typeof MainAiProvidersIdAddModelsRoute
   '/ai-providers/$id/edit': typeof MainAiProvidersIdEditRoute
+  '/models/$id/edit': typeof MainModelsIdEditRoute
   '/agents/$agentName/': typeof MainAgentsAgentNameIndexRoute
   '/agents/$agentName/skills/$skillName': typeof MainAgentsAgentNameSkillsSkillNameRouteWithChildren
   '/agents/$agentName/skills/create': typeof MainAgentsAgentNameSkillsCreateRoute
@@ -331,11 +358,14 @@ export interface FileRoutesByTo {
   '/agents/create': typeof MainAgentsCreateRoute
   '/ai-providers/create': typeof MainAiProvidersCreateRoute
   '/models/add': typeof MainModelsAddRoute
+  '/models/create': typeof MainModelsCreateRoute
   '/agents': typeof MainAgentsIndexRoute
   '/ai-providers': typeof MainAiProvidersIndexRoute
+  '/models': typeof MainModelsIndexRoute
   '/agents/$agentName/edit': typeof MainAgentsAgentNameEditRoute
   '/ai-providers/$id/add-models': typeof MainAiProvidersIdAddModelsRoute
   '/ai-providers/$id/edit': typeof MainAiProvidersIdEditRoute
+  '/models/$id/edit': typeof MainModelsIdEditRoute
   '/agents/$agentName': typeof MainAgentsAgentNameIndexRoute
   '/agents/$agentName/skills/create': typeof MainAgentsAgentNameSkillsCreateRoute
   '/agents/$agentName/skills/$skillName/edit': typeof MainAgentsAgentNameSkillsSkillNameEditRoute
@@ -361,11 +391,14 @@ export interface FileRoutesById {
   '/_main/agents/create': typeof MainAgentsCreateRoute
   '/_main/ai-providers/create': typeof MainAiProvidersCreateRoute
   '/_main/models/add': typeof MainModelsAddRoute
+  '/_main/models/create': typeof MainModelsCreateRoute
   '/_main/agents/': typeof MainAgentsIndexRoute
   '/_main/ai-providers/': typeof MainAiProvidersIndexRoute
+  '/_main/models/': typeof MainModelsIndexRoute
   '/_main/agents/$agentName/edit': typeof MainAgentsAgentNameEditRoute
   '/_main/ai-providers/$id/add-models': typeof MainAiProvidersIdAddModelsRoute
   '/_main/ai-providers/$id/edit': typeof MainAiProvidersIdEditRoute
+  '/_main/models/$id/edit': typeof MainModelsIdEditRoute
   '/_main/agents/$agentName/': typeof MainAgentsAgentNameIndexRoute
   '/_main/agents/$agentName/skills/$skillName': typeof MainAgentsAgentNameSkillsSkillNameRouteWithChildren
   '/_main/agents/$agentName/skills/create': typeof MainAgentsAgentNameSkillsCreateRoute
@@ -395,11 +428,14 @@ export interface FileRouteTypes {
     | '/agents/create'
     | '/ai-providers/create'
     | '/models/add'
+    | '/models/create'
     | '/agents'
     | '/ai-providers'
+    | '/models'
     | '/agents/$agentName/edit'
     | '/ai-providers/$id/add-models'
     | '/ai-providers/$id/edit'
+    | '/models/$id/edit'
     | '/agents/$agentName/'
     | '/agents/$agentName/skills/$skillName'
     | '/agents/$agentName/skills/create'
@@ -426,11 +462,14 @@ export interface FileRouteTypes {
     | '/agents/create'
     | '/ai-providers/create'
     | '/models/add'
+    | '/models/create'
     | '/agents'
     | '/ai-providers'
+    | '/models'
     | '/agents/$agentName/edit'
     | '/ai-providers/$id/add-models'
     | '/ai-providers/$id/edit'
+    | '/models/$id/edit'
     | '/agents/$agentName'
     | '/agents/$agentName/skills/create'
     | '/agents/$agentName/skills/$skillName/edit'
@@ -455,11 +494,14 @@ export interface FileRouteTypes {
     | '/_main/agents/create'
     | '/_main/ai-providers/create'
     | '/_main/models/add'
+    | '/_main/models/create'
     | '/_main/agents/'
     | '/_main/ai-providers/'
+    | '/_main/models/'
     | '/_main/agents/$agentName/edit'
     | '/_main/ai-providers/$id/add-models'
     | '/_main/ai-providers/$id/edit'
+    | '/_main/models/$id/edit'
     | '/_main/agents/$agentName/'
     | '/_main/agents/$agentName/skills/$skillName'
     | '/_main/agents/$agentName/skills/create'
@@ -516,6 +558,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MainSettingsRouteImport
       parentRoute: typeof MainRoute
     }
+    '/_main/models/': {
+      id: '/_main/models/'
+      path: '/models'
+      fullPath: '/models'
+      preLoaderRoute: typeof MainModelsIndexRouteImport
+      parentRoute: typeof MainRoute
+    }
     '/_main/ai-providers/': {
       id: '/_main/ai-providers/'
       path: '/ai-providers'
@@ -528,6 +577,13 @@ declare module '@tanstack/react-router' {
       path: '/agents'
       fullPath: '/agents'
       preLoaderRoute: typeof MainAgentsIndexRouteImport
+      parentRoute: typeof MainRoute
+    }
+    '/_main/models/create': {
+      id: '/_main/models/create'
+      path: '/models/create'
+      fullPath: '/models/create'
+      preLoaderRoute: typeof MainModelsCreateRouteImport
       parentRoute: typeof MainRoute
     }
     '/_main/models/add': {
@@ -564,6 +620,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/agents/$agentName/'
       preLoaderRoute: typeof MainAgentsAgentNameIndexRouteImport
       parentRoute: typeof MainAgentsAgentNameRoute
+    }
+    '/_main/models/$id/edit': {
+      id: '/_main/models/$id/edit'
+      path: '/models/$id/edit'
+      fullPath: '/models/$id/edit'
+      preLoaderRoute: typeof MainModelsIdEditRouteImport
+      parentRoute: typeof MainRoute
     }
     '/_main/ai-providers/$id/edit': {
       id: '/_main/ai-providers/$id/edit'
@@ -837,10 +900,13 @@ interface MainRouteChildren {
   MainAgentsCreateRoute: typeof MainAgentsCreateRoute
   MainAiProvidersCreateRoute: typeof MainAiProvidersCreateRoute
   MainModelsAddRoute: typeof MainModelsAddRoute
+  MainModelsCreateRoute: typeof MainModelsCreateRoute
   MainAgentsIndexRoute: typeof MainAgentsIndexRoute
   MainAiProvidersIndexRoute: typeof MainAiProvidersIndexRoute
+  MainModelsIndexRoute: typeof MainModelsIndexRoute
   MainAiProvidersIdAddModelsRoute: typeof MainAiProvidersIdAddModelsRoute
   MainAiProvidersIdEditRoute: typeof MainAiProvidersIdEditRoute
+  MainModelsIdEditRoute: typeof MainModelsIdEditRoute
 }
 
 const MainRouteChildren: MainRouteChildren = {
@@ -849,10 +915,13 @@ const MainRouteChildren: MainRouteChildren = {
   MainAgentsCreateRoute: MainAgentsCreateRoute,
   MainAiProvidersCreateRoute: MainAiProvidersCreateRoute,
   MainModelsAddRoute: MainModelsAddRoute,
+  MainModelsCreateRoute: MainModelsCreateRoute,
   MainAgentsIndexRoute: MainAgentsIndexRoute,
   MainAiProvidersIndexRoute: MainAiProvidersIndexRoute,
+  MainModelsIndexRoute: MainModelsIndexRoute,
   MainAiProvidersIdAddModelsRoute: MainAiProvidersIdAddModelsRoute,
   MainAiProvidersIdEditRoute: MainAiProvidersIdEditRoute,
+  MainModelsIdEditRoute: MainModelsIdEditRoute,
 }
 
 const MainRouteWithChildren = MainRoute._addFileChildren(MainRouteChildren)

--- a/packages/web/src/routes/__tests__/route-registry.test.ts
+++ b/packages/web/src/routes/__tests__/route-registry.test.ts
@@ -41,7 +41,10 @@ const EXPECTED_ROUTE_IDS = [
   '/_main/ai-providers/create',
   '/_main/ai-providers/$id/edit',
   '/_main/ai-providers/$id/add-models',
+  '/_main/models/',
   '/_main/models/add',
+  '/_main/models/create',
+  '/_main/models/$id/edit',
 ];
 
 describe('Route Registry', () => {

--- a/packages/web/src/routes/__tests__/route-rendering.test.tsx
+++ b/packages/web/src/routes/__tests__/route-rendering.test.tsx
@@ -59,6 +59,16 @@ vi.mock('@web/components/models/add-models-view', () => ({
   AddModelsView: () => <div data-testid="page-models-add" />,
 }));
 
+vi.mock('@web/components/models/models-list', () => ({
+  ModelsListView: () => <div data-testid="page-models-list" />,
+}));
+
+vi.mock('@web/components/models/model-form', () => ({
+  ModelForm: ({ modelId }: { modelId?: string }) => (
+    <div data-testid={modelId ? 'page-models-edit' : 'page-models-create'} />
+  ),
+}));
+
 vi.mock('@web/components/settings/system-settings-view', () => ({
   SystemSettingsView: () => <div data-testid="page-settings" />,
 }));
@@ -186,6 +196,9 @@ const ROUTE_TABLE: [string, string, string][] = [
   ['edit ai provider', '/ai-providers/p1/edit', 'page-ai-providers-edit'],
   ['add models to provider', '/ai-providers/p1/add-models', 'page-models-add'],
   ['add models (generic)', '/models/add?providerId=p1', 'page-models-add'],
+  ['models list', '/models', 'page-models-list'],
+  ['create model', '/models/create', 'page-models-create'],
+  ['edit model', '/models/m1/edit', 'page-models-edit'],
   ['settings', '/settings', 'page-settings'],
   ['create skill', '/agents/test-agent/skills/create', 'page-skill-create'],
   [

--- a/packages/web/src/routes/_main/models.$id.edit.lazy.tsx
+++ b/packages/web/src/routes/_main/models.$id.edit.lazy.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { createLazyFileRoute } from '@tanstack/react-router';
+import { ModelForm } from '@web/components/models/model-form';
+
+export const Route = createLazyFileRoute('/_main/models/$id/edit')({
+  component: EditModelPage,
+});
+
+function EditModelPage() {
+  const { id } = Route.useParams();
+  return <ModelForm modelId={id} />;
+}

--- a/packages/web/src/routes/_main/models.$id.edit.tsx
+++ b/packages/web/src/routes/_main/models.$id.edit.tsx
@@ -1,0 +1,3 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_main/models/$id/edit')({});

--- a/packages/web/src/routes/_main/models.create.lazy.tsx
+++ b/packages/web/src/routes/_main/models.create.lazy.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { createLazyFileRoute } from '@tanstack/react-router';
+import { ModelForm } from '@web/components/models/model-form';
+
+export const Route = createLazyFileRoute('/_main/models/create')({
+  component: ModelForm,
+});

--- a/packages/web/src/routes/_main/models.create.tsx
+++ b/packages/web/src/routes/_main/models.create.tsx
@@ -1,0 +1,3 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_main/models/create')({});

--- a/packages/web/src/routes/_main/models.index.lazy.tsx
+++ b/packages/web/src/routes/_main/models.index.lazy.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { createLazyFileRoute } from '@tanstack/react-router';
+import { ModelsListView } from '@web/components/models/models-list';
+
+export const Route = createLazyFileRoute('/_main/models/')({
+  component: ModelsListView,
+});

--- a/packages/web/src/routes/_main/models.index.tsx
+++ b/packages/web/src/routes/_main/models.index.tsx
@@ -1,0 +1,3 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_main/models/')({});


### PR DESCRIPTION
## Problem

`/models/create` answers **Not Found**. Settings' "No models configured" card links straight to it (`NoModelsWarning`, `validation-warnings.tsx:45`), as do the three "Add Model" buttons in `models-list.tsx`.

The TanStack Router migration (#203) ported the old Next.js app's `app/(main)/models/add` page but left behind the other three:

- `app/(main)/models/page.tsx`
- `app/(main)/models/create/page.tsx`
- `app/(main)/models/[id]/edit/page.tsx`

The components they rendered — `ModelsListView` and `ModelForm` — survived with nothing routing to them, so the standalone models section has been unreachable ever since, by those links or by URL.

## Solution

Add the three missing route pairs, shaped like their `ai-providers` siblings:

| route | component |
| --- | --- |
| `/models` | `ModelsListView` |
| `/models/create` | `ModelForm` |
| `/models/$id/edit` | `ModelForm modelId={id}` |

All three rather than just `create`, because they are one broken loop: `ModelForm` navigates to `/models` after saving and the list's row menu links to `/models/$id/edit`, so restoring `create` alone would land you on the next Not Found the moment you saved.

## Why nothing caught it

Those dead links go through `PermissiveLink` and `usePermissiveNavigate`, the migration's escape hatches, which cast the path to `'/'`. A route that does not exist typechecks like any other. So the routes also join `EXPECTED_ROUTE_IDS` in `route-registry.test.ts` and the table in `route-rendering.test.tsx`, where dropping them fails the suite.

## Test notes

`pnpm typecheck`, `pnpm check`, and the route, models and settings suites pass. `routeTree.gen.ts` is regenerated by `vite build`, not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ThPDrmaVh7VWhWh9uQxpJ