### PR TITLE
fix(api): stop restating response_format in the system prompt

### DIFF
--- a/packages/api/src/handlers/handler-utils.test.ts
+++ b/packages/api/src/handlers/handler-utils.test.ts
@@ -51,6 +51,8 @@ import type {
   SuperAgentsTarget,
 } from '@shared/types/api/request/headers';
 import { HeaderKey, StrategyModes } from '@shared/types/api/request/headers';
+import type { ChatCompletionRequestBody } from '@shared/types/api/routes/chat-completions-api/request';
+import type { ChatCompletionMessage } from '@shared/types/api/routes/shared/messages';
 import { ChatCompletionMessageRole } from '@shared/types/api/routes/shared/messages';
 import { AIProvider, ContentTypeName } from '@shared/types/constants';
 import { CacheMode } from '@shared/types/middleware/cache';
@@ -303,6 +305,149 @@ describe('tryPost Error Handling', () => {
       );
 
       expect(mockSuperAgentsRequestData.requestBody).toEqual(before);
+    });
+  });
+
+  describe('the JSON instructions added for `response_format`', () => {
+    /**
+     * Restating the schema in the system prompt is a fallback for providers
+     * that cannot express the constraint at all. Handing it to a provider that
+     * carries `response_format` itself only buries the skill's own prompt --
+     * for `json_schema` the block was prepended, so the skill's instructions
+     * ended up behind gateway boilerplate.
+     */
+    afterEach(() => {
+      vi.mocked(transformToProviderRequest).mockReset();
+    });
+
+    /** Records the body handed to the provider transform, then stops there. */
+    const captureProviderBody = (functionConfig?: AIProviderConfig) => {
+      (providerConfigs as Record<string, AIProviderConfig | undefined>)[
+        mockSuperAgentsTarget.configuration.ai_provider
+      ] = {
+        api: {
+          getBaseURL: vi.fn().mockResolvedValue('https://api.example.com'),
+          getEndpoint: vi.fn().mockReturnValue('/v1/chat/completions'),
+          headers: vi.fn().mockResolvedValue({}),
+        },
+        ...functionConfig,
+      } as unknown as AIProviderConfig;
+      vi.mocked(inputHookHandler).mockResolvedValue({
+        errorResponse: undefined,
+        transformedSuperAgentsBody: undefined,
+      });
+
+      const seen: { messages?: ChatCompletionMessage[] } = {};
+      vi.mocked(transformToProviderRequest).mockImplementation(
+        (_provider, _saTarget, saRequestData) => {
+          seen.messages = (
+            saRequestData.requestBody as ChatCompletionRequestBody
+          ).messages;
+          throw new Error('stop here');
+        },
+      );
+      return seen;
+    };
+
+    const nativeResponseFormat = {
+      [FunctionName.CHAT_COMPLETE]: {
+        response_format: { param: 'response_format' },
+      },
+    } as unknown as AIProviderConfig;
+
+    const askForJson = () => {
+      mockSuperAgentsRequestData.requestBody = {
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: ChatCompletionMessageRole.USER, content: 'Hello' }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'answer',
+            schema: { type: 'object', properties: { a: { type: 'string' } } },
+          },
+        },
+      } as never;
+      mockSuperAgentsTarget.configuration.system_prompt = 'You are helpful.';
+    };
+
+    it('are left out when the provider forwards `response_format`', async () => {
+      const seen = captureProviderBody(nativeResponseFormat);
+      askForJson();
+
+      await tryPost(
+        mockContext,
+        mockSuperAgentsConfig,
+        mockSuperAgentsTarget,
+        mockSuperAgentsRequestData,
+        0,
+      );
+
+      expect(seen.messages?.[0]).toEqual({
+        role: ChatCompletionMessageRole.SYSTEM,
+        content: 'You are helpful.',
+      });
+    });
+
+    it('are left out for Anthropic, which builds the tool itself', async () => {
+      mockSuperAgentsTarget.configuration.ai_provider = AIProvider.ANTHROPIC;
+      const seen = captureProviderBody();
+      askForJson();
+
+      await tryPost(
+        mockContext,
+        mockSuperAgentsConfig,
+        mockSuperAgentsTarget,
+        mockSuperAgentsRequestData,
+        0,
+      );
+
+      expect(seen.messages?.[0]).toEqual({
+        role: ChatCompletionMessageRole.SYSTEM,
+        content: 'You are helpful.',
+      });
+    });
+
+    it('are added when the provider has no way to ask for JSON', async () => {
+      const seen = captureProviderBody();
+      askForJson();
+
+      await tryPost(
+        mockContext,
+        mockSuperAgentsConfig,
+        mockSuperAgentsTarget,
+        mockSuperAgentsRequestData,
+        0,
+      );
+
+      const systemPrompt = seen.messages?.[0].content as string;
+      expect(systemPrompt).toContain('strictly conforms to the following');
+      expect(systemPrompt).toContain('You are helpful.');
+      expect(systemPrompt).not.toContain('__json_output');
+    });
+
+    it('are left out of a caller system message the provider can constrain', async () => {
+      const seen = captureProviderBody(nativeResponseFormat);
+      askForJson();
+      (
+        mockSuperAgentsRequestData.requestBody as ChatCompletionRequestBody
+      ).messages.unshift({
+        role: ChatCompletionMessageRole.SYSTEM,
+        content: 'From the caller',
+      });
+      mockSuperAgentsTarget.configuration.system_prompt = null;
+
+      await tryPost(
+        mockContext,
+        mockSuperAgentsConfig,
+        mockSuperAgentsTarget,
+        mockSuperAgentsRequestData,
+        0,
+      );
+
+      expect(seen.messages?.[0]).toEqual({
+        role: ChatCompletionMessageRole.SYSTEM,
+        content: 'From the caller',
+      });
     });
   });
 

