### PR TITLE
feat(api): stop internal skill calls paying for prompt cache writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,6 +465,13 @@ Both failures are quiet: the call cannot connect, the caller logs and continues,
 and optimization simply never happens. `e2e/contract/optimizer.spec.ts` covers
 the whole path against the stub provider.
 
+Every internal call also spreads `SA_SKILL_REQUEST_PARAMS` (`constants.ts`)
+into its request body: `prompt_cache_options: { mode: 'explicit' }`, which on
+OpenAI's GPT-5.6 models stops a billed cache write that no later request would
+read, since each call's prompt is its own. The gateway drops the parameter for
+the models that reject it (`dropUnsupportedParameters`, from the capability
+table) and forwards it only where a provider's config lists it.
+
 ## Skill Optimization System
 
 ### System Prompt Evolution

--- a/packages/api/src/ai-providers/openai/chat-complete.test.ts
+++ b/packages/api/src/ai-providers/openai/chat-complete.test.ts
@@ -1,0 +1,38 @@
+import { openAIChatCompleteConfig } from '@api/ai-providers/openai/chat-complete';
+import { transformUsingProviderConfig } from '@api/services/transform-to-provider-request';
+import type { SuperAgentsRequestBody } from '@shared/types/api/request/body';
+import type { SuperAgentsTarget } from '@shared/types/api/request/headers';
+import { describe, expect, it } from 'vitest';
+
+describe('OpenAI chat completions configuration', () => {
+  const target = {} as SuperAgentsTarget;
+  const body = {
+    model: 'gpt-5.6',
+    messages: [{ role: 'user', content: 'Hello' }],
+  } as SuperAgentsRequestBody;
+
+  /**
+   * The parameter only helps if it reaches OpenAI: the internal skills send
+   * it to stop a billed cache write, and a config that did not list it would
+   * drop it on the way out.
+   */
+  it('forwards prompt_cache_options as sent', () => {
+    const sent = transformUsingProviderConfig(
+      openAIChatCompleteConfig,
+      { ...body, prompt_cache_options: { mode: 'explicit' } },
+      target,
+    );
+
+    expect(sent.prompt_cache_options).toEqual({ mode: 'explicit' });
+  });
+
+  it('leaves prompt_cache_options out when the request has none', () => {
+    const sent = transformUsingProviderConfig(
+      openAIChatCompleteConfig,
+      body,
+      target,
+    );
+
+    expect(sent).not.toHaveProperty('prompt_cache_options');
+  });
+});

