### PR TITLE
feat(api): repair a skill's fallback naming at early regeneration

### DIFF
--- a/packages/api/src/middlewares/optimizer/early-regeneration-create.test.ts
+++ b/packages/api/src/middlewares/optimizer/early-regeneration-create.test.ts
@@ -1,5 +1,7 @@
 import { checkAndRegenerateEvaluationsEarly } from '@api/middlewares/optimizer/evaluations';
+import { repairSkillNaming } from '@api/optimization/utils/describe-skill';
 import { regenerateEvaluationsWithExamples } from '@api/optimization/utils/evaluations';
+import { generateSeedSystemPromptWithContext } from '@api/optimization/utils/system-prompt';
 import { createMockContext } from '@api/test-utils/mock-context';
 import type {
   EvaluationMethodConnector,
@@ -34,6 +36,9 @@ vi.mock('@api/optimization/utils/evaluations', () => ({
   regenerateEvaluationsWithExamples: vi.fn(),
 }));
 vi.mock('@api/utils/sse-event-manager', () => ({ emitSSEEvent: vi.fn() }));
+vi.mock('@api/optimization/utils/describe-skill', () => ({
+  repairSkillNaming: vi.fn().mockResolvedValue(null),
+}));
 
 const mockContext = createMockContext();
 
@@ -138,6 +143,7 @@ const run = (
   );
 
 beforeEach(() => {
+  vi.mocked(repairSkillNaming).mockResolvedValue(null);
   vi.useFakeTimers({ toFake: ['Date'] });
   vi.setSystemTime(new Date('2026-03-01T12:00:00.000Z'));
   vi.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -216,6 +222,39 @@ describe('checkAndRegenerateEvaluationsEarly, past the guards', () => {
       { params: {}, weight: 1 },
     );
     expect(userData.createSkillOptimizationEvaluations).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('builds the regenerated prompt and evaluations on a repaired naming', async () => {
+    // A skill created while system settings had no models kept the
+    // heuristic fallback naming; this pass repairs it first, so everything
+    // regenerated here describes the job with the real words.
+    const skill = skillOf();
+    const { userData, logsStore } = connectors(skill, []);
+    vi.mocked(repairSkillNaming).mockResolvedValue({
+      name: 'answer-analytics-questions',
+      description: 'Answers questions about the analytics warehouse.',
+    });
+
+    await run(userData, logsStore, skill);
+
+    expect(repairSkillNaming).toHaveBeenCalledWith(
+      mockContext,
+      userData,
+      skill,
+      'an agent that answers analytics questions',
+      expect.stringContaining('How many users signed up?'),
+    );
+    expect(
+      vi.mocked(generateSeedSystemPromptWithContext).mock.calls[0][2],
+    ).toBe('Answers questions about the analytics warehouse.');
+    expect(
+      vi.mocked(regenerateEvaluationsWithExamples).mock.calls[0][1],
+    ).toEqual(
+      expect.objectContaining({
+        description: 'Answers questions about the analytics warehouse.',
+      }),
+    );
     expect(console.error).not.toHaveBeenCalled();
   });
 

--- a/packages/api/src/middlewares/optimizer/evaluations.ts
+++ b/packages/api/src/middlewares/optimizer/evaluations.ts
@@ -1,4 +1,5 @@
 import { generateExampleConversations } from '@api/middlewares/optimizer/system-prompt';
+import { repairSkillNaming } from '@api/optimization/utils/describe-skill';
 import { regenerateEvaluationsWithExamples } from '@api/optimization/utils/evaluations';
 import { generateSeedSystemPromptWithContext } from '@api/optimization/utils/system-prompt';
 import type {
@@ -176,6 +177,22 @@ export async function checkAndRegenerateEvaluationsEarly(
       return;
     }
 
+    // A skill born before system settings had models kept its heuristic
+    // fallback naming -- `describeSkillForRequest` could not be asked, and
+    // nothing else revisits naming. This pass is that retry too, and it runs
+    // first so the regenerated prompt and evaluations build on the real
+    // description rather than the boilerplate.
+    const repairedNaming = await repairSkillNaming(
+      c,
+      userDataStorageConnector,
+      skill,
+      agentDescription,
+      examples[0],
+    );
+    const describedSkill = repairedNaming
+      ? { ...skill, ...repairedNaming }
+      : skill;
+
     // Extract response format from the first log that has one (needed for system prompt)
     let responseFormat: unknown;
     for (const log of exampleLogs) {
@@ -190,7 +207,7 @@ export async function checkAndRegenerateEvaluationsEarly(
     const newSystemPrompt = await generateSeedSystemPromptWithContext(
       c,
       agentDescription,
-      skill.description,
+      describedSkill.description,
       examples,
       userDataStorageConnector,
       responseFormat,
@@ -218,7 +235,7 @@ export async function checkAndRegenerateEvaluationsEarly(
     // Regenerate evaluations with real examples
     const newEvaluationParams = await regenerateEvaluationsWithExamples(
       c,
-      skill,
+      describedSkill,
       agentDescription,
       examples,
       evaluationConnectorsMap,

--- a/packages/api/src/optimization/utils/describe-skill.test.ts
+++ b/packages/api/src/optimization/utils/describe-skill.test.ts
@@ -1,6 +1,9 @@
 import {
+  awaitingRealNaming,
   describeSkillForRequest,
+  HEURISTIC_DESCRIPTION_PREFIX,
   heuristicSkillNaming,
+  repairSkillNaming,
   slugifySkillName,
   uniqueSkillName,
 } from '@api/optimization/utils/describe-skill';
@@ -8,7 +11,8 @@ import { createMockContext } from '@api/test-utils/mock-context';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
 import { AIProvider } from '@shared/types/constants';
-import type { Agent } from '@shared/types/data';
+import type { Agent, Skill } from '@shared/types/data';
+import { SkillEventType } from '@shared/types/data/skill-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockParse = vi.fn();
@@ -27,6 +31,8 @@ vi.mock('@api/constants', async (importOriginal) => ({
 vi.mock('@api/utils/evaluation-model-resolver', () => ({
   resolveSystemSettingsModel: vi.fn(),
 }));
+
+vi.mock('@api/utils/sse-event-manager', () => ({ emitSSEEvent: vi.fn() }));
 
 describe('slugifySkillName', () => {
   it('produces a name the skill schema accepts', () => {
@@ -198,5 +204,184 @@ describe('describeSkillForRequest', () => {
     );
 
     expect(naming.name).toBe(heuristicSkillNaming(intent).name);
+  });
+});
+
+describe('repairSkillNaming', () => {
+  const c = createMockContext();
+
+  /** A skill that was created while system settings had no models. */
+  const brokenSkill = (overrides: Partial<Skill> = {}): Skill =>
+    ({
+      id: 'skill-1',
+      agent_id: 'agent-1',
+      name: 'you-are-a-restaurant-concierge',
+      auto_created: true,
+      description: `${HEURISTIC_DESCRIPTION_PREFIX} You are a restaurant concierge.`,
+      seed_system_prompt: 'You are a restaurant concierge.',
+      ...overrides,
+    }) as Skill;
+
+  const repairConnector = (siblings: string[] = ['translate']) =>
+    ({
+      getSkills: vi
+        .fn()
+        .mockResolvedValue(
+          [...siblings, 'you-are-a-restaurant-concierge'].map((name) => ({
+            name,
+          })),
+        ),
+      updateSkill: vi.fn().mockResolvedValue(undefined),
+      createSkillEvent: vi.fn().mockResolvedValue(undefined),
+    }) as unknown as UserDataStorageConnector;
+
+  const modelSays = (parsed: unknown) =>
+    mockParse.mockResolvedValue({ choices: [{ message: { parsed } }] });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(resolveSystemSettingsModel).mockResolvedValue({
+      model: 'gpt-5-mini',
+      provider: AIProvider.OPENAI,
+      apiKey: 'sk-test',
+    });
+  });
+
+  it('renames a skill stuck with its fallback naming', async () => {
+    const connector = repairConnector();
+    modelSays({
+      name: 'restaurant-concierge',
+      description: 'Books tables and answers questions about the restaurant.',
+    });
+
+    const naming = await repairSkillNaming(
+      c,
+      connector,
+      brokenSkill(),
+      'Helps guests of the restaurant.',
+      'User: a table for two\n\nAssistant: Booked.',
+    );
+
+    expect(naming).toEqual({
+      name: 'restaurant-concierge',
+      description: 'Books tables and answers questions about the restaurant.',
+    });
+    expect(connector.updateSkill).toHaveBeenCalledWith(c, 'skill-1', {
+      name: 'restaurant-concierge',
+      description: 'Books tables and answers questions about the restaurant.',
+    });
+    expect(connector.createSkillEvent).toHaveBeenCalledWith(
+      c,
+      expect.objectContaining({
+        skill_id: 'skill-1',
+        event_type: SkillEventType.DESCRIPTION_UPDATED,
+        metadata: expect.objectContaining({
+          previous_name: 'you-are-a-restaurant-concierge',
+        }),
+      }),
+    );
+    // The describer saw the seed prompt and the real example.
+    const request = mockParse.mock.calls[0][0] as {
+      messages: { content: string }[];
+    };
+    expect(request.messages[1].content).toContain(
+      'You are a restaurant concierge.',
+    );
+    expect(request.messages[1].content).toContain('a table for two');
+  });
+
+  it('suffixes a name a sibling already has', async () => {
+    const connector = repairConnector(['restaurant-concierge']);
+    modelSays({
+      name: 'restaurant-concierge',
+      description: 'Books tables and answers questions about the restaurant.',
+    });
+
+    const naming = await repairSkillNaming(
+      c,
+      connector,
+      brokenSkill(),
+      'Helps guests of the restaurant.',
+    );
+
+    expect(naming?.name).toBe('restaurant-concierge-2');
+  });
+
+  it('keeps the fallback when the describer falls back again', async () => {
+    vi.mocked(resolveSystemSettingsModel).mockResolvedValue(null);
+    const connector = repairConnector();
+
+    const naming = await repairSkillNaming(
+      c,
+      connector,
+      brokenSkill(),
+      'Helps guests of the restaurant.',
+    );
+
+    expect(naming).toBeNull();
+    expect(connector.updateSkill).not.toHaveBeenCalled();
+  });
+
+  it('leaves a skill with real naming alone', async () => {
+    const connector = repairConnector();
+
+    const naming = await repairSkillNaming(
+      c,
+      connector,
+      brokenSkill({ description: 'Books tables for restaurant guests.' }),
+      'Helps guests of the restaurant.',
+    );
+
+    expect(naming).toBeNull();
+    expect(mockParse).not.toHaveBeenCalled();
+    expect(vi.mocked(connector.getSkills)).not.toHaveBeenCalled();
+  });
+
+  it('leaves a skill with no seed prompt alone', async () => {
+    const connector = repairConnector();
+
+    expect(
+      await repairSkillNaming(
+        c,
+        connector,
+        brokenSkill({ seed_system_prompt: null }),
+        'Helps guests of the restaurant.',
+      ),
+    ).toBeNull();
+    expect(mockParse).not.toHaveBeenCalled();
+  });
+
+  it('answers null when the rename cannot be written', async () => {
+    const connector = repairConnector();
+    vi.mocked(connector.updateSkill).mockRejectedValue(new Error('storage'));
+    modelSays({
+      name: 'restaurant-concierge',
+      description: 'Books tables and answers questions about the restaurant.',
+    });
+
+    await expect(
+      repairSkillNaming(
+        c,
+        connector,
+        brokenSkill(),
+        'Helps guests of the restaurant.',
+      ),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('awaitingRealNaming', () => {
+  it('flags only auto-created skills still carrying the fallback', () => {
+    const description = `${HEURISTIC_DESCRIPTION_PREFIX} You translate.`;
+    expect(awaitingRealNaming({ auto_created: true, description })).toBe(true);
+    expect(awaitingRealNaming({ auto_created: false, description })).toBe(
+      false,
+    );
+    expect(
+      awaitingRealNaming({
+        auto_created: true,
+        description: 'Translates whatever the user sends.',
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/api/src/optimization/utils/describe-skill.ts
+++ b/packages/api/src/optimization/utils/describe-skill.ts
@@ -2,8 +2,10 @@ import { getApiUrl } from '@api/constants';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
-import { warn } from '@shared/console-logging';
-import type { Agent } from '@shared/types/data';
+import { emitSSEEvent } from '@api/utils/sse-event-manager';
+import { info, warn } from '@shared/console-logging';
+import type { Agent, Skill } from '@shared/types/data';
+import { SkillEventType } from '@shared/types/data/skill-event';
 import OpenAI from 'openai';
 import { z } from 'zod';
 
@@ -69,15 +71,33 @@ export function heuristicSkillNaming(intent: string): SkillNaming {
       .find(Boolean) ?? '';
   const name = slugifySkillName(firstLine.split(/\s+/).slice(0, 5).join(' '));
   const description =
-    `Created by the gateway for requests whose instructions begin: ${intent.slice(0, 500)}`.slice(
+    `${HEURISTIC_DESCRIPTION_PREFIX} ${intent.slice(0, 500)}`.slice(
       0,
       DESCRIPTION_MAX_LENGTH,
     );
   return { name, description };
 }
 
+/**
+ * How every heuristic description begins -- and, still standing on a skill,
+ * the sign that `describeSkillForRequest` could not be asked when the skill
+ * was created and the skill is waiting for a real name.
+ */
+export const HEURISTIC_DESCRIPTION_PREFIX =
+  'Created by the gateway for requests whose instructions begin:';
+
+/** Whether a skill still carries the naming creation fell back to. */
+export function awaitingRealNaming(
+  skill: Pick<Skill, 'auto_created' | 'description'>,
+): boolean {
+  return (
+    skill.auto_created &&
+    skill.description.startsWith(HEURISTIC_DESCRIPTION_PREFIX)
+  );
+}
+
 function describerUserMessage(
-  agent: Agent,
+  agent: Pick<Agent, 'description'>,
   intent: string,
   takenNames: string[],
 ): string {
@@ -106,7 +126,7 @@ ${intent}${taken}`;
 export async function describeSkillForRequest(
   c: AppContext,
   connector: UserDataStorageConnector,
-  agent: Agent,
+  agent: Pick<Agent, 'description'>,
   intent: string,
   takenNames: string[],
 ): Promise<SkillNaming> {
@@ -198,5 +218,91 @@ export async function describeSkillForRequest(
       e,
     );
     return fallback;
+  }
+}
+
+/** Enough of an example conversation to show the describer the job. */
+const REPAIR_EXAMPLE_MAX_LENGTH = 1000;
+
+/**
+ * Gives a skill stuck with its heuristic fallback naming the real name it
+ * missed at creation.
+ *
+ * A skill created before system settings had models -- mid-setup, most
+ * often -- could not ask `describe-skill` and kept the fallback: its
+ * prompt's first words as the name, the "created by the gateway"
+ * boilerplate as the description. Nothing else ever revisits naming, so the
+ * early-regeneration pass calls this as its repair moment, the same way it
+ * retries missing evaluations. Asks the describer again with the seed
+ * prompt and a real example, and only keeps an answer that is not the
+ * fallback -- one shot, since the pass runs once per skill. Nothing here
+ * can fail the pass; a repair that goes wrong answers null and the skill
+ * keeps the naming it has.
+ */
+export async function repairSkillNaming(
+  c: AppContext,
+  connector: UserDataStorageConnector,
+  skill: Skill,
+  agentDescription: string,
+  example?: string,
+): Promise<SkillNaming | null> {
+  if (!awaitingRealNaming(skill) || !skill.seed_system_prompt) {
+    return null;
+  }
+  try {
+    const intent = [
+      skill.seed_system_prompt,
+      example?.slice(0, REPAIR_EXAMPLE_MAX_LENGTH),
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+    const siblings = await connector.getSkills(c, {
+      agent_id: skill.agent_id,
+    });
+    const takenNames = siblings
+      .map((sibling) => sibling.name)
+      .filter((name) => name !== skill.name);
+
+    const naming = await describeSkillForRequest(
+      c,
+      connector,
+      { description: agentDescription },
+      intent,
+      takenNames,
+    );
+    if (naming.description.startsWith(HEURISTIC_DESCRIPTION_PREFIX)) {
+      // The describer fell back again; the naming we have says as much.
+      return null;
+    }
+
+    const name = uniqueSkillName(naming.name, takenNames);
+    await connector.updateSkill(c, skill.id, {
+      name,
+      description: naming.description,
+    });
+    await connector.createSkillEvent(c, {
+      agent_id: skill.agent_id,
+      skill_id: skill.id,
+      cluster_id: null,
+      event_type: SkillEventType.DESCRIPTION_UPDATED,
+      metadata: {
+        reason: 'heuristic_naming_repaired',
+        previous_name: skill.name,
+      },
+    });
+    emitSSEEvent('skill:updated', {
+      skillId: skill.id,
+      agentId: skill.agent_id,
+    });
+    info(
+      `[SKILL_CREATION] Renamed skill ${skill.name} to ${name}, repairing its fallback naming`,
+    );
+    return { name, description: naming.description };
+  } catch (e) {
+    warn(
+      `[SKILL_CREATION] Could not repair the naming of skill ${skill.name}:`,
+      e,
+    );
+    return null;
   }
 }

--- a/packages/shared/src/types/data/skill.ts
+++ b/packages/shared/src/types/data/skill.ts
@@ -130,6 +130,15 @@ export type SkillCreateParams = z.infer<typeof SkillCreateParams>;
 
 export const SkillUpdateParams = z
   .object({
+    name: z
+      .string()
+      .min(3)
+      .max(100)
+      .regex(/^[a-z0-9_-]+$/, {
+        message:
+          'Name must only contain lowercase letters, numbers, underscores, and hyphens',
+      })
+      .optional(),
     description: z.string().min(25).max(10000).optional(),
     metadata: SkillMetadata.optional(),
     optimize: z.boolean().optional(),
@@ -155,6 +164,7 @@ export const SkillUpdateParams = z
   .refine(
     (data) => {
       const updateFields = [
+        'name',
         'description',
         'metadata',
         'optimize',


### PR DESCRIPTION
## Problem

A skill auto-created before system settings point at any models — easy to hit mid-setup, since routing needs no models but `describe-skill` does — keeps its heuristic fallback forever: the prompt's first words as its name (`you-are-a-title-generator`), the "Created by the gateway for requests whose instructions begin:" boilerplate as its description. Nothing revisits naming, so a badly-timed birth sticks.

## Solution

The early-regeneration pass (after a skill's first 5 requests) is already the repair moment for auto-created skills — it retries their missing evaluations. It now repairs naming the same way:

- `repairSkillNaming` re-asks `describe-skill` for an auto-created skill whose description still starts with the fallback marker, feeding it the seed system prompt plus one real example conversation from the same 5 logs the pass already extracted.
- It runs **before** the prompt/evaluation regeneration, so those build on the real description instead of the boilerplate.
- Only a non-fallback answer is kept (one shot — the pass runs once per skill); sibling names get suffixed rather than collided with; any failure warns, returns null, and the pass continues untouched.
- Emits `skill:updated` + a `DESCRIPTION_UPDATED` skill event recording the previous name.

Skill names were not updatable at all, so `SkillUpdateParams` gains `name` with the same validation as creation (`^[a-z0-9_-]+$`, 3–100 chars); both backends enforce `UNIQUE (agent_id, name)`.

## Tests

- 7 new tests for `repairSkillNaming` + `awaitingRealNaming` (rename, sibling suffixing, fallback-again, curated skill untouched, no seed prompt, storage failure).
- Early-regeneration full-path test asserting the repaired description flows into the regenerated prompt and evaluations.
- Full gate: 2806 unit tests / 173 files, e2e 61/61 on contract:libsql, build + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVE6sf3u4vewGBo88kfwXF