--- a/packages/api/src/handlers/handler-utils.ts
+++ b/packages/api/src/handlers/handler-utils.ts
@@ -222,21 +222,39 @@ export async function tryPost(
       ...overrideParams,
     } as SuperAgentsRequestBody;
 
-    // Anthropic has no `response_format`, so the gateway emulates it with the
-    // `__json_output` tool (see ai-providers/anthropic/chat-complete.ts). Every
-    // other provider has to put the JSON in the message itself, and telling one
-    // to call a tool it was never given is how answers end up narrated or
-    // wrapped in a ```json fence.
-    const jsonOutputInstruction =
-      saTarget.configuration.ai_provider === AIProvider.ANTHROPIC
-        ? 'Use the __json_output tool to provide your response.'
-        : 'Respond with the JSON object alone: no markdown code fences, no commentary, no other text.';
+    // `response_format` is an OpenAI concept, and most providers carry it
+    // themselves: either as a parameter their config forwards, or -- Anthropic,
+    // which has no such field -- as the `__json_output` tool that config builds,
+    // forces through `tool_choice`, and explains in a system instruction of its
+    // own (see ai-providers/anthropic/chat-complete.ts). Where the provider is
+    // already constraining the output, restating the schema in the system prompt
+    // adds nothing and crowds out the prompt the skill was configured with.
+    const providerCarriesResponseFormat = ((): boolean => {
+      const provider = saTarget.configuration.ai_provider;
+      if (provider === AIProvider.ANTHROPIC) return true;
 
-    // Helper to generate JSON schema instructions for response_format
+      const providerConfig = providerConfigs[provider];
+      const functionConfig = providerConfig?.getConfig
+        ? providerConfig.getConfig(overriddenSuperAgentsRequestBody)[
+            saRequestData.functionName
+          ]
+        : providerConfig?.[saRequestData.functionName];
+
+      return Boolean(functionConfig && 'response_format' in functionConfig);
+    })();
+
+    // Helper to generate JSON schema instructions for response_format.
+    // Only for the providers that cannot express the constraint at all
+    // (Bedrock, Replicate, Workers AI, ...), which have to be asked in prose.
     const getJsonSchemaInstructions = (
       responseFormat: ChatCompletionRequestBody['response_format'],
     ): string => {
-      if (!responseFormat) return '';
+      if (!responseFormat || providerCarriesResponseFormat) return '';
+
+      // Telling a provider to call a tool it was never given is how answers end
+      // up narrated or wrapped in a ```json fence, so ask for the bare object.
+      const jsonOutputInstruction =
+        'Respond with the JSON object alone: no markdown code fences, no commentary, no other text.';
 
       if (responseFormat.type === 'json_schema') {
         const schema =


### PR DESCRIPTION
Fixes #173

## Problem

`tryPost` (`packages/api/src/handlers/handler-utils.ts`) spliced a JSON-mode block into the system prompt whenever a request carried `response_format` — for **every** provider. For `json_schema` it *prepended* the block, so the skill's own configured prompt ended up behind gateway boilerplate plus a pretty-printed dump of the whole schema.

Almost nobody needed it:

- **Anthropic** already handles this in its own config (`ai-providers/anthropic/chat-complete.ts`): it builds the `__json_output` tool, forces it through `tool_choice`, and appends its own system instruction. The handler was adding a second, duplicate one.
- **Most other providers** forward `response_format` as a parameter — OpenAI, Azure, Google, Vertex, DeepSeek, Mistral, xAI, Ollama, OpenRouter, Together, Fireworks, HuggingFace, and everything built on `open-ai-base` (Groq et al.). They are already constraining the output; restating the schema in prose only crowds the prompt.

Only providers with no way to express the constraint at all — Bedrock, Replicate, Workers AI, AI21, PaLM, Reka, Upstage, DeepInfra, SiliconFlow — actually have to be asked in prose.

## Solution

The instructions become what they were meant to be: a fallback. A new `providerCarriesResponseFormat` check reads the provider's *own* function config — honouring `getConfig`, so Bedrock's per-model configs resolve — and returns true when it declares a `response_format` parameter, or when the provider is Anthropic. When it does, `getJsonSchemaInstructions` returns `''` and the system prompt reaches the model exactly as configured.

Reading the config rather than a hard-coded provider list means a provider that later gains or loses `response_format` support — including one `chatCompleteParams(exclude)` strips it from — needs no change here. The Anthropic branch of `jsonOutputInstruction` is gone, since Anthropic no longer reaches the fallback.

## Test notes

Four new cases in `handler-utils.test.ts`, each asserting on the body that reached the provider transform:

- native `response_format` → no injection
- Anthropic → no injection
- a provider with no support → injected, and no stale `__json_output` mention
- a caller-supplied system message the provider can constrain → left untouched

Three of them fail against the old behaviour (verified by disabling the new check).

- `pnpm typecheck` — clean
- `pnpm test` — 2810 passed
- `pnpm test:e2e` — 61 passed

`pnpm check` reports two findings that predate this branch and are in untouched files (an unused `StructuredOutputResponse` alias in `connectors/evaluations/task-completion/service/task-and-outcome.ts`, and a formatting diff in `optimization/utils/describe-skill.test.ts`). Left alone as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155XSuzBVYjY9eSMk1jkkNY