--- a/packages/api/src/ai-providers/openai/chat-complete.ts
+++ b/packages/api/src/ai-providers/openai/chat-complete.ts
@@ -120,6 +120,9 @@ export const openAIChatCompleteConfig: AIProviderFunctionConfig = {
   reasoning_effort: {
     param: 'reasoning_effort',
   },
+  prompt_cache_options: {
+    param: 'prompt_cache_options',
+  },
 };
 
 export const openAIChatCompleteResponseTransform: ResponseTransformFunction = (

--- a/packages/api/src/ai-providers/openai/model-capabilities.ts
+++ b/packages/api/src/ai-providers/openai/model-capabilities.ts
@@ -24,14 +24,20 @@ export const openAIModelCapabilities: ProviderModelCapabilities = {
     presence_penalty: { min: -2, max: 2 },
   },
 
+  // `prompt_cache_options` exists from gpt-5.6 on, and the models before it
+  // answer the field with a 400 rather than ignoring it. So the entry for
+  // gpt-5.6 and later is the only one that takes it: every other entry lists
+  // it as unsupported, and this default covers the models with no entry.
+  defaultUnsupportedParameters: [ModelParameter.PROMPT_CACHE_OPTIONS],
+
   models: [
-    // GPT-5 reasoning models: gpt-5, -mini, -nano, -pro, the 5.x point
-    // releases and their dated snapshots. Only the default temperature is
-    // accepted, so sampling parameters are dropped rather than sent. The
-    // `-chat` variants are ordinary chat models and take them.
-    // Support reasoning_effort: minimal, low, medium, high
+    // GPT-5.6 and later, reasoning variants: the same restrictions as the
+    // rest of the gpt-5 family below, plus `prompt_cache_options`. Listed
+    // first because the family pattern below matches these names too. The
+    // major versions from 6 to 9 are included on the assumption that a
+    // successor keeps what its predecessor took.
     {
-      modelPattern: /^gpt-5(?!-chat)([.-].*)?$/,
+      modelPattern: /^gpt-(?:5\.(?:[6-9]|[1-9]\d)|[6-9])(?!-chat)(?:[.-].*)?$/,
       endpointConfigs: {
         [FunctionName.CHAT_COMPLETE]: {
           unsupportedParameters: [
@@ -57,6 +63,40 @@ export const openAIModelCapabilities: ProviderModelCapabilities = {
         },
       },
     },
+    // GPT-5 reasoning models: gpt-5, -mini, -nano, -pro, the 5.x point
+    // releases before 5.6 and their dated snapshots. Only the default
+    // temperature is accepted, so sampling parameters are dropped rather than
+    // sent. The `-chat` variants are ordinary chat models and take them.
+    // Support reasoning_effort: minimal, low, medium, high
+    {
+      modelPattern: /^gpt-5(?!-chat)([.-].*)?$/,
+      endpointConfigs: {
+        [FunctionName.CHAT_COMPLETE]: {
+          unsupportedParameters: [
+            ModelParameter.TEMPERATURE,
+            ModelParameter.TOP_P,
+            ModelParameter.PRESENCE_PENALTY,
+            ModelParameter.FREQUENCY_PENALTY,
+            ModelParameter.PROMPT_CACHE_OPTIONS,
+          ],
+          legacyParameterMapping: {
+            [ModelParameter.MAX_TOKENS]: ModelParameter.MAX_COMPLETION_TOKENS,
+          },
+        },
+        [FunctionName.STREAM_CHAT_COMPLETE]: {
+          unsupportedParameters: [
+            ModelParameter.TEMPERATURE,
+            ModelParameter.TOP_P,
+            ModelParameter.PRESENCE_PENALTY,
+            ModelParameter.FREQUENCY_PENALTY,
+            ModelParameter.PROMPT_CACHE_OPTIONS,
+          ],
+          legacyParameterMapping: {
+            [ModelParameter.MAX_TOKENS]: ModelParameter.MAX_COMPLETION_TOKENS,
+          },
+        },
+      },
+    },
     // o1 models
     {
       modelPattern: /^o1(-preview|-mini)?$/,
@@ -67,6 +107,7 @@ export const openAIModelCapabilities: ProviderModelCapabilities = {
             ModelParameter.TOP_P,
             ModelParameter.FREQUENCY_PENALTY,
             ModelParameter.PRESENCE_PENALTY,
+            ModelParameter.PROMPT_CACHE_OPTIONS,
           ],
           legacyParameterMapping: {
             [ModelParameter.MAX_TOKENS]: ModelParameter.MAX_COMPLETION_TOKENS,
@@ -78,6 +119,7 @@ export const openAIModelCapabilities: ProviderModelCapabilities = {
             ModelParameter.TOP_P,
             ModelParameter.FREQUENCY_PENALTY,
             ModelParameter.PRESENCE_PENALTY,
+            ModelParameter.PROMPT_CACHE_OPTIONS,
           ],
           legacyParameterMapping: {
             [ModelParameter.MAX_TOKENS]: ModelParameter.MAX_COMPLETION_TOKENS,
@@ -123,6 +165,7 @@ export const openAIModelCapabilities: ProviderModelCapabilities = {
             ModelParameter.TOP_P,
             ModelParameter.PRESENCE_PENALTY,
             ModelParameter.FREQUENCY_PENALTY,
+            ModelParameter.PROMPT_CACHE_OPTIONS,
           ],
           legacyParameterMapping: {
             [ModelParameter.MAX_TOKENS]: ModelParameter.MAX_COMPLETION_TOKENS,
@@ -134,6 +177,7 @@ export const openAIModelCapabilities: ProviderModelCapabilities = {
             ModelParameter.TOP_P,
             ModelParameter.PRESENCE_PENALTY,
             ModelParameter.FREQUENCY_PENALTY,
+            ModelParameter.PROMPT_CACHE_OPTIONS,
           ],
           legacyParameterMapping: {
             [ModelParameter.MAX_TOKENS]: ModelParameter.MAX_COMPLETION_TOKENS,
@@ -146,10 +190,16 @@ export const openAIModelCapabilities: ProviderModelCapabilities = {
       modelPattern: /^gpt-4o(-mini)?$/,
       endpointConfigs: {
         [FunctionName.CHAT_COMPLETE]: {
-          unsupportedParameters: [ModelParameter.REASONING_EFFORT],
+          unsupportedParameters: [
+            ModelParameter.REASONING_EFFORT,
+            ModelParameter.PROMPT_CACHE_OPTIONS,
+          ],
         },
         [FunctionName.STREAM_CHAT_COMPLETE]: {
-          unsupportedParameters: [ModelParameter.REASONING_EFFORT],
+          unsupportedParameters: [
+            ModelParameter.REASONING_EFFORT,
+            ModelParameter.PROMPT_CACHE_OPTIONS,
+          ],
         },
       },
     },

--- a/packages/api/src/connectors/evaluations/llm-judge.test.ts
+++ b/packages/api/src/connectors/evaluations/llm-judge.test.ts
@@ -117,6 +117,8 @@ describe('LLM Judge', () => {
           expect.objectContaining({ role: 'system' }),
           expect.objectContaining({ role: 'user' }),
         ]),
+        // One-shot prompts: nothing would read a cache written for them.
+        prompt_cache_options: { mode: 'explicit' },
       }),
     );
   });

--- a/packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts
@@ -1,5 +1,5 @@
 import type { TaskCompletionEvaluationParameters } from '@api/connectors/evaluations/task-completion/types';
-import { getApiUrl } from '@api/constants';
+import { getApiUrl, SA_SKILL_REQUEST_PARAMS } from '@api/constants';
 import { parseJudgeJson } from '@api/evaluations/llm-judge';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
@@ -93,6 +93,7 @@ export async function extractTaskAndOutcome(
       },
     })
     .chat.completions.create({
+      ...SA_SKILL_REQUEST_PARAMS,
       model: modelConfig.model,
       messages: [
         { role: 'system', content: systemPrompt },

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -1,4 +1,5 @@
 import type { AppContext } from '@api/types/hono';
+import type { ChatCompletionRequestBody } from '@shared/types/api/routes/chat-completions-api/request';
 
 const DUMMY_JWT_SECRET = 'default-dev-jwt-secret';
 /**
@@ -190,3 +191,19 @@ export const SA_SKILLS = [
   'route-or-create',
   'compact-intent',
 ];
+
+/**
+ * Request parameters every internal skill call carries.
+ *
+ * Internal skills are one-shot: a judge call, an evaluation generation, a
+ * reflection, each with a prompt no later request shares. OpenAI's GPT-5.6
+ * models cache the prompt implicitly and bill the write at 1.25x the input
+ * price, so each call was paying to cache a prefix nothing would read back.
+ * Explicit mode caches only the blocks marked with a breakpoint, and none are
+ * marked, so nothing is written. The gateway drops the option for the models
+ * that reject it (`dropUnsupportedParameters`) and forwards it only where a
+ * provider's config lists it, so sending it unconditionally is safe.
+ */
+export const SA_SKILL_REQUEST_PARAMS = {
+  prompt_cache_options: { mode: 'explicit' },
+} as const satisfies Pick<ChatCompletionRequestBody, 'prompt_cache_options'>;

--- a/packages/api/src/evaluations/llm-judge.ts
+++ b/packages/api/src/evaluations/llm-judge.ts
@@ -1,5 +1,5 @@
 import { isAPIKeyRequiredForProvider } from '@api/ai-providers';
-import { getApiUrl } from '@api/constants';
+import { getApiUrl, SA_SKILL_REQUEST_PARAMS } from '@api/constants';
 import {
   evaluationCriteria,
   scoringGuidelinesText,
@@ -294,6 +294,7 @@ Provide a score between 0 and 1 with detailed reasoning for your evaluation.`;
         });
 
         const response = await clientWithHeaders.chat.completions.create({
+          ...SA_SKILL_REQUEST_PARAMS,
           model: judgeConfig.model,
           messages: [
             { role: 'system', content: prompt.systemPrompt },

--- a/packages/api/src/handlers/handler-utils.test.ts
+++ b/packages/api/src/handlers/handler-utils.test.ts
@@ -35,6 +35,7 @@ vi.mock('@shared/console-logging', () => ({
 }));
 
 import { providerConfigs } from '@api/ai-providers';
+import { openAIModelCapabilities } from '@api/ai-providers/openai/model-capabilities';
 // Import after mocks are set up
 import { tryPost } from '@api/handlers/handler-utils';
 import transformToProviderRequest from '@api/services/transform-to-provider-request';
@@ -358,6 +359,45 @@ describe('tryPost Error Handling', () => {
         expect.stringContaining('Dropped temperature'),
       );
       expect(mockSuperAgentsRequestData.requestBody).toEqual(before);
+      warn.mockRestore();
+    });
+
+    /**
+     * The internal skills send `prompt_cache_options` on every call, and the
+     * OpenAI models before gpt-5.6 answer it with a 400. Against the real
+     * table: kept away from those, through to the ones that take it.
+     */
+    it.each([
+      ['gpt-5-mini', false],
+      ['gpt-5.6', true],
+    ])('forwards prompt_cache_options to %s: %s', async (model, forwarded) => {
+      reachTheTransform();
+      registerProviderCapabilities(openAIModelCapabilities);
+      mockSuperAgentsTarget.configuration.model = model;
+      mockSuperAgentsRequestData.requestBody = {
+        model,
+        messages: [{ role: ChatCompletionMessageRole.USER, content: 'Hello' }],
+        prompt_cache_options: { mode: 'explicit' },
+      } as never;
+      const warn = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+      await tryPost(
+        mockContext,
+        mockSuperAgentsConfig,
+        mockSuperAgentsTarget,
+        mockSuperAgentsRequestData,
+        0,
+      );
+
+      const sent = vi.mocked(transformToProviderRequest).mock.calls[0][2]
+        .requestBody as Record<string, unknown>;
+      if (forwarded) {
+        expect(sent.prompt_cache_options).toEqual({ mode: 'explicit' });
+      } else {
+        expect(sent).not.toHaveProperty('prompt_cache_options');
+      }
       warn.mockRestore();
     });
   });

--- a/packages/api/src/optimization/utils/describe-skill.ts
+++ b/packages/api/src/optimization/utils/describe-skill.ts
@@ -1,4 +1,4 @@
-import { getApiUrl } from '@api/constants';
+import { getApiUrl, SA_SKILL_REQUEST_PARAMS } from '@api/constants';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
@@ -174,6 +174,7 @@ export async function describeSkillForRequest(
         defaultHeaders: { 'sa-config': JSON.stringify(saConfig) },
       })
       .chat.completions.parse({
+        ...SA_SKILL_REQUEST_PARAMS,
         model: modelConfig.model,
         messages: [
           { role: 'system', content: DESCRIBER_SYSTEM_PROMPT },

--- a/packages/api/src/optimization/utils/evaluations.test.ts
+++ b/packages/api/src/optimization/utils/evaluations.test.ts
@@ -91,6 +91,26 @@ describe('generateEvaluationCreateParams', () => {
     expect(params.skill_id).toBe('skill-1');
   });
 
+  it('opts out of the implicit prompt cache, like every internal skill call', async () => {
+    mockParse.mockResolvedValue(parsedAs({ task: 'Review the diff' }));
+
+    await generateEvaluationCreateParams(
+      mockContext,
+      skill,
+      connectorFor(
+        EvaluationMethodName.TASK_COMPLETION,
+        z.object({ task: z.string() }),
+      ),
+      EvaluationMethodName.TASK_COMPLETION,
+      'an agent that maintains a website',
+      storageConnector,
+    );
+
+    expect(mockParse.mock.calls[0][0]).toMatchObject({
+      prompt_cache_options: { mode: 'explicit' },
+    });
+  });
+
   it('does not call the model for a method with no AI parameters', async () => {
     /**
      * Every method but task_completion declares an empty AI schema. Asking a

--- a/packages/api/src/optimization/utils/evaluations.ts
+++ b/packages/api/src/optimization/utils/evaluations.ts
@@ -1,4 +1,4 @@
-import { getApiUrl } from '@api/constants';
+import { getApiUrl, SA_SKILL_REQUEST_PARAMS } from '@api/constants';
 import type {
   EvaluationMethodConnector,
   UserDataStorageConnector,
@@ -194,6 +194,7 @@ export async function generateEvaluationCreateParams(
       },
     })
     .chat.completions.parse({
+      ...SA_SKILL_REQUEST_PARAMS,
       model: modelConfig.model,
       messages: [
         { role: 'system', content: systemPrompt },

--- a/packages/api/src/optimization/utils/system-prompt.ts
+++ b/packages/api/src/optimization/utils/system-prompt.ts
@@ -1,4 +1,4 @@
-import { getApiUrl } from '@api/constants';
+import { getApiUrl, SA_SKILL_REQUEST_PARAMS } from '@api/constants';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
@@ -133,6 +133,7 @@ async function callSystemPromptAPI(
       },
     })
     .chat.completions.parse({
+      ...SA_SKILL_REQUEST_PARAMS,
       model,
       messages: [
         { role: 'system', content: systemPrompt },

--- a/packages/api/src/utils/model-validator.test.ts
+++ b/packages/api/src/utils/model-validator.test.ts
@@ -581,4 +581,59 @@ describe('Model Validator', () => {
       expect(takesTemperature('gpt-50')).toBe(true);
     });
   });
+
+  /**
+   * Against the real OpenAI table. `prompt_cache_options` exists from
+   * gpt-5.6 on, and the models before it answer the field with a 400 rather
+   * than ignoring it, so the table has to say no for everything else --
+   * including the models it has no entry for.
+   */
+  describe('prompt_cache_options on OpenAI', () => {
+    beforeEach(() => {
+      registerProviderCapabilities(openAIModelCapabilities);
+    });
+
+    const takes = (parameter: ModelParameter, model: string) =>
+      validateParameter(
+        AIProvider.OPENAI,
+        model,
+        parameter,
+        FunctionName.CHAT_COMPLETE,
+      ).isSupported;
+
+    it.each([
+      'gpt-5.6',
+      'gpt-5.6-sol',
+      'gpt-5.6-mini-2026-08-01',
+      'gpt-5.7',
+      'gpt-5.10',
+      'gpt-6',
+      'gpt-6.1-pro',
+    ])('is kept for %s', (model) => {
+      expect(takes(ModelParameter.PROMPT_CACHE_OPTIONS, model)).toBe(true);
+    });
+
+    it.each([
+      'gpt-5',
+      'gpt-5-mini',
+      'gpt-5.1',
+      'gpt-5.5',
+      'gpt-5-chat-latest',
+      'gpt-4o',
+      'gpt-4.1',
+      'gpt-3.5-turbo',
+      'o1',
+      'o3-mini',
+      'o4-mini',
+      'gpt-60',
+    ])('is dropped for %s', (model) => {
+      expect(takes(ModelParameter.PROMPT_CACHE_OPTIONS, model)).toBe(false);
+    });
+
+    it('keeps the family restrictions for the models that take it', () => {
+      expect(takes(ModelParameter.TEMPERATURE, 'gpt-5.6')).toBe(false);
+      expect(takes(ModelParameter.TEMPERATURE, 'gpt-6')).toBe(false);
+      expect(takes(ModelParameter.REASONING_EFFORT, 'gpt-5.6')).toBe(true);
+    });
+  });
 });

--- a/packages/api/src/utils/super-agents/intent-compaction.ts
+++ b/packages/api/src/utils/super-agents/intent-compaction.ts
@@ -1,4 +1,4 @@
-import { getApiUrl } from '@api/constants';
+import { getApiUrl, SA_SKILL_REQUEST_PARAMS } from '@api/constants';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
@@ -64,6 +64,7 @@ async function compactOnce(
       defaultHeaders: { 'sa-config': JSON.stringify(saConfig) },
     })
     .chat.completions.create({
+      ...SA_SKILL_REQUEST_PARAMS,
       model: modelConfig.model,
       // Deterministic, so the summary -- and with it the identity embedding
       // -- stays put across restarts instead of drifting per process.

--- a/packages/api/src/utils/super-agents/skill-arbiter.ts
+++ b/packages/api/src/utils/super-agents/skill-arbiter.ts
@@ -1,4 +1,4 @@
-import { getApiUrl } from '@api/constants';
+import { getApiUrl, SA_SKILL_REQUEST_PARAMS } from '@api/constants';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
@@ -130,6 +130,7 @@ export async function arbitrateSkillForRequest(
         defaultHeaders: { 'sa-config': JSON.stringify(saConfig) },
       })
       .chat.completions.parse({
+        ...SA_SKILL_REQUEST_PARAMS,
         model: modelConfig.model,
         messages: [
           { role: 'system', content: ARBITER_SYSTEM_PROMPT },

--- a/packages/shared/src/types/ai-providers/model-capabilities.ts
+++ b/packages/shared/src/types/ai-providers/model-capabilities.ts
@@ -23,6 +23,7 @@ const MODEL_PARAMETERS = [
   'thinking',
   'logprobs',
   'top_logprobs',
+  'prompt_cache_options',
 ] as const;
 
 /**
@@ -51,6 +52,7 @@ export const ModelParameter = {
   THINKING: 'thinking',
   LOGPROBS: 'logprobs',
   TOP_LOGPROBS: 'top_logprobs',
+  PROMPT_CACHE_OPTIONS: 'prompt_cache_options',
 } as const;
 
 /**

--- a/packages/shared/src/types/api/routes/chat-completions-api/request.test.ts
+++ b/packages/shared/src/types/api/routes/chat-completions-api/request.test.ts
@@ -24,6 +24,24 @@ describe('Chat Completions API Request Types', () => {
       expect(parsed.messages[0].content).toBe('Hello, world!');
     });
 
+    it('accepts prompt_cache_options and rejects a mode it does not know', () => {
+      const request = {
+        model: 'gpt-5.6',
+        messages: [{ role: 'user', content: 'Hello, world!' }],
+        prompt_cache_options: { mode: 'explicit' },
+      };
+
+      expect(
+        ChatCompletionRequestBody.parse(request).prompt_cache_options,
+      ).toEqual({ mode: 'explicit' });
+      expect(() =>
+        ChatCompletionRequestBody.parse({
+          ...request,
+          prompt_cache_options: { mode: 'never' },
+        }),
+      ).toThrow();
+    });
+
     it('should validate request with system and user messages', () => {
       const request = {
         model: 'claude-3-5-sonnet-20241022',

--- a/packages/shared/src/types/api/routes/chat-completions-api/request.ts
+++ b/packages/shared/src/types/api/routes/chat-completions-api/request.ts
@@ -11,6 +11,25 @@ import {
 import { z } from 'zod';
 
 /**
+ * How the provider caches the prompt prefix: OpenAI's `prompt_cache_options`,
+ * which exists from GPT-5.6 on. Those models cache implicitly by default and
+ * bill the write; `explicit` caches only the blocks marked with a breakpoint,
+ * so a request that marks none writes nothing.
+ *
+ * @see https://developers.openai.com/api/docs/guides/prompt-caching
+ */
+export const ChatCompletionPromptCacheOptions = z.object({
+  /** `implicit`, the default, places a breakpoint at the end of the prompt. */
+  mode: z.enum(['implicit', 'explicit']).optional(),
+  /** Minimum lifetime of the breakpoints the request writes; `30m` so far. */
+  ttl: z.string().optional(),
+});
+
+export type ChatCompletionPromptCacheOptions = z.infer<
+  typeof ChatCompletionPromptCacheOptions
+>;
+
+/**
  * The parameters for the chat completions API request.
  * Used for the /v1/chat/completions endpoint.
  */
@@ -104,6 +123,8 @@ export const ChatCompletionRequestBody = z.object({
   top_logprobs: z.number().optional(),
   /** Whether to enable parallel function calling during tool use. */
   parallel_tool_calls: z.boolean().optional(),
+  /** How the provider caches the prompt prefix. Forwarded only to the models that take it. */
+  prompt_cache_options: ChatCompletionPromptCacheOptions.optional(),
   // Provider-specific parameters
   /** Google Vertex AI specific safety settings. */
   safety_settings: z.any().optional(),


### PR DESCRIPTION
## Problem

OpenAI's GPT-5.6 models cache the prompt implicitly and bill the write at 1.25x the input price. The internal skills (judge, evaluation generation, task extraction, reflection, describe-skill, the arbiter, intent compaction) each send a one-shot prompt that no later request shares, so every call was paying to cache a prefix nothing ever read back. The judge runs per request and per evaluation, so this added up.

## Solution

- `prompt_cache_options` joins the chat completions request schema (`mode`, `ttl`) and the OpenAI config forwards it.
- Every internal skill call spreads `SA_SKILL_REQUEST_PARAMS` from `constants.ts`, which is `prompt_cache_options: { mode: 'explicit' }`. Explicit mode caches only the blocks marked with a breakpoint, and none are marked, so nothing is written.
- Models before gpt-5.6 answer the field with a 400 rather than ignoring it. The OpenAI capability table now takes it only on gpt-5.6 and later (a new entry ahead of the gpt-5 family pattern; every older entry and the provider default list it as unsupported), and `dropUnsupportedParameters` strips it for the rest. On a pre-5.6 judge model such as the default `gpt-5-mini` this logs a "Dropped prompt_cache_options" warning per call, like a dropped `temperature` does.
- A provider whose config does not list the parameter never sees it. Only OpenAI lists it; Microsoft's docs say Azure OpenAI does not take it yet. Enabling another provider later is one line in its chat config.
- AGENTS.md documents the behavior under Internal Skill Calls.

Not covered: the Responses API path (the internal skills use chat completions), and an explicit `prompt_cache_breakpoint` on the judge's shared system message, which would keep cheap prefix reads and needs breakpoint support on content parts.

## Test notes

- Schema: accepts `prompt_cache_options`, rejects an unknown mode.
- OpenAI adapter: forwards the field as sent, omits it when absent.
- Capability table, against the real one: kept for `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.7`, `gpt-6`; dropped for `gpt-5`, `gpt-5-mini`, `gpt-5.5`, `gpt-4o`, `gpt-4.1`, `o1`, `o3-mini`, `o4-mini`, and the unmatched names. The gpt-5.6 entry keeps the family's sampling restrictions.
- Handler chain with the real table: `gpt-5-mini` loses the field before the provider transform, `gpt-5.6` keeps it.
- Judge and evaluation-generation callers send it.
- `pnpm check`, `pnpm typecheck`, and `pnpm test` (176 files, 2849 tests) pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9ucjzD7awVfgM51k7XoDx
