### PR TITLE
fix(api): drop the parameters a model rejects, and pass its error through

### DIFF
--- a/packages/api/src/ai-providers/openai/model-capabilities.ts
+++ b/packages/api/src/ai-providers/openai/model-capabilities.ts
@@ -25,10 +25,13 @@ export const openAIModelCapabilities: ProviderModelCapabilities = {
   },
 
   models: [
-    // GPT-5 models (reasoning models)
+    // GPT-5 reasoning models: gpt-5, -mini, -nano, -pro, the 5.x point
+    // releases and their dated snapshots. Only the default temperature is
+    // accepted, so sampling parameters are dropped rather than sent. The
+    // `-chat` variants are ordinary chat models and take them.
     // Support reasoning_effort: minimal, low, medium, high
     {
-      modelPattern: /^(gpt-5|gpt-5-mini|gpt-5-nano)$/,
+      modelPattern: /^gpt-5(?!-chat)([.-].*)?$/,
       endpointConfigs: {
         [FunctionName.CHAT_COMPLETE]: {
           unsupportedParameters: [

--- a/packages/api/src/errors/http.ts
+++ b/packages/api/src/errors/http.ts
@@ -2,6 +2,14 @@ export interface ErrorResponse {
   status: number;
   statusText: string;
   body: string;
+  /**
+   * The provider's `content-type`, so the body reaches the caller as what it
+   * is. A `Response` built from a string without one is `text/plain`, which
+   * sends a provider's JSON error through the text path and buries it inside
+   * `{"html-message": ...}` -- where the OpenAI client reports it as
+   * "400 status code (no body)".
+   */
+  contentType?: string;
 }
 
 export class HttpError extends Error {
@@ -11,5 +19,15 @@ export class HttpError extends Error {
     super(message);
     this.name = 'HttpError';
     this.response = response;
+  }
+
+  /** The error as the response it came from, status and content type intact. */
+  toResponse(): Response {
+    const { body, status, statusText, contentType } = this.response;
+    return new Response(body, {
+      status,
+      statusText,
+      ...(contentType ? { headers: { 'content-type': contentType } } : {}),
+    });
   }
 }

--- a/packages/api/src/handlers/handler-utils.test.ts
+++ b/packages/api/src/handlers/handler-utils.test.ts
@@ -42,8 +42,10 @@ import type { AppContext } from '@api/types/hono';
 import { HttpMethod } from '@api/types/http';
 import { getCachedResponse } from '@api/utils/cache';
 import { inputHookHandler } from '@api/utils/hooks';
+import { registerProviderCapabilities } from '@api/utils/model-validator';
 import { constructRequest } from '@api/utils/super-agents/requests';
 import type { AIProviderConfig } from '@shared/types/ai-providers/config';
+import { ModelParameter } from '@shared/types/ai-providers/model-capabilities';
 import { FunctionName } from '@shared/types/api/request';
 import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
 import type {
@@ -303,6 +305,58 @@ describe('tryPost Error Handling', () => {
       );
 
       expect(mockSuperAgentsRequestData.requestBody).toEqual(before);
+    });
+
+    /**
+     * The capability table kept unsupported parameters out of the target's
+     * defaults, but a `temperature` the caller sent rode through the spread
+     * untouched -- and a reasoning model rejects the whole request over it.
+     */
+    it('loses the parameters the target model rejects, and only those', async () => {
+      reachTheTransform();
+      registerProviderCapabilities({
+        provider: AIProvider.OPENAI,
+        models: [
+          {
+            modelPattern: 'reasoning-only',
+            endpointConfigs: {
+              [FunctionName.CHAT_COMPLETE]: {
+                unsupportedParameters: [ModelParameter.TEMPERATURE],
+              },
+            },
+          },
+        ],
+      });
+      mockSuperAgentsTarget.configuration.model = 'reasoning-only';
+      mockSuperAgentsTarget.configuration.top_p = null;
+      mockSuperAgentsRequestData.requestBody = {
+        model: 'reasoning-only',
+        temperature: 0,
+        top_p: 0.5,
+        messages: [{ role: ChatCompletionMessageRole.USER, content: 'Hello' }],
+      } as never;
+      const before = structuredClone(mockSuperAgentsRequestData.requestBody);
+      const warn = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+      await tryPost(
+        mockContext,
+        mockSuperAgentsConfig,
+        mockSuperAgentsTarget,
+        mockSuperAgentsRequestData,
+        0,
+      );
+
+      const sent = vi.mocked(transformToProviderRequest).mock.calls[0][2]
+        .requestBody as Record<string, unknown>;
+      expect(sent).not.toHaveProperty('temperature');
+      expect(sent.top_p).toBe(0.5);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Dropped temperature'),
+      );
+      expect(mockSuperAgentsRequestData.requestBody).toEqual(before);
+      warn.mockRestore();
     });
   });
 

--- a/packages/api/src/handlers/handler-utils.ts
+++ b/packages/api/src/handlers/handler-utils.ts
@@ -197,6 +197,39 @@ function getHyperParamDefaults(
 }
 
 /**
+ * Removes from the outgoing body the parameters the target model rejects.
+ *
+ * The capability table keeps such parameters out of the target's *defaults*
+ * (`getHyperParamDefaults`), but a caller's own `temperature` used to ride
+ * through the spread untouched -- and a reasoning model answers that with a
+ * 400 for the whole request. Dropping it is the only way the request can
+ * succeed; the warning records that it happened.
+ */
+function dropUnsupportedParameters(
+  functionName: FunctionName,
+  saTarget: SuperAgentsTarget,
+  body: Record<string, unknown>,
+): void {
+  const provider = saTarget.configuration.ai_provider;
+  const modelId = saTarget.configuration.model;
+
+  for (const parameter of Object.values(ModelParameter)) {
+    if (!(parameter in body)) continue;
+    const validation = validateParameter(
+      provider,
+      modelId,
+      parameter,
+      functionName,
+    );
+    if (validation.isSupported) continue;
+    delete body[parameter];
+    console.warn(
+      `[${provider}/${modelId}][${functionName}] ✗ Dropped ${parameter} from the request: ${validation.reason}`,
+    );
+  }
+}
+
+/**
  * Makes a POST request to a provider and returns the response.
  * The POST request is constructed using the provider, apiKey, and requestBody parameters.
  * The fn parameter is the type of request being made (e.g., "complete", "chatComplete").
@@ -221,6 +254,11 @@ export async function tryPost(
       ...hyperParamDefaults,
       ...overrideParams,
     } as SuperAgentsRequestBody;
+    dropUnsupportedParameters(
+      saRequestData.functionName,
+      saTarget,
+      overriddenSuperAgentsRequestBody as Record<string, unknown>,
+    );
 
     // Anthropic has no `response_format`, so the gateway emulates it with the
     // `__json_output` tool (see ai-providers/anthropic/chat-complete.ts). Every
@@ -611,10 +649,7 @@ export async function tryPost(
     return createResponse(c, createResponseOptions);
   } catch (error) {
     if (error instanceof HttpError) {
-      return new Response(error.response.body, {
-        status: error.response.status,
-        statusText: error.response.statusText,
-      });
+      return error.toResponse();
     }
     return new Response(
       JSON.stringify({
@@ -753,10 +788,7 @@ export async function tryTargets(
           );
         } else {
           if (e instanceof HttpError) {
-            response = new Response(e.response.body, {
-              status: e.response.status,
-              statusText: e.response.statusText,
-            });
+            response = e.toResponse();
           }
         }
       }
@@ -873,6 +905,7 @@ export async function recursiveOutputHookHandler(
       status: mappedResponse.status,
       statusText: mappedResponse.statusText,
       body: errorBody,
+      contentType: mappedResponse.headers.get('content-type') ?? undefined,
     });
   }
 

--- a/packages/api/src/handlers/retry-handler.test.ts
+++ b/packages/api/src/handlers/retry-handler.test.ts
@@ -1,0 +1,61 @@
+import { retryRequest } from '@api/handlers/retry-handler';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A provider's error has to reach the caller as what the provider sent. The
+ * handler rebuilds the failed response once `async-retry` gives up, and a
+ * `Response` built from a string is `text/plain` unless told otherwise --
+ * which sent OpenAI's JSON error down the gateway's text path, wrapped as
+ * `{"html-message": ...}`, and left the OpenAI client reporting
+ * "400 status code (no body)".
+ */
+
+const url = 'https://api.openai.com/v1/chat/completions';
+
+const openAIRejects = (status: number) => async () =>
+  new Response(
+    JSON.stringify({
+      error: {
+        message:
+          "Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.",
+        type: 'invalid_request_error',
+        param: 'temperature',
+        code: 'unsupported_value',
+      },
+    }),
+    { status, headers: { 'content-type': 'application/json' } },
+  );
+
+describe('retryRequest with a provider error', () => {
+  it('keeps the content type of an error it does not retry', async () => {
+    const { response } = await retryRequest(
+      url,
+      {},
+      0,
+      [429, 500],
+      null,
+      openAIRejects(400),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('content-type')).toBe('application/json');
+    const body = (await response.json()) as { error: { param: string } };
+    expect(body.error.param).toBe('temperature');
+  });
+
+  it('keeps it once a retried error runs out of attempts', async () => {
+    const { response } = await retryRequest(
+      url,
+      {},
+      0,
+      [500],
+      null,
+      openAIRejects(500),
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get('content-type')).toBe('application/json');
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('unsupported_value');
+  });
+});

--- a/packages/api/src/handlers/retry-handler.ts
+++ b/packages/api/src/handlers/retry-handler.ts
@@ -102,6 +102,7 @@ export const retryRequest = async (
               status: response.status,
               statusText: response.statusText,
               body: responseText,
+              contentType: response.headers.get('content-type') ?? undefined,
             });
 
             if (response.status === 429 && followProviderRetry) {
@@ -156,6 +157,7 @@ export const retryRequest = async (
               status: response.status,
               statusText: response.statusText,
               body: responseText,
+              contentType: response.headers.get('content-type') ?? undefined,
             });
             bail(errorObj);
             return;
@@ -203,10 +205,7 @@ export const retryRequest = async (
         status: 503,
       });
     } else if (error instanceof HttpError) {
-      errorResponse = new Response(error.response.body, {
-        status: error.response.status,
-        statusText: error.response.statusText,
-      });
+      errorResponse = error.toResponse();
     } else if (error instanceof Error) {
       // The retry handler will always attach status code to the error object
       errorResponse = new Response(

--- a/packages/api/src/optimization/utils/describe-skill.test.ts
+++ b/packages/api/src/optimization/utils/describe-skill.test.ts
@@ -224,13 +224,11 @@ describe('repairSkillNaming', () => {
 
   const repairConnector = (siblings: string[] = ['translate']) =>
     ({
-      getSkills: vi
-        .fn()
-        .mockResolvedValue(
-          [...siblings, 'you-are-a-restaurant-concierge'].map((name) => ({
-            name,
-          })),
-        ),
+      getSkills: vi.fn().mockResolvedValue(
+        [...siblings, 'you-are-a-restaurant-concierge'].map((name) => ({
+          name,
+        })),
+      ),
       updateSkill: vi.fn().mockResolvedValue(undefined),
       createSkillEvent: vi.fn().mockResolvedValue(undefined),
     }) as unknown as UserDataStorageConnector;

--- a/packages/api/src/utils/model-validator.test.ts
+++ b/packages/api/src/utils/model-validator.test.ts
@@ -2,6 +2,7 @@
  * Tests for model capability validation and parameter transformation.
  */
 
+import { openAIModelCapabilities } from '@api/ai-providers/openai/model-capabilities';
 import {
   parseModelIdentifier,
   registerProviderCapabilities,
@@ -539,6 +540,45 @@ describe('Model Validator', () => {
 
       // Should be supported because gpt-3.5 doesn't match the gpt-4.* pattern
       expect(result.isSupported).toBe(true);
+    });
+  });
+
+  /**
+   * Against the real OpenAI table. Only `gpt-5`, `gpt-5-mini` and
+   * `gpt-5-nano` used to match, by exact name, so every point release and
+   * dated snapshot was sent `temperature` -- which reasoning models answer
+   * with a 400.
+   */
+  describe('the OpenAI gpt-5 family', () => {
+    beforeEach(() => {
+      registerProviderCapabilities(openAIModelCapabilities);
+    });
+
+    const takesTemperature = (model: string) =>
+      validateParameter(
+        AIProvider.OPENAI,
+        model,
+        ModelParameter.TEMPERATURE,
+        FunctionName.CHAT_COMPLETE,
+      ).isSupported;
+
+    it.each([
+      'gpt-5',
+      'gpt-5-mini',
+      'gpt-5-nano-2025-08-07',
+      'gpt-5-pro',
+      'gpt-5.1',
+      'gpt-5.6-sol',
+    ])('drops temperature for %s', (model) => {
+      expect(takesTemperature(model)).toBe(false);
+    });
+
+    it('keeps temperature for the chat variants, which take it', () => {
+      expect(takesTemperature('gpt-5-chat-latest')).toBe(true);
+    });
+
+    it('does not mistake gpt-50 for the family', () => {
+      expect(takesTemperature('gpt-50')).toBe(true);
     });
   });
 });

--- a/packages/api/src/utils/super-agents/responses.test.ts
+++ b/packages/api/src/utils/super-agents/responses.test.ts
@@ -201,6 +201,7 @@ describe('createResponse', () => {
         ok: false,
         status: 400,
         statusText: 'Bad Request',
+        headers: new Headers({ 'content-type': 'application/json' }),
         clone: vi.fn(),
         text: vi.fn().mockResolvedValue('{"error": "Invalid request"}'),
       } as unknown as Response;

--- a/packages/api/src/utils/super-agents/responses.ts
+++ b/packages/api/src/utils/super-agents/responses.ts
@@ -175,6 +175,7 @@ export async function createResponse(
       status: mappedResponse.status,
       statusText: mappedResponse.statusText,
       body: await mappedResponse.text(),
+      contentType: mappedResponse.headers.get('content-type') ?? undefined,
     });
     throw errorObj;
   }


