### PR TITLE
fix(api): refuse a model delete before it detaches the model from its skills

### DIFF
--- a/packages/api/src/v1/super-agents/models.test.ts
+++ b/packages/api/src/v1/super-agents/models.test.ts
@@ -293,12 +293,72 @@ describe('Models API Status Codes', () => {
   });
 
   describe('DELETE /:id', () => {
+    const modelId = '123e4567-e89b-12d3-a456-426614174000';
+
+    const systemSettings = {
+      id: '9f6e6c1e-1f3e-4a2a-9a5f-2f2b1c9d4e10',
+      system_prompt_reflection_model_id: null,
+      evaluation_generation_model_id: null,
+      embedding_model_id: null,
+      judge_model_id: null,
+      developer_mode: false,
+      created_at: '2023-01-01T00:00:00.000Z',
+      updated_at: '2023-01-01T00:00:00.000Z',
+    };
+
     it('should return 400 for invalid UUID', async () => {
       const res = await client[':id'].$delete({
         param: { id: 'invalid-uuid' },
       });
 
       expect(res.status).toBe(400);
+    });
+
+    it('should return 409 naming the settings that use the model', async () => {
+      mockUserDataStorageConnector.getSystemSettings.mockResolvedValue({
+        ...systemSettings,
+        system_prompt_reflection_model_id: modelId,
+        judge_model_id: modelId,
+      });
+
+      const res = await client[':id'].$delete({ param: { id: modelId } });
+
+      expect(res.status).toBe(409);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toContain('System Prompt Reflection and Judge model');
+    });
+
+    it('should leave the skills alone when the delete is refused', async () => {
+      mockUserDataStorageConnector.getSystemSettings.mockResolvedValue({
+        ...systemSettings,
+        embedding_model_id: modelId,
+      });
+
+      await client[':id'].$delete({ param: { id: modelId } });
+
+      expect(
+        mockUserDataStorageConnector.getSkillsByModelId,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockUserDataStorageConnector.removeModelsFromSkill,
+      ).not.toHaveBeenCalled();
+      expect(mockUserDataStorageConnector.deleteModel).not.toHaveBeenCalled();
+    });
+
+    it('should delete a model no system setting uses', async () => {
+      mockUserDataStorageConnector.getSystemSettings.mockResolvedValue(
+        systemSettings,
+      );
+      mockUserDataStorageConnector.getSkillsByModelId.mockResolvedValue([]);
+      mockUserDataStorageConnector.deleteModel.mockResolvedValue(undefined);
+
+      const res = await client[':id'].$delete({ param: { id: modelId } });
+
+      expect(res.status).toBe(200);
+      expect(mockUserDataStorageConnector.deleteModel).toHaveBeenCalledWith(
+        expect.anything(),
+        modelId,
+      );
     });
   });
 

--- a/packages/api/src/v1/super-agents/models.ts
+++ b/packages/api/src/v1/super-agents/models.ts
@@ -12,6 +12,29 @@ import { SkillEventType } from '@shared/types/data/skill-event';
 import { Hono } from 'hono';
 import { z } from 'zod';
 
+/**
+ * The system settings that hold a model, labelled as the dashboard labels
+ * them. Both backends declare these columns `ON DELETE RESTRICT`, so a model
+ * sitting in one of them cannot be deleted -- and the database says so with a
+ * bare "FOREIGN KEY constraint failed", which names neither the setting nor
+ * the model. Checking up front also keeps a refused delete from having already
+ * detached the model from every skill that used it.
+ */
+const SYSTEM_SETTINGS_MODEL_SLOTS = [
+  ['system_prompt_reflection_model_id', 'System Prompt Reflection'],
+  ['evaluation_generation_model_id', 'Evaluation Generation'],
+  ['embedding_model_id', 'Embedding'],
+  ['judge_model_id', 'Judge'],
+] as const;
+
+/** "A", "A and B", "A, B and C". */
+function formatList(items: string[]): string {
+  if (items.length < 2) {
+    return items.join('');
+  }
+  return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
+}
+
 export const modelsRouter = new Hono<AppEnv>()
   // GET /v1/super-agents/models
   .get('/', async (c) => {
@@ -106,6 +129,25 @@ export const modelsRouter = new Hono<AppEnv>()
       try {
         const userDataStorageConnector = c.get('user_data_storage_connector');
         const { id } = c.req.valid('param');
+
+        // Before anything below detaches the model from its skills, since none
+        // of that is rolled back when the delete itself is refused.
+        const systemSettings =
+          await userDataStorageConnector.getSystemSettings(c);
+        const settingsUsingModel = SYSTEM_SETTINGS_MODEL_SLOTS.filter(
+          ([column]) => systemSettings?.[column] === id,
+        ).map(([, label]) => label);
+
+        if (settingsUsingModel.length > 0) {
+          return c.json(
+            {
+              error: `Cannot delete this model because System Settings uses it as the ${formatList(
+                settingsUsingModel,
+              )} model. Choose a different one in System Settings first.`,
+            },
+            409,
+          );
+        }
 
         // Find all skills using this model
         const affectedSkills =


### PR DESCRIPTION
## Problem

Deleting a model that System Settings uses fails, as it should — the four `system_settings` model columns are `ON DELETE RESTRICT` on both backends (`supabase/migrations/20251124192123_...sql:18-21`, `connectors/libsql/schema.ts:441-444`). But it fails badly, in two ways.

**The message names nothing.** A SQLite foreign key failure reports no table, so `parseDatabaseError` has nothing to key on and falls back to the generic 23503 text:

```
Error deleting model: LibsqlError: SQLITE_CONSTRAINT: FOREIGN KEY constraint failed
--> DELETE /v1/super-agents/models/49c318d7-... 409
```

which the dashboard toasts as *"The referenced record does not exist."* — about a model that plainly does exist. Nothing tells you which setting is holding it.

**The refusal comes too late.** The handler walks every skill using the model first — `removeModelsFromSkill`, a `MODEL_REMOVED` event, an SSE emit, `handleGenerateArms` — and only then calls `deleteModel`. None of that is in a transaction, so when the delete is refused the model has already been stripped out of its skills. The delete looks like it failed; the unwiring stands.

## Solution

Check the four settings slots up front and return 409 before touching anything:

```
Cannot delete this model because System Settings uses it as the System Prompt
Reflection, Evaluation Generation and Judge model. Choose a different one in
System Settings first.
```

The slot labels match the ones on the Settings page, so the message says where to go. The check reads the settings the connector already exposes, so it behaves the same on both backends rather than depending on how each phrases a constraint violation.

## Test notes

Three tests added to `models.test.ts`: the 409 with the right labels, that a refused delete calls neither `getSkillsByModelId` nor `removeModelsFromSkill` nor `deleteModel`, and that a model no setting uses still deletes.

Verified against a running dev server — the `DELETE` that produced the log above now returns that 409, and the dashboard toasts the API's message verbatim. `pnpm typecheck`, `pnpm check` and `pnpm test` (170 files, 2778 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsawneR8fZpJYjsfFcP3De