### PR TITLE
feat: re-judge a log's evaluations on human thumbs up/down

### DIFF
--- a/e2e/contract/optimizer.spec.ts
+++ b/e2e/contract/optimizer.spec.ts
@@ -29,6 +29,7 @@ import {
   getSkillEvaluations,
   getSkillModels,
   getSkills,
+  SKILLS_PATH,
   type Skill,
 } from '../fixtures/skills';
 
@@ -649,5 +650,108 @@ test.describe('skill creation', () => {
         return decisions.sort();
       })
       .toEqual(['created', 'embedding', 'embedding', 'embedding', 'embedding']);
+  });
+});
+
+/**
+ * Thumbs up/down on a log is the one evaluation with a human in it: posting
+ * feedback re-runs the log's evaluations with the verdict folded into the
+ * judges' prompts and replaces the stored run. The loop only executes end to
+ * end here -- the POST, the background re-run through the internal judge
+ * skill, the run replacement in storage -- and the run replacement is a
+ * storage behaviour that has to hold on both backends. It lives in this file
+ * because it writes the same global system settings row as the rest.
+ */
+test.describe('feedback re-evaluation', () => {
+  let configured: OptimizedSkill;
+
+  test.beforeAll(async ({ request }) => {
+    configured = await setUpOptimizedSkill(request, 'feedback');
+
+    // Give the skill a judge-backed evaluation to re-run.
+    const created = await request.post(
+      `${SKILLS_PATH}/${configured.skillId}/evaluations`,
+      { data: { methods: ['conversation_completeness'] } },
+    );
+    expect(created.ok()).toBe(true);
+  });
+
+  test('a thumbs down re-judges the log with the verdict as context', async ({
+    request,
+  }) => {
+    const userMessage = 'summarize the release notes for me';
+    const response = await request.post(CHAT_COMPLETIONS_PATH, {
+      headers: {
+        'sa-config': optimizedConfig(
+          configured.agentName,
+          configured.skillName,
+        ),
+      },
+      data: chatBody(userMessage),
+    });
+    expect(response.status()).toBe(200);
+
+    // The log and its realtime evaluation run are written in the background.
+    let logId = '';
+    await expect
+      .poll(async () => {
+        const logs = await getLogs(request, configured.skillId);
+        const logged = logs.find((log) =>
+          log.ai_provider_request_log.request_body.messages?.some(
+            (message) => message.content === userMessage,
+          ),
+        );
+        logId = logged?.id ?? '';
+        return logId;
+      })
+      .not.toBe('');
+
+    const runsForLog = async (): Promise<{ id: string }[]> => {
+      const runs = await request.get(
+        `${SKILLS_PATH}/${configured.skillId}/evaluation-runs`,
+        { params: { log_id: logId } },
+      );
+      return (await runs.json()) as { id: string }[];
+    };
+
+    let originalRunId = '';
+    await expect
+      .poll(
+        async () => {
+          const runs = await runsForLog();
+          originalRunId = runs[0]?.id ?? '';
+          return runs.length;
+        },
+        { timeout: 30_000 },
+      )
+      .toBe(1);
+
+    // The human presses thumbs down.
+    const feedback = await request.post('/v1/super-agents/feedbacks', {
+      data: { log_id: logId, score: 0 },
+    });
+    expect(feedback.status()).toBe(201);
+
+    // The verdict-informed run replaces the original -- still exactly one.
+    await expect
+      .poll(
+        async () => {
+          const runs = await runsForLog();
+          return runs.length === 1 && runs[0].id !== originalRunId
+            ? 'replaced'
+            : 'waiting';
+        },
+        { timeout: 30_000 },
+      )
+      .toBe('replaced');
+
+    // And the judge really was told: the re-run's request to the provider
+    // carries the verdict note.
+    const forwarded = await stubRequests(request, configured.textModel);
+    const verdictCalls = forwarded.filter((body) =>
+      JSON.stringify(body).includes('manually reviewed this exact response'),
+    );
+    expect(verdictCalls.length).toBeGreaterThan(0);
+    expect(JSON.stringify(verdictCalls)).toContain('BAD output');
   });
 });

--- a/packages/api/src/connectors/evaluations/conversation-completeness/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/conversation-completeness/service/evaluate.ts
@@ -2,11 +2,15 @@ import type {
   ConversationCompletenessEvaluationParameters,
   ConversationCompletenessResult,
 } from '@api/connectors/evaluations/conversation-completeness/types';
+import { humanVerdictNote } from '@api/evaluations/human-verdict';
 import {
   createLLMJudge,
   type LLMJudgeModelConfig,
 } from '@api/evaluations/llm-judge';