### PR DESCRIPTION
## Problem

Every request through an agent whose system prompt is long enough to need compacting logged this, and fell back to embedding a truncated prompt:

```
--> POST /v1/chat/completions 400 1s
⚠ [SKILL_ROUTING] Could not compact a 9674-character system prompt; embedding its head instead: 400 status code (no body)
```

Three things stacked up.

**The model rejects `temperature`.** The compactor sends `temperature: 0` for determinism, and the configured reflection model was `gpt-5.6-sol` — a reasoning model that accepts only the default temperature. The OpenAI capability table encodes exactly this, but its pattern was `/^(gpt-5|gpt-5-mini|gpt-5-nano)$/`: an exact match, so no point release (`gpt-5.1`, `gpt-5.6-sol`) and no dated snapshot (`gpt-5-nano-2025-08-07`, which appears in this repo) was covered.

**The table only governs defaults.** Even for a covered model, `getHyperParamDefaults` keeps unsupported parameters out of the *target's* defaults — a `temperature` the caller put in the body rode through the spread in `tryPost` untouched and was sent anyway. Nothing between the body and the provider looked at capabilities.

**The reason was hidden.** After `async-retry` gives up, `retryRequest` rebuilds the failed response from the body string, and a `Response` built from a string is `text/plain`. `responseHandler` then routes it through `handleTextResponse`, which wraps it as `{"html-message": "<the provider's JSON>"}`. The OpenAI client parses that, finds no `error` key, and reports "400 status code (no body)". So the one log line that could have said *why* said nothing.

