### PR TITLE
fix(api): regenerate a skill's evaluations in place

### DIFF
--- a/packages/api/src/middlewares/optimizer/early-regeneration-create.test.ts
+++ b/packages/api/src/middlewares/optimizer/early-regeneration-create.test.ts
@@ -32,7 +32,10 @@ vi.mock('@api/optimization/utils/system-prompt', () => ({
     Promise.resolve('a prompt improved from real examples'),
   ),
 }));
-vi.mock('@api/optimization/utils/evaluations', () => ({
+vi.mock('@api/optimization/utils/evaluations', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@api/optimization/utils/evaluations')
+  >()),
   regenerateEvaluationsWithExamples: vi.fn(),
 }));
 vi.mock('@api/utils/sse-event-manager', () => ({ emitSSEEvent: vi.fn() }));

--- a/packages/api/src/middlewares/optimizer/evaluations.ts
+++ b/packages/api/src/middlewares/optimizer/evaluations.ts
@@ -1,6 +1,9 @@
 import { generateExampleConversations } from '@api/middlewares/optimizer/system-prompt';
 import { repairSkillNaming } from '@api/optimization/utils/describe-skill';
-import { regenerateEvaluationsWithExamples } from '@api/optimization/utils/evaluations';
+import {
+  applyRegeneratedEvaluations,
+  regenerateEvaluationsWithExamples,
+} from '@api/optimization/utils/evaluations';
 import { generateSeedSystemPromptWithContext } from '@api/optimization/utils/system-prompt';
 import type {
   EvaluationMethodConnector,
@@ -243,24 +246,13 @@ export async function checkAndRegenerateEvaluationsEarly(
       userDataStorageConnector,
     );
 
-    // Update evaluations in-place to preserve their IDs and relationships
-    // Match evaluations by method to ensure correct updates
-    for (const evaluation of existingEvaluations) {
-      const newParams = newEvaluationParams.find(
-        (p) => p.evaluation_method === evaluation.evaluation_method,
-      );
-
-      if (newParams) {
-        await userDataStorageConnector.updateSkillOptimizationEvaluation(
-          c,
-          evaluation.id,
-          {
-            params: newParams.params,
-            weight: newParams.weight,
-          },
-        );
-      }
-    }
+    // In place, so the ids -- and every score recorded against them -- stay
+    await applyRegeneratedEvaluations(
+      c,
+      userDataStorageConnector,
+      existingEvaluations,
+      newEvaluationParams,
+    );
 
     // The from-scratch case: record what was generated, the way creation
     // would have.

--- a/packages/api/src/optimization/skill-optimizations.test.ts
+++ b/packages/api/src/optimization/skill-optimizations.test.ts
@@ -1,0 +1,170 @@
+import { handleGenerateArms } from '@api/optimization/skill-optimizations';
+import { regenerateEvaluationsWithExamples } from '@api/optimization/utils/evaluations';
+import type {
+  LogsStorageConnector,
+  UserDataStorageConnector,
+} from '@api/types/connector';
+import type { AppContext } from '@api/types/hono';
+import type { Skill } from '@shared/types/data';
+import type { SkillOptimizationEvaluationCreateParams } from '@shared/types/data/skill-optimization-evaluation';
+import { EvaluationMethodName } from '@shared/types/evaluations';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Rebuilding a skill's arms -- which every change to its models does --
+ * regenerates its evaluations from real examples once it has five logs.
+ * That used to delete the evaluations and insert new ones, which orphaned
+ * every judge result the skill's logs had: a log's weighted score joins its
+ * results back to the evaluation rows, so removing a model from a skill
+ * blanked the scores of every log judged so far. The evaluations are
+ * updated in place now and keep their ids.
+ */
+
+vi.mock('@api/middlewares/optimizer/system-prompt', () => ({
+  generateExampleConversations: vi.fn(() => ['User: hi\nAssistant: hello']),
+}));
+vi.mock('@api/optimization/utils/evaluations', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@api/optimization/utils/evaluations')
+  >()),
+  regenerateEvaluationsWithExamples: vi.fn(),
+}));
+vi.mock('@api/optimization/utils/system-prompt', () => ({
+  generateSeedSystemPromptForSkill: vi.fn(() => Promise.resolve('seed')),
+  generateSeedSystemPromptWithContext: vi.fn(() =>
+    Promise.resolve('seed, from examples'),
+  ),
+}));
+
+const skill = {
+  id: 'skill-1',
+  agent_id: 'agent-1',
+  description: 'Answers questions about candles.',
+  seed_system_prompt: null,
+} as unknown as Skill;
+
+const existingEvaluations = [
+  {
+    id: 'eval-latency',
+    evaluation_method: 'latency',
+    params: { max_ms: 1_000 },
+    weight: 1,
+  },
+  {
+    id: 'eval-task',
+    evaluation_method: 'task_completion',
+    params: { criteria: 'answers' },
+    weight: 1,
+  },
+];
+
+const regenerated: SkillOptimizationEvaluationCreateParams[] = [
+  {
+    skill_id: 'skill-1',
+    agent_id: 'agent-1',
+    evaluation_method: EvaluationMethodName.TASK_COMPLETION,
+    params: { criteria: 'answers the question about the candle' },
+    weight: 2,
+  },
+  {
+    skill_id: 'skill-1',
+    agent_id: 'agent-1',
+    evaluation_method: EvaluationMethodName.LATENCY,
+    params: { max_ms: 5_000 },
+    weight: 1,
+  },
+];
+
+const setup = (
+  logCount: number,
+): { userData: UserDataStorageConnector; c: AppContext } => {
+  const userData = {
+    getSkills: vi.fn().mockResolvedValue([skill]),
+    getAgents: vi
+      .fn()
+      .mockResolvedValue([{ id: 'agent-1', description: 'A support agent' }]),
+    getSkillOptimizationEvaluations: vi
+      .fn()
+      .mockResolvedValue(existingEvaluations),
+    updateSkillOptimizationEvaluation: vi.fn().mockResolvedValue(undefined),
+    deleteSkillOptimizationEvaluationsForSkill: vi
+      .fn()
+      .mockResolvedValue(undefined),
+    createSkillOptimizationEvaluations: vi.fn().mockResolvedValue([]),
+    getSkillOptimizationArms: vi.fn().mockResolvedValue([]),
+    getSkillOptimizationClusters: vi.fn().mockResolvedValue([]),
+    updateSkillOptimizationCluster: vi.fn().mockResolvedValue(undefined),
+    // No models: the rebuild stops after the evaluation step, the one under test
+    getSkillModels: vi.fn().mockResolvedValue([]),
+  } as unknown as UserDataStorageConnector;
+  const logsStore = {
+    getLogs: vi
+      .fn()
+      .mockResolvedValue(
+        Array.from({ length: logCount }, (_, i) => ({ id: `log-${i}` })),
+      ),
+  } as unknown as LogsStorageConnector;
+  const variables: Record<string, unknown> = {
+    logs_storage_connector: logsStore,
+    evaluation_connectors_map: { latency: {}, task_completion: {} },
+  };
+  const c = {
+    get: (key: string) => variables[key],
+    json: vi.fn((body: unknown, status?: number) => ({ body, status })),
+  } as unknown as AppContext;
+  return { userData, c };
+};
+
+describe('handleGenerateArms', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(regenerateEvaluationsWithExamples).mockResolvedValue(regenerated);
+  });
+
+  it('regenerates the evaluations in place once the skill has five logs, keeping their ids', async () => {
+    const { userData, c } = setup(5);
+
+    await handleGenerateArms(c, userData, skill.id);
+
+    expect(regenerateEvaluationsWithExamples).toHaveBeenCalledWith(
+      c,
+      skill,
+      'A support agent',
+      ['User: hi\nAssistant: hello'],
+      expect.anything(),
+      ['latency', 'task_completion'],
+      userData,
+    );
+    expect(userData.updateSkillOptimizationEvaluation).toHaveBeenCalledTimes(2);
+    expect(userData.updateSkillOptimizationEvaluation).toHaveBeenCalledWith(
+      c,
+      'eval-latency',
+      { params: { max_ms: 5_000 }, weight: 1 },
+    );
+    expect(userData.updateSkillOptimizationEvaluation).toHaveBeenCalledWith(
+      c,
+      'eval-task',
+      {
+        params: { criteria: 'answers the question about the candle' },
+        weight: 2,
+      },
+    );
+    // Deleting would orphan every score recorded against these evaluations
+    expect(
+      userData.deleteSkillOptimizationEvaluationsForSkill,
+    ).not.toHaveBeenCalled();
+    expect(userData.createSkillOptimizationEvaluations).not.toHaveBeenCalled();
+  });
+
+  it('leaves the evaluations alone before the skill has five logs', async () => {
+    const { userData, c } = setup(3);
+
+    await handleGenerateArms(c, userData, skill.id);
+
+    expect(regenerateEvaluationsWithExamples).not.toHaveBeenCalled();
+    expect(userData.updateSkillOptimizationEvaluation).not.toHaveBeenCalled();
+    expect(
+      userData.deleteSkillOptimizationEvaluationsForSkill,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/optimization/skill-optimizations.ts
+++ b/packages/api/src/optimization/skill-optimizations.ts
@@ -1,6 +1,9 @@
 import { generateExampleConversations } from '@api/middlewares/optimizer/system-prompt';
 import { BaseArmsParams } from '@api/optimization/base-arms';
-import { regenerateEvaluationsWithExamples } from '@api/optimization/utils/evaluations';
+import {
+  applyRegeneratedEvaluations,
+  regenerateEvaluationsWithExamples,
+} from '@api/optimization/utils/evaluations';
 import {
   generateSeedSystemPromptForSkill,
   generateSeedSystemPromptWithContext,
@@ -108,13 +111,12 @@ export async function handleGenerateArms(
             userStorageConnector,
           );
 
-        // Delete old evaluations and create new ones
-        await userStorageConnector.deleteSkillOptimizationEvaluationsForSkill(
+        // In place, so the ids -- and every score the skill's logs were
+        // given against these evaluations -- stay
+        await applyRegeneratedEvaluations(
           c,
-          skill.id,
-        );
-        await userStorageConnector.createSkillOptimizationEvaluations(
-          c,
+          userStorageConnector,
+          existingEvaluations,
           regeneratedEvaluationParams,
         );
       }

--- a/packages/api/src/optimization/utils/evaluations.ts
+++ b/packages/api/src/optimization/utils/evaluations.ts
@@ -7,7 +7,10 @@ import type { AppContext } from '@api/types/hono';
 import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
 import { warn } from '@shared/console-logging';
 import type { Skill } from '@shared/types/data';
-import type { SkillOptimizationEvaluationCreateParams } from '@shared/types/data/skill-optimization-evaluation';
+import type {
+  SkillOptimizationEvaluation,
+  SkillOptimizationEvaluationCreateParams,
+} from '@shared/types/data/skill-optimization-evaluation';
 import type { EvaluationMethodName } from '@shared/types/evaluations';
 import OpenAI from 'openai';
 import type { ParsedChatCompletion } from 'openai/resources/chat/completions.mjs';
@@ -274,4 +277,31 @@ export async function regenerateEvaluationsWithExamples(
   });
 
   return await Promise.all(regeneratePromises);
+}
+
+/**
+ * Apply regenerated evaluations to the ones a skill already has: matched by
+ * method, updated in place. An evaluation's id is what every judge result
+ * recorded against it points at -- a log's weighted score is computed by
+ * joining its results back to these rows -- so regeneration must never
+ * delete and recreate them: that orphans every score the skill's logs have
+ * and blanks them in the dashboard. A method that was not regenerated keeps
+ * what it had.
+ */
+export async function applyRegeneratedEvaluations(
+  c: AppContext,
+  connector: UserDataStorageConnector,
+  existing: SkillOptimizationEvaluation[],
+  regenerated: SkillOptimizationEvaluationCreateParams[],
+): Promise<void> {
+  for (const evaluation of existing) {
+    const next = regenerated.find(
+      (params) => params.evaluation_method === evaluation.evaluation_method,
+    );
+    if (!next) continue;
+    await connector.updateSkillOptimizationEvaluation(c, evaluation.id, {
+      params: next.params,
+      weight: next.weight,
+    });
+  }
 }


### PR DESCRIPTION
## Problem

Removing a model from a skill blanked the evaluation scores of every log the skill had been judged on. The scores were still in the evaluation-run rows; what vanished were the evaluations they pointed at.

Every change to a skill's models (and editing, resetting or creating the skill) rebuilds its arms through `handleGenerateArms`. Once the skill has five embedded logs, that function also regenerates the evaluations from real examples, and it did so by deleting all of them and inserting new rows with new ids. `logs_with_eval_scores` computes a log's weighted score by joining each stored result's `evaluation_id` to `skill_optimization_evaluations` (the weight lives there), so results that point at deleted rows drop out and the average becomes null. The log page then shows "6 evals" with per-method scores in the details panel and no weighted score in the header.

Seen on a dev database: six requests judged at 8:40 PM, a model removed from the skill at 8:45 PM, six new evaluation rows six seconds later, and all six results on each of those logs referencing ids that no longer exist.

## Solution

The early-regeneration pass (`middlewares/optimizer/evaluations.ts`) already updated evaluations in place, matched by method, precisely to preserve ids. That loop is now `applyRegeneratedEvaluations` in `optimization/utils/evaluations.ts`, and both the early pass and the arm rebuild call it. No path deletes evaluations during regeneration any more.

Logs orphaned before this change stay unscored; nothing here recreates the deleted rows. Re-judging them, or having the view count an orphaned result at weight 1, would be a separate change.

## Tests

- New `optimization/skill-optimizations.test.ts`: with five logs, each evaluation is updated by id and neither the wholesale delete nor the insert is called; below five logs nothing is touched.
- `early-regeneration-create.test.ts` keeps the helper real while mocking the model call.
- `pnpm check`, `pnpm typecheck`, and the optimizer, skill-creation, skills-route and models-route suites pass on a clean checkout of `main` plus this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7nkpUM1RjfcuHjy8E8MFR