-import type { UserDataStorageConnector } from '@api/types/connector';
+import type {
+  EvaluateLogOptions,
+  UserDataStorageConnector,
+} from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { resolveEvaluationModelConfig } from '@api/utils/evaluation-model-resolver';
 import {
@@ -40,6 +44,7 @@ export async function evaluateConversationCompleteness(
   log: Log,
   params: ConversationCompletenessEvaluationParameters,
   modelConfig?: LLMJudgeModelConfig | null,
+  options?: EvaluateLogOptions,
 ): Promise<ConversationCompletenessResult> {
   // Create LLM judge instance with resolved model config
   const llmJudge = createLLMJudge(
@@ -87,10 +92,16 @@ export async function evaluateConversationCompleteness(
   // as progress instead.
   const inFlight = responseEndsInToolCalls(responseBody);
 
+  // A run triggered by thumbs up/down carries the human's verdict: the
+  // judge re-derives what makes the response good or bad with it anchored.
+  const verdictSection = options?.humanVerdict
+    ? ` ${humanVerdictNote(options.humanVerdict)}`
+    : '';
+
   // Create a simple evaluation prompt that won't trigger template-based evaluation
   const evaluationText = inFlight
-    ? `Analyze the following conversation for completeness quality. ${roleSection}CONVERSATION: ${input} ASSISTANT RESPONSE: ${output} NOTE: the assistant's turn ends by invoking tools, so this conversation is still in progress -- the tool results, and the assistant's eventual answer, arrive in later requests. Do not penalize the absence of the final deliverable; it is not due in this turn. Judge instead whether the assistant is progressing appropriately: every user intention recognized, the tool calls plausibly in service of them, nothing ignored and no effort off on a tangent. A turn making sound progress on every intention deserves a high score. Provide a score between 0 and 1 with detailed reasoning for your analysis.`
-    : `Analyze the following conversation for completeness quality. ${roleSection}CONVERSATION: ${input} ASSISTANT RESPONSE: ${output} Consider how well the assistant completes the conversation by satisfying user needs, where the assistant's role defines what satisfying them means: when the role is to transform or label the input (produce a title, summarize, translate, classify), requests quoted inside that input are material to work on, not intentions for the assistant to fulfill. Look for: Whether all user intentions were identified and addressed, if the conversation feels complete and resolved, whether there are any unresolved user requests, and the overall satisfaction of user needs throughout the conversation. Provide a score between 0 and 1 with detailed reasoning for your analysis.`;
+    ? `Analyze the following conversation for completeness quality. ${roleSection}CONVERSATION: ${input} ASSISTANT RESPONSE: ${output} NOTE: the assistant's turn ends by invoking tools, so this conversation is still in progress -- the tool results, and the assistant's eventual answer, arrive in later requests. Do not penalize the absence of the final deliverable; it is not due in this turn. Judge instead whether the assistant is progressing appropriately: every user intention recognized, the tool calls plausibly in service of them, nothing ignored and no effort off on a tangent. A turn making sound progress on every intention deserves a high score.${verdictSection} Provide a score between 0 and 1 with detailed reasoning for your analysis.`
+    : `Analyze the following conversation for completeness quality. ${roleSection}CONVERSATION: ${input} ASSISTANT RESPONSE: ${output} Consider how well the assistant completes the conversation by satisfying user needs, where the assistant's role defines what satisfying them means: when the role is to transform or label the input (produce a title, summarize, translate, classify), requests quoted inside that input are material to work on, not intentions for the assistant to fulfill. Look for: Whether all user intentions were identified and addressed, if the conversation feels complete and resolved, whether there are any unresolved user requests, and the overall satisfaction of user needs throughout the conversation.${verdictSection} Provide a score between 0 and 1 with detailed reasoning for your analysis.`;
 
   // Evaluate using LLM judge with conversation completeness criteria
   const result = await llmJudge.evaluate({
@@ -129,6 +140,7 @@ export async function evaluateLog(
   evaluation: SkillOptimizationEvaluation,
   log: Log,
   storageConnector: UserDataStorageConnector,
+  options?: EvaluateLogOptions,
 ): Promise<SkillOptimizationEvaluationResult> {
   const params =
     evaluation.params as ConversationCompletenessEvaluationParameters;
@@ -148,6 +160,7 @@ export async function evaluateLog(
     log,
     params,
     modelConfig,
+    options,
   );
 
   const execution_time = Date.now() - start_time;

--- a/packages/api/src/connectors/evaluations/human-verdict.test.ts
+++ b/packages/api/src/connectors/evaluations/human-verdict.test.ts
@@ -1,0 +1,192 @@
+import { createMockContext } from '@api/test-utils/mock-context';
+import type { UserDataStorageConnector } from '@api/types/connector';
+import { HttpMethod } from '@api/types/http';
+import { FunctionName } from '@shared/types/api/request';
+import { AIProvider } from '@shared/types/constants';
+import type { SkillOptimizationEvaluation } from '@shared/types/data';
+import type { Log } from '@shared/types/data/log';
+import { CacheMode, CacheStatus } from '@shared/types/middleware/cache';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A thumbs up/down re-runs the log's evaluations with the human verdict in
+ * the judges' prompts. This is the propagation test: every LLM-judge method
+ * must show its judge the verdict note; a judge that never hears about the
+ * verdict re-answers from the same blind spot the human just corrected.
+ */
+
+const mockParse = vi.fn();
+const mockWithOptions = vi.fn().mockReturnValue({
+  chat: { completions: { parse: mockParse, create: mockParse } },
+});
+
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: { completions: { parse: mockParse, create: mockParse } },
+    withOptions: mockWithOptions,
+  })),
+}));
+
+vi.mock('@api/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@api/constants')>();
+  return { ...actual, getApiUrl: () => 'http://localhost:8787' };
+});
+
+// A keyless provider, so the judge call is made rather than skipped
+vi.mock('@api/utils/evaluation-model-resolver', () => ({
+  resolveEvaluationModelConfig: vi.fn().mockResolvedValue({
+    model: 'judge-model',
+    provider: 'ollama',
+  }),
+}));
+
+vi.mock(
+  '@api/connectors/evaluations/task-completion/service/task-and-outcome',
+  () => ({
+    extractTaskAndOutcome: vi.fn().mockResolvedValue({
+      task: 'answer the question',
+      outcome: 'an answer was produced',
+    }),
+  }),
+);
+
+import { evaluateLog as evaluateConversationCompleteness } from '@api/connectors/evaluations/conversation-completeness/service/evaluate';
+import { evaluateLog as evaluateKnowledgeRetention } from '@api/connectors/evaluations/knowledge-retention/service/evaluate';
+import { evaluateLog as evaluateTaskCompletion } from '@api/connectors/evaluations/task-completion/service/evaluate';
+import { evaluateLog as evaluateTurnRelevancy } from '@api/connectors/evaluations/turn-relevancy/service/evaluate';
+
+const log: Log = {
+  id: 'log-1',
+  agent_id: 'agent-1',
+  skill_id: 'skill-1',
+  cluster_id: null,
+  method: HttpMethod.POST,
+  endpoint: '/v1/chat/completions',
+  function_name: FunctionName.CHAT_COMPLETE,
+  status: 200,
+  start_time: 1677652288000,
+  first_token_time: null,
+  end_time: 1677652289000,
+  duration: 1000,
+  base_sa_config: {},
+  ai_provider: AIProvider.OPENAI,
+  model: 'gpt-4',
+  hook_logs: [],
+  cache_status: CacheStatus.MISS,
+  embedding: null,
+  trace_id: null,
+  parent_span_id: null,
+  span_id: null,
+  span_name: null,
+  app_id: null,
+  external_user_id: null,
+  external_user_human_name: null,
+  original_system_prompt: null,
+  user_metadata: null,
+  metadata: {},
+  ai_provider_request_log: {
+    provider: AIProvider.OPENAI,
+    function_name: FunctionName.CHAT_COMPLETE,
+    method: HttpMethod.POST,
+    request_url: 'https://api.openai.com/v1/chat/completions',
+    request_body: {
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'What is the capital of France?' }],
+    },
+    response_body: {
+      id: 'chatcmpl-1',
+      object: 'chat.completion',
+      created: 1677652288,
+      model: 'gpt-4',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'Berlin.' },
+          finish_reason: 'stop',
+        },
+      ],
+    },
+    raw_request_body: '{}',
+    raw_response_body: '{}',
+    status: 200,
+    cache_mode: CacheMode.DISABLED,
+    cache_status: CacheStatus.MISS,
+  },
+} as unknown as Log;
+
+const evaluationOf = (method: string): SkillOptimizationEvaluation =>
+  ({
+    id: 'eval-1',
+    agent_id: 'agent-1',
+    skill_id: 'skill-1',
+    evaluation_method: method,
+    // task_completion parses its params strictly and needs the full set
+    params:
+      method === 'task_completion'
+        ? {
+            task: '',
+            threshold: 0.5,
+            include_reason: true,
+            strict_mode: false,
+            async_mode: false,
+            verbose_mode: false,
+            temperature: 0.1,
+            max_tokens: 1000,
+            batch_size: 1,
+          }
+        : { temperature: 0.1, max_tokens: 1000 },
+    weight: 1,
+    model_id: null,
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+  }) as SkillOptimizationEvaluation;
+
+const storage = {} as UserDataStorageConnector;
+
+const judges = [
+  ['conversation_completeness', evaluateConversationCompleteness],
+  ['knowledge_retention', evaluateKnowledgeRetention],
+  ['turn_relevancy', evaluateTurnRelevancy],
+  ['task_completion', evaluateTaskCompletion],
+] as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockParse.mockResolvedValue({
+    choices: [
+      {
+        message: {
+          content: JSON.stringify({ score: 0.1, reasoning: 'clearly wrong' }),
+        },
+      },
+    ],
+  });
+});
+
+describe.each(judges)('%s with a human verdict', (method, evaluateLog) => {
+  it('shows the judge the bad verdict', async () => {
+    await evaluateLog(createMockContext(), evaluationOf(method), log, storage, {
+      humanVerdict: 'bad',
+    });
+
+    const judgeSaw = JSON.stringify(mockParse.mock.calls);
+    expect(judgeSaw).toContain('manually reviewed this exact response');
+    expect(judgeSaw).toContain('BAD output');
+  });
+
+  it('shows the judge the good verdict', async () => {
+    await evaluateLog(createMockContext(), evaluationOf(method), log, storage, {
+      humanVerdict: 'good',
+    });
+
+    expect(JSON.stringify(mockParse.mock.calls)).toContain('GOOD output');
+  });
+
+  it('says nothing about a verdict on an ordinary run', async () => {
+    await evaluateLog(createMockContext(), evaluationOf(method), log, storage);
+
+    expect(JSON.stringify(mockParse.mock.calls)).not.toContain(
+      'manually reviewed',
+    );
+  });
+});