## Solution

- `openAIModelCapabilities`: the gpt-5 entry matches `/^gpt-5(?!-chat)([.-].*)?$/` — the whole family and its snapshots, leaving out the `-chat` variants, which are ordinary chat models and take sampling parameters. `gpt-50` does not match.
- `tryPost` runs the merged body through `dropUnsupportedParameters`, removing whatever the target model's capabilities reject, with a warning in the same style as the existing `reasoning_effort` one. That covers the compactor, the judge and evaluation calls (temperature 0.1), and any client sending these through the gateway. The caller's own request object is not touched.
- `HttpError` carries the provider's `content-type` and gains `toResponse()`; the three places that re-created a `Response` from one use it, and the three places that throw one from a real response record the type. A provider's JSON error now reaches the caller as JSON:

```
{"error":{"message":"openai error: ...","type":"invalid_request_error",...},"provider":"openai"}
```

## Test notes

- `model-validator.test.ts`: the real OpenAI table against `gpt-5`, `gpt-5-mini`, `gpt-5-nano-2025-08-07`, `gpt-5-pro`, `gpt-5.1`, `gpt-5.6-sol` (rejected), `gpt-5-chat-latest` and `gpt-50` (allowed).
- `handler-utils.test.ts`: `tryPost` drops a rejected `temperature`, keeps a supported `top_p`, warns, and leaves the caller's body alone.
- `retry-handler.test.ts` (new): the content type survives both the non-retried and the exhausted-retries path.
- Verified on a dev server that the gateway's error for this request now comes back `application/json` with OpenAI's message, where before it was the `html-message` wrapper.

`pnpm typecheck`, `pnpm check` and `pnpm test` (174 files, 2817 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYrmYGSZV2sztjGYgVrhka