--- a/packages/api/src/connectors/evaluations/knowledge-retention/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/knowledge-retention/service/evaluate.ts
@@ -1,6 +1,10 @@
 import type { KnowledgeRetentionEvaluationParameters } from '@api/connectors/evaluations/knowledge-retention/types';
+import { humanVerdictNote } from '@api/evaluations/human-verdict';
 import { createLLMJudge } from '@api/evaluations/llm-judge';
-import type { UserDataStorageConnector } from '@api/types/connector';
+import type {
+  EvaluateLogOptions,
+  UserDataStorageConnector,
+} from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { resolveEvaluationModelConfig } from '@api/utils/evaluation-model-resolver';
 import {
@@ -28,6 +32,7 @@ export async function evaluateLog(
   evaluation: SkillOptimizationEvaluation,
   log: Log,
   storageConnector: UserDataStorageConnector,
+  options?: EvaluateLogOptions,
 ): Promise<SkillOptimizationEvaluationResult> {
   const params = evaluation.params as KnowledgeRetentionEvaluationParameters;
 
@@ -77,7 +82,12 @@ export async function evaluateLog(
     ? `THE ASSISTANT'S ROLE (its system prompt): ${role} `
     : '';
 
-  const evaluationText = `Analyze the following conversation for knowledge retention quality. ${roleSection}CONVERSATION: ${input} ASSISTANT RESPONSE: ${output} Consider how well the assistant retains and recalls information provided by the user throughout the conversation, judged against what its role requires it to carry forward. Look for: Knowledge retention vs. knowledge attrition patterns, consistency in recalling previously mentioned information, ability to maintain context across multiple turns, and specific instances where information was retained or lost. For single-turn conversations, assess if the assistant would be able to retain the information for future reference. Provide a score between 0 and 1 with detailed reasoning for your analysis.`;
+  // A feedback-triggered run carries the human's verdict as an anchor.
+  const verdictSection = options?.humanVerdict
+    ? ` ${humanVerdictNote(options.humanVerdict)}`
+    : '';
+
+  const evaluationText = `Analyze the following conversation for knowledge retention quality. ${roleSection}CONVERSATION: ${input} ASSISTANT RESPONSE: ${output} Consider how well the assistant retains and recalls information provided by the user throughout the conversation, judged against what its role requires it to carry forward. Look for: Knowledge retention vs. knowledge attrition patterns, consistency in recalling previously mentioned information, ability to maintain context across multiple turns, and specific instances where information was retained or lost. For single-turn conversations, assess if the assistant would be able to retain the information for future reference.${verdictSection} Provide a score between 0 and 1 with detailed reasoning for your analysis.`;
 
   // Explicit criteria pin the scored judge path. The old `outputFormat:
   // 'json'` call had the judge re-split this text at its first blank line --

--- a/packages/api/src/connectors/evaluations/task-completion/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/service/evaluate.ts
@@ -1,8 +1,12 @@
 import { extractTaskAndOutcome } from '@api/connectors/evaluations/task-completion/service/task-and-outcome';
 import getTaskCompletionVerdictTemplate from '@api/connectors/evaluations/task-completion/templates/verdict';
 import { TaskCompletionEvaluationParameters } from '@api/connectors/evaluations/task-completion/types';
+import { humanVerdictNote } from '@api/evaluations/human-verdict';
 import { createLLMJudge } from '@api/evaluations/llm-judge';
-import type { UserDataStorageConnector } from '@api/types/connector';
+import type {
+  EvaluateLogOptions,
+  UserDataStorageConnector,
+} from '@api/types/connector';
 import type { LLMJudge } from '@api/types/evaluations/llm-judge';
 import type { AppContext } from '@api/types/hono';
 import { resolveEvaluationModelConfig } from '@api/utils/evaluation-model-resolver';
@@ -37,13 +41,20 @@ async function generateVerdict(
     task,
     outcome,
     inProgress,
-  }: { task: string; outcome: string; inProgress: boolean },
+    humanVerdict,
+  }: {
+    task: string;
+    outcome: string;
+    inProgress: boolean;
+    humanVerdict?: 'good' | 'bad';
+  },
   llm_judge: LLMJudge,
 ): Promise<{ verdict: number; reason: string }> {
   const verdictTemplate = getTaskCompletionVerdictTemplate({
     task,
     outcome,
     inProgress,
+    humanVerdictNote: humanVerdict ? humanVerdictNote(humanVerdict) : undefined,
   });
   // Explicit prompts: the heuristic re-split of the joined text only kept
   // returning real scores because the template's JSON instruction happened
@@ -114,6 +125,7 @@ export async function evaluateLog(
   evaluation: SkillOptimizationEvaluation,
   log: Log,
   storageConnector: UserDataStorageConnector,
+  options?: EvaluateLogOptions,
 ): Promise<SkillOptimizationEvaluationResult> {
   const start_time = Date.now();
 
@@ -145,7 +157,7 @@ export async function evaluateLog(
 
     // Step 2: Generate verdict
     const { verdict, reason } = await generateVerdict(
-      { task, outcome, inProgress },
+      { task, outcome, inProgress, humanVerdict: options?.humanVerdict },
       llmJudge,
     );
     const verdict_llm_output = JSON.stringify({ verdict, reason });

--- a/packages/api/src/connectors/evaluations/task-completion/templates/verdict.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/templates/verdict.ts
@@ -7,6 +7,8 @@ export function getTaskCompletionVerdictTemplate(data: {
   task: string;
   outcome: string;
   inProgress?: boolean;
+  /** A human's verified verdict on the response, when feedback triggered this run. */
+  humanVerdictNote?: string;
 }): TaskCompletionTemplateConfig {
   // An intermediate agentic turn ends by invoking tools; the task continues
   // in later requests. Judged as a finished task it scores near zero no
@@ -35,7 +37,7 @@ Return your response as a JSON object with this exact structure:
   const userPrompt = `Task: ${data.task}
 
 Outcome: ${data.outcome}
-${data.inProgress ? '\nNote: this turn ended in tool calls, so the task is still in progress. Score how well the work so far serves the task.\n' : ''}
+${data.inProgress ? '\nNote: this turn ended in tool calls, so the task is still in progress. Score how well the work so far serves the task.\n' : ''}${data.humanVerdictNote ? `\n${data.humanVerdictNote}\n` : ''}
 Please evaluate how well the outcome fulfills the task requirements and provide a score between 0.0 and 1.0.`;
 
   return {

--- a/packages/api/src/connectors/evaluations/turn-relevancy/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/turn-relevancy/service/evaluate.ts
@@ -1,7 +1,11 @@
 import { getTurnRelevancyTemplate } from '@api/connectors/evaluations/turn-relevancy/templates/main';
 import { TurnRelevancyEvaluationParameters } from '@api/connectors/evaluations/turn-relevancy/types';
+import { humanVerdictNote } from '@api/evaluations/human-verdict';
 import { createLLMJudge } from '@api/evaluations/llm-judge';
-import type { UserDataStorageConnector } from '@api/types/connector';
+import type {
+  EvaluateLogOptions,
+  UserDataStorageConnector,
+} from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { resolveEvaluationModelConfig } from '@api/utils/evaluation-model-resolver';
 import {
@@ -93,6 +97,7 @@ export async function evaluateLog(
   evaluation: SkillOptimizationEvaluation,
   log: Log,
   storageConnector: UserDataStorageConnector,
+  options?: EvaluateLogOptions,
 ): Promise<SkillOptimizationEvaluationResult> {
   const params = TurnRelevancyEvaluationParameters.parse(evaluation.params);
 
@@ -121,6 +126,9 @@ export async function evaluateLog(
     conversation_history,
     current_turn,
     assistant_role,
+    human_verdict_note: options?.humanVerdict
+      ? humanVerdictNote(options.humanVerdict)
+      : undefined,
     strict_mode: params.strict_mode || false,
     verbose_mode: params.verbose_mode ?? true,
     include_reason: params.include_reason ?? true,

--- a/packages/api/src/connectors/evaluations/turn-relevancy/templates/main.ts
+++ b/packages/api/src/connectors/evaluations/turn-relevancy/templates/main.ts
@@ -3,6 +3,8 @@ export function getTurnRelevancyTemplate(input: {
   current_turn: string;
   /** The assistant's system prompt: relevance is relative to its job. */
   assistant_role?: string;
+  /** A human's verified verdict on the response, when feedback triggered this run. */
+  human_verdict_note?: string;
   strict_mode?: boolean;
   verbose_mode?: boolean;
   include_reason?: boolean;
@@ -11,6 +13,7 @@ export function getTurnRelevancyTemplate(input: {
     conversation_history,
     current_turn,
     assistant_role,
+    human_verdict_note,
     strict_mode,
     include_reason,
   } = input;
@@ -29,6 +32,9 @@ Return a JSON object with fields:
   }
   lines.push(`Conversation History:\n${conversation_history}`);
   lines.push(`\nCurrent Turn:\n${current_turn}`);
+  if (human_verdict_note) {
+    lines.push(`\n${human_verdict_note}`);
+  }
   lines.push(`\nInstructions:`);
   if (assistant_role) {
     lines.push(

--- a/packages/api/src/evaluations/human-verdict.ts
+++ b/packages/api/src/evaluations/human-verdict.ts
@@ -1,0 +1,13 @@
+/**
+ * A human pressed thumbs up or down on a log: the one signal in the system
+ * that is not a model's opinion. Feedback triggers a re-run of the log's
+ * evaluations carrying this note, so the judges re-derive what makes the
+ * response good or bad with the verdict as an anchor instead of guessing.
+ */
+export type HumanVerdict = 'good' | 'bad';
+
+export function humanVerdictNote(verdict: HumanVerdict): string {
+  return verdict === 'good'
+    ? 'IMPORTANT: A human has manually reviewed this exact response and verified it as a GOOD output. Treat that verdict as ground truth about the overall quality. Your job is to work out what makes it work on the dimension you are scoring and score accordingly; if your own analysis says it is bad, re-examine that analysis against the human verdict before answering -- you are likely misreading the task.'
+    : 'IMPORTANT: A human has manually reviewed this exact response and verified it as a BAD output. Treat that verdict as ground truth about the overall quality. Your job is to work out what makes it fall short on the dimension you are scoring and score accordingly; if your own analysis says it is good, re-examine that analysis against the human verdict before answering -- you are likely missing the flaw.';
+}

--- a/packages/api/src/types/connector.ts
+++ b/packages/api/src/types/connector.ts
@@ -417,6 +417,16 @@ export interface HooksConnector {
   executeHook(hook: Hook): Promise<HookResult> | HookResult;
 }
 
+/**
+ * Extra context for one evaluation pass. `humanVerdict` is set when a run
+ * was triggered by thumbs up/down feedback on the log: the LLM judges fold
+ * the verified verdict into their prompts and re-derive what makes the
+ * response good or bad; connectors that compute rather than judge ignore it.
+ */
+export interface EvaluateLogOptions {
+  humanVerdict?: 'good' | 'bad';
+}
+
 export interface EvaluationMethodConnector {
   getDetails: () => EvaluationMethodDetails;
   evaluateLog: (
@@ -424,6 +434,7 @@ export interface EvaluationMethodConnector {
     evaluation: SkillOptimizationEvaluation,
     log: Log,
     storageConnector: UserDataStorageConnector,
+    options?: EvaluateLogOptions,
   ) => Promise<SkillOptimizationEvaluationResult>;
   getParameterSchema: z.ZodType;
   getAIParameterSchema?: z.ZodType; // Optional - not all evaluations need AI for parameter generation

--- a/packages/api/src/utils/realtime-evaluations.ts
+++ b/packages/api/src/utils/realtime-evaluations.ts
@@ -1,4 +1,5 @@
 import type {
+  EvaluateLogOptions,
   EvaluationMethodConnector,
   UserDataStorageConnector,
 } from '@api/types/connector';
@@ -22,6 +23,7 @@ export async function runEvaluationsForLog(
     Record<EvaluationMethodName, EvaluationMethodConnector>
   >,
   storageConnector: UserDataStorageConnector,
+  options?: EvaluateLogOptions,
 ): Promise<SkillOptimizationEvaluationResult[]> {
   if (skillOptimizationEvaluations.length === 0) {
     return [];
@@ -45,6 +47,7 @@ export async function runEvaluationsForLog(
           evaluation,
           log,
           storageConnector,
+          options,
         );
       } catch (err) {
         // Don't throw - we want other evaluations to continue even if one fails

--- a/packages/api/src/utils/super-agents/feedback-reevaluation.test.ts
+++ b/packages/api/src/utils/super-agents/feedback-reevaluation.test.ts
@@ -1,0 +1,131 @@
+import type {
+  LogsStorageConnector,
+  UserDataStorageConnector,
+} from '@api/types/connector';
+import type { AppContext } from '@api/types/hono';
+import { runEvaluationsForLog } from '@api/utils/realtime-evaluations';
+import { reevaluateLogFromFeedback } from '@api/utils/super-agents/feedback-reevaluation';
+import type { Feedback } from '@shared/types/data/feedback';
+import type { Log } from '@shared/types/data/log';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Thumbs up/down is the one evaluation with a human in it. What must hold:
+ * the verdict reaches the judges as context, and the verdict-informed run
+ * REPLACES the log's old runs -- the eval-score view averages every run of
+ * a log, and the old scores are exactly what the human just corrected.
+ */
+
+vi.mock('@api/utils/realtime-evaluations', () => ({
+  runEvaluationsForLog: vi.fn(),
+}));
+vi.mock('@api/utils/sse-event-manager', () => ({ emitSSEEvent: vi.fn() }));
+
+const log = {
+  id: 'log-1',
+  agent_id: 'agent-1',
+  skill_id: 'skill-1',
+  cluster_id: 'cluster-1',
+} as unknown as Log;
+
+const feedbackOf = (score: number): Feedback =>
+  ({ id: 'feedback-1', log_id: 'log-1', score }) as Feedback;
+
+const evaluations = [{ id: 'eval-1', evaluation_method: 'task_completion' }];
+const newResults = [{ evaluation_id: 'eval-1', score: 0.2 }];
+
+let userData: UserDataStorageConnector;
+let logsStore: LogsStorageConnector;
+let context: AppContext;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  userData = {
+    getSkillOptimizationEvaluations: vi.fn().mockResolvedValue(evaluations),
+    getSkillOptimizationEvaluationRuns: vi
+      .fn()
+      .mockResolvedValue([{ id: 'run-old-1' }, { id: 'run-old-2' }]),
+    deleteSkillOptimizationEvaluationRun: vi.fn().mockResolvedValue(undefined),
+    createSkillOptimizationEvaluationRun: vi
+      .fn()
+      .mockResolvedValue({ id: 'run-new' }),
+  } as unknown as UserDataStorageConnector;
+  logsStore = {
+    getLogs: vi.fn().mockResolvedValue([log]),
+  } as unknown as LogsStorageConnector;
+
+  const values: Record<string, unknown> = {
+    user_data_storage_connector: userData,
+    logs_storage_connector: logsStore,
+    evaluation_connectors_map: {},
+  };
+  context = { get: (key: string) => values[key] } as unknown as AppContext;
+
+  vi.mocked(runEvaluationsForLog).mockResolvedValue(
+    newResults as unknown as Awaited<ReturnType<typeof runEvaluationsForLog>>,
+  );
+});
+
+describe('reevaluateLogFromFeedback', () => {
+  it('re-runs the evaluations with the human verdict and replaces the runs', async () => {
+    await reevaluateLogFromFeedback(context, feedbackOf(0));
+
+    // The judges are told a human verified the output as bad
+    expect(runEvaluationsForLog).toHaveBeenCalledWith(
+      context,
+      log,
+      evaluations,
+      {},
+      userData,
+      { humanVerdict: 'bad' },
+    );
+
+    // The old runs are gone and the verdict-informed one stands alone
+    expect(userData.deleteSkillOptimizationEvaluationRun).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(userData.createSkillOptimizationEvaluationRun).toHaveBeenCalledWith(
+      context,
+      {
+        agent_id: 'agent-1',
+        skill_id: 'skill-1',
+        cluster_id: 'cluster-1',
+        log_id: 'log-1',
+        results: newResults,
+      },
+    );
+  });
+
+  it('maps a thumbs up to a good verdict', async () => {
+    await reevaluateLogFromFeedback(context, feedbackOf(1));
+
+    expect(vi.mocked(runEvaluationsForLog).mock.calls[0][5]).toEqual({
+      humanVerdict: 'good',
+    });
+  });
+
+  it('keeps the old runs when the re-evaluation produces nothing', async () => {
+    // Judges can all fail (provider down). Deleting the old runs first would
+    // trade a stale score for no score at all.
+    vi.mocked(runEvaluationsForLog).mockResolvedValue([]);
+
+    await reevaluateLogFromFeedback(context, feedbackOf(0));
+
+    expect(
+      userData.deleteSkillOptimizationEvaluationRun,
+    ).not.toHaveBeenCalled();
+    expect(
+      userData.createSkillOptimizationEvaluationRun,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for a log that no longer exists', async () => {
+    vi.mocked(logsStore.getLogs).mockResolvedValue([]);
+
+    await reevaluateLogFromFeedback(context, feedbackOf(0));
+
+    expect(runEvaluationsForLog).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/utils/super-agents/feedback-reevaluation.ts
+++ b/packages/api/src/utils/super-agents/feedback-reevaluation.ts
@@ -1,0 +1,101 @@
+import type { AppContext } from '@api/types/hono';
+import { runEvaluationsForLog } from '@api/utils/realtime-evaluations';
+import { emitSSEEvent } from '@api/utils/sse-event-manager';
+import { error } from '@shared/console-logging';
+import type { Feedback } from '@shared/types/data/feedback';
+import { getRuntimeKey } from 'hono/adapter';
+
+/**
+ * Thumbs up/down on a log re-runs all of its evaluations with the human
+ * verdict folded into the judges' prompts, and REPLACES the log's stored
+ * evaluation runs with the verdict-informed one -- the log's displayed
+ * score, and the contrastive examples reflection picks its lessons from,
+ * should reflect what a human verified rather than an unanchored guess.
+ *
+ * Arm stats are left alone: a log does not record which arm served it, and
+ * the original run already paid its stats forward.
+ */
+export async function reevaluateLogFromFeedback(
+  c: AppContext,
+  feedback: Feedback,
+): Promise<void> {
+  const userDataConnector = c.get('user_data_storage_connector');
+  const logsConnector = c.get('logs_storage_connector');
+  const evaluationConnectorsMap = c.get('evaluation_connectors_map');
+
+  const [log] = await logsConnector.getLogs(c, { id: feedback.log_id });
+  if (!log) {
+    error(`[FEEDBACK_REEVAL] Log ${feedback.log_id} not found`);
+    return;
+  }
+
+  const evaluations = await userDataConnector.getSkillOptimizationEvaluations(
+    c,
+    { agent_id: log.agent_id, skill_id: log.skill_id },
+  );
+  if (evaluations.length === 0) {
+    return;
+  }
+
+  const humanVerdict = feedback.score >= 0.5 ? 'good' : 'bad';
+  const results = await runEvaluationsForLog(
+    c,
+    log,
+    evaluations,
+    evaluationConnectorsMap,
+    userDataConnector,
+    { humanVerdict },
+  );
+  if (results.length === 0) {
+    error(
+      `[FEEDBACK_REEVAL] No evaluations produced results for log ${log.id}`,
+    );
+    return;
+  }
+
+  // Replace, not append: the eval-score view averages every run of a log,
+  // and the pre-verdict scores are exactly what the human just corrected.
+  const previousRuns =
+    await userDataConnector.getSkillOptimizationEvaluationRuns(c, {
+      log_id: log.id,
+    });
+  for (const run of previousRuns) {
+    await userDataConnector.deleteSkillOptimizationEvaluationRun(c, run.id);
+  }
+
+  const evaluationRun =
+    await userDataConnector.createSkillOptimizationEvaluationRun(c, {
+      agent_id: log.agent_id,
+      skill_id: log.skill_id,
+      cluster_id: log.cluster_id ?? null,
+      log_id: log.id,
+      results,
+    });
+
+  emitSSEEvent('skill-optimization:evaluation-run-created', {
+    evaluationRun,
+    agentId: log.agent_id,
+    skillId: log.skill_id,
+    clusterId: log.cluster_id ?? null,
+    logId: log.id,
+  });
+}
+
+/**
+ * Fire-and-forget wrapper for the feedback route: the POST answers as soon
+ * as the feedback row exists, and the judges run behind it.
+ */
+export function scheduleFeedbackReevaluation(
+  c: AppContext,
+  feedback: Feedback,
+): void {
+  const reevaluation = reevaluateLogFromFeedback(c, feedback).catch((e) => {
+    error(
+      `[FEEDBACK_REEVAL] Re-evaluation for log ${feedback.log_id} failed:`,
+      e instanceof Error ? e.message : String(e),
+    );
+  });
+  if (getRuntimeKey() === 'workerd') {
+    c.executionCtx.waitUntil(reevaluation);
+  }
+}

--- a/packages/api/src/v1/super-agents/feedback.test.ts
+++ b/packages/api/src/v1/super-agents/feedback.test.ts
@@ -1,4 +1,5 @@
 import type { AppEnv } from '@api/types/hono';
+import { scheduleFeedbackReevaluation } from '@api/utils/super-agents/feedback-reevaluation';
 import { feedbacksRouter } from '@api/v1/super-agents/feedbacks';
 import type { Feedback } from '@shared/types/data/feedback';
 import { Hono } from 'hono';
@@ -136,6 +137,12 @@ const mockDeleteFeedback =
   >;
 
 // Mock uuid
+// Feedback is the thumbs up/down evaluation: creating it schedules a re-run
+// of the log's evaluations with the human verdict as judge context.
+vi.mock('@api/utils/super-agents/feedback-reevaluation', () => ({
+  scheduleFeedbackReevaluation: vi.fn(),
+}));
+
 vi.mock('uuid', () => ({
   v4: (): string => '123e4567-e89b-12d3-a456-426614174000',
 }));
@@ -290,6 +297,32 @@ describe('Feedback API', () => {
           created_at: expect.any(String),
           updated_at: expect.any(String),
         }),
+      );
+    });
+
+    it('schedules the re-evaluation with the created feedback', async () => {
+      const createdFeedback: Feedback = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        log_id: '123e4567-e89b-12d3-a456-426614174002',
+        score: 0,
+        created_at: '2023-01-01T00:00:00.000Z',
+        updated_at: '2023-01-01T00:00:00.000Z',
+      };
+      mockCreateFeedback.mockResolvedValue(createdFeedback);
+
+      const res = await app.request('/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          log_id: '123e4567-e89b-12d3-a456-426614174002',
+          score: 0,
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(scheduleFeedbackReevaluation).toHaveBeenCalledWith(
+        expect.anything(),
+        createdFeedback,
       );
     });
 

--- a/packages/api/src/v1/super-agents/feedbacks.ts
+++ b/packages/api/src/v1/super-agents/feedbacks.ts
@@ -1,5 +1,6 @@
 import type { AppEnv } from '@api/types/hono';
 import { parseDatabaseError } from '@api/utils/database-error';
+import { scheduleFeedbackReevaluation } from '@api/utils/super-agents/feedback-reevaluation';
 import { zValidator } from '@hono/zod-validator';
 import {
   FeedbackCreateParams,
@@ -31,6 +32,12 @@ export const feedbacksRouter = new Hono<AppEnv>()
       const newFeedback = await c
         .get('user_data_storage_connector')
         .createFeedback(c, feedbackData);
+
+      // The special part of this evaluation: a verified verdict re-runs the
+      // log's evaluations with the judges told a human called it good or
+      // bad, so they re-derive why. Runs behind the response.
+      scheduleFeedbackReevaluation(c, newFeedback);
+
       return c.json(newFeedback, 201);
     } catch (error) {
       console.error('Error creating feedback:', error);

--- a/packages/shared/src/types/data/feedback.ts
+++ b/packages/shared/src/types/data/feedback.ts
@@ -7,7 +7,9 @@ export const Feedback = z
     id: z.uuid(),
     log_id: z.uuid(),
     score: z.number().min(0).max(1),
-    feedback: z.string().optional(),
+    // Nullable like the column: thumbs up/down comes with no text, and both
+    // backends answer NULL for it.
+    feedback: z.string().nullable().optional(),
     created_at: z.iso.datetime({ offset: true }),
     updated_at: z.iso.datetime({ offset: true }),
   })

--- a/packages/shared/src/types/data/skill-optimization-evaluation-run.ts
+++ b/packages/shared/src/types/data/skill-optimization-evaluation-run.ts
@@ -76,7 +76,9 @@ export const SkillOptimizationEvaluationRunCreateParams = z
   .object({
     agent_id: z.uuid(),
     skill_id: z.uuid(),
-    cluster_id: z.uuid(),
+    // Nullable like the column: a feedback-triggered re-evaluation copies the
+    // log's cluster, and a log served without optimization has none.
+    cluster_id: z.uuid().nullable(),
     log_id: z.uuid(),
     results: z.array(SkillOptimizationEvaluationResult),
   })

--- a/packages/web/src/api/v1/super-agents/feedbacks.ts
+++ b/packages/web/src/api/v1/super-agents/feedbacks.ts
@@ -1,0 +1,65 @@
+import type { feedbacksRouter } from '@api/v1/super-agents/feedbacks';
+import type {
+  Feedback,
+  FeedbackQueryParams,
+} from '@shared/types/data/feedback';
+import { hc } from 'hono/client';
+
+const client = hc<typeof feedbacksRouter>('/v1/super-agents/feedbacks', {
+  init: {
+    credentials: 'include',
+  },
+});
+
+export async function getFeedback(
+  params: FeedbackQueryParams,
+): Promise<Feedback[]> {
+  const query: Record<string, string> = {};
+  if (params.id) query.id = params.id;
+  if (params.log_id) query.log_id = params.log_id;
+  if (params.limit) query.limit = params.limit.toString();
+  if (params.offset) query.offset = params.offset.toString();
+
+  const response = await client.index.$get({ query });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch feedback');
+  }
+
+  return (await response.json()) as Feedback[];
+}
+
+export async function createFeedback(params: {
+  log_id: string;
+  score: number;
+  feedback?: string;
+}): Promise<Feedback> {
+  // The create schema fills id and timestamps itself; its input type wants
+  // them present as undefined.
+  const response = await client.index.$post({
+    json: {
+      id: undefined,
+      log_id: params.log_id,
+      score: params.score,
+      feedback: params.feedback,
+      created_at: undefined,
+      updated_at: undefined,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to create feedback');
+  }
+
+  return (await response.json()) as Feedback;
+}
+
+export async function deleteFeedback(feedbackId: string): Promise<void> {
+  const response = await client[':feedbackId'].$delete({
+    param: { feedbackId },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to delete feedback');
+  }
+}

--- a/packages/web/src/components/agents/skills/logs/log-details-view.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-details-view.tsx
@@ -8,6 +8,7 @@ import { extractSystemPrompt } from '@shared/utils/system-prompt';
 import { CompletionViewer } from '@web/components/agents/skills/logs/components/completion-viewer';
 import { GenericViewer } from '@web/components/agents/skills/logs/components/generic-viewer';
 import { MessagesView } from '@web/components/agents/skills/logs/components/messages-view';
+import { LogFeedback } from '@web/components/agents/skills/logs/log-feedback';
 import { Badge } from '@web/components/ui/badge';
 import { Button } from '@web/components/ui/button';
 import {
@@ -276,6 +277,7 @@ export function LogDetailsView(): ReactElement {
         description={formatTimestamp(selectedLog.start_time)}
         showBackButton
         onBack={handleBack}
+        actions={<LogFeedback logId={selectedLog.id} />}
       />
       <div className="flex-1 overflow-hidden p-6">
         {/* Log Detail Card */}

--- a/packages/web/src/components/agents/skills/logs/log-feedback.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-feedback.test.tsx
@@ -1,0 +1,107 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The thumbs on a log: one verdict per log, the other thumb replaces it,
+ * the same thumb withdraws it. The server does the special part (re-running
+ * the evaluations); what matters here is the score each press sends.
+ */
+
+const getFeedback = vi.fn();
+const createFeedback = vi.fn();
+const deleteFeedback = vi.fn();
+
+vi.mock('@web/api/v1/super-agents/feedbacks', () => ({
+  getFeedback: (...args: unknown[]) => getFeedback(...args),
+  createFeedback: (...args: unknown[]) => createFeedback(...args),
+  deleteFeedback: (...args: unknown[]) => deleteFeedback(...args),
+}));
+
+const toast = vi.fn();
+vi.mock('@web/hooks/use-toast', () => ({
+  useToast: () => ({ toast }),
+}));
+
+import { LogFeedback } from '@web/components/agents/skills/logs/log-feedback';
+
+const renderFeedback = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LogFeedback logId="log-1" />
+    </QueryClientProvider>,
+  );
+};
+
+describe('LogFeedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends a thumbs down as score 0', async () => {
+    getFeedback.mockResolvedValue([]);
+    createFeedback.mockResolvedValue({ id: 'feedback-1', score: 0 });
+
+    renderFeedback();
+    fireEvent.click(screen.getByLabelText('Bad output'));
+
+    await waitFor(() => {
+      expect(createFeedback).toHaveBeenCalledWith({
+        log_id: 'log-1',
+        score: 0,
+      });
+    });
+    expect(deleteFeedback).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Marked as a bad output' }),
+    );
+  });
+
+  it('replaces the opposite verdict', async () => {
+    getFeedback.mockResolvedValue([
+      { id: 'feedback-1', log_id: 'log-1', score: 0 },
+    ]);
+    createFeedback.mockResolvedValue({ id: 'feedback-2', score: 1 });
+
+    renderFeedback();
+    // Wait for the existing verdict to render before pressing
+    await waitFor(() => {
+      expect(screen.getByLabelText('Bad output')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+    fireEvent.click(screen.getByLabelText('Good output'));
+
+    await waitFor(() => {
+      expect(createFeedback).toHaveBeenCalledWith({
+        log_id: 'log-1',
+        score: 1,
+      });
+    });
+    expect(deleteFeedback).toHaveBeenCalledWith('feedback-1');
+  });
+
+  it('withdraws the verdict when the same thumb is pressed again', async () => {
+    getFeedback.mockResolvedValue([
+      { id: 'feedback-1', log_id: 'log-1', score: 1 },
+    ]);
+
+    renderFeedback();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Good output')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+    fireEvent.click(screen.getByLabelText('Good output'));
+
+    await waitFor(() => {
+      expect(deleteFeedback).toHaveBeenCalledWith('feedback-1');
+    });
+    expect(createFeedback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/agents/skills/logs/log-feedback.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-feedback.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createFeedback,
+  deleteFeedback,
+  getFeedback,
+} from '@web/api/v1/super-agents/feedbacks';
+import { Button } from '@web/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@web/components/ui/tooltip';
+import { useToast } from '@web/hooks/use-toast';
+import { ThumbsDownIcon, ThumbsUpIcon } from 'lucide-react';
+import type { ReactElement } from 'react';
+
+/**
+ * Thumbs up / thumbs down on one log. This is an evaluation, but a special
+ * one: the verdict is stored as feedback (score 1 or 0) and the server
+ * re-runs every evaluation of the log with the judges told a human verified
+ * the output as good or bad, so their scores and reasoning get re-anchored.
+ * Pressing the same thumb again withdraws the feedback.
+ */
+export function LogFeedback({ logId }: { logId: string }): ReactElement {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: feedbackList = [] } = useQuery({
+    queryKey: ['feedback', logId],
+    queryFn: () => getFeedback({ log_id: logId }),
+  });
+  const existing = feedbackList[0];
+  const currentVerdict =
+    existing === undefined ? null : existing.score >= 0.5 ? 'good' : 'bad';
+
+  const mutation = useMutation({
+    mutationFn: async (verdict: 'good' | 'bad') => {
+      // One verdict per log: pressing the other thumb replaces it, pressing
+      // the same thumb withdraws it.
+      for (const feedback of feedbackList) {
+        await deleteFeedback(feedback.id);
+      }
+      if (verdict === currentVerdict) {
+        return null;
+      }
+      return await createFeedback({
+        log_id: logId,
+        score: verdict === 'good' ? 1 : 0,
+      });
+    },
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({ queryKey: ['feedback', logId] });
+      if (created) {
+        toast({
+          title:
+            created.score >= 0.5
+              ? 'Marked as a good output'
+              : 'Marked as a bad output',
+          description:
+            'Re-running the evaluations with your verdict as context.',
+        });
+      }
+    },
+    onError: () => {
+      toast({
+        title: 'Could not save feedback',
+        description: 'Please try again later',
+      });
+    },
+  });
+
+  return (
+    <TooltipProvider>
+      <div className="flex items-center gap-1">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={currentVerdict === 'good' ? 'default' : 'outline'}
+              size="icon"
+              aria-label="Good output"
+              aria-pressed={currentVerdict === 'good'}
+              disabled={mutation.isPending}
+              onClick={() => mutation.mutate('good')}
+            >
+              <ThumbsUpIcon className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="text-xs">
+              Verify as a good output and re-run the evaluations with that
+              context
+            </p>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={currentVerdict === 'bad' ? 'destructive' : 'outline'}
+              size="icon"
+              aria-label="Bad output"
+              aria-pressed={currentVerdict === 'bad'}
+              disabled={mutation.isPending}
+              onClick={() => mutation.mutate('bad')}
+            >
+              <ThumbsDownIcon className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="text-xs">
+              Verify as a bad output and re-run the evaluations with that
+              context
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
## Problem

Every evaluation score in the system is a model's opinion. When a human looks at a log and knows the output was good or bad, there was nowhere to say so — and no way to make the judges reconsider a score the human can see is wrong.

## Solution

Thumbs up / thumbs down on each log, on the log detail page. It's an evaluation, but a special one: the verdict is stored through the **existing feedback API** (score 1 = 👍, 0 = 👎 — no new evaluation method, no schema migration), and posting it re-runs every evaluation of that log with the judges told a human manually verified the output as good or bad, and asked to work out *what makes it so* rather than re-answering from the blind spot the human just corrected.

- The verdict note reaches all four LLM-judge methods (task_completion, conversation_completeness, knowledge_retention, turn_relevancy) via a new optional `EvaluateLogOptions` on the connector interface; deterministic methods (latency, tool_correctness) ignore it.
- The verdict-informed run **replaces** the log's stored runs — the eval-score view averages every run of a log, and the old scores are exactly what the human corrected. The corrected scores then feed reflection's contrastive example selection. Arm stats are untouched (a log doesn't record which arm served it). If the re-run produces nothing (judges down), the old runs are kept.
- The re-run happens in the background behind the POST (`waitUntil` on workerd).
- UI: one verdict per log; the other thumb replaces it, the same thumb withdraws it.

## Also fixed on the way

- Creating feedback without text **500ed on libSQL**: the `feedback` column is NULL but the shared schema never allowed null. Nothing had ever written feedback through that backend — the new e2e spec found it.
- The e2e spec first raced `optimizer.spec` over the global system-settings row when run as its own file; it lives inside `optimizer.spec` now, which is serial for exactly that reason.

## Test notes

- Unit: 173 files, 2805 passed — new suites for the re-evaluation flow (verdict mapping, run replacement, judges-down safety), verdict propagation into all four judges' prompts (good/bad/absent), the route trigger, and the thumbs component.
- e2e: the full loop runs on **both backends** (29/29 contract:libsql, 29/29 contract:supabase) — POST feedback → background re-judge through the internal judge skill → run replaced in storage → stub provider observed the verdict note in the judge's prompt.
- `pnpm typecheck`, `pnpm check`, `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVE6sf3u4vewGBo88kfwXF