### PR TITLE
feat: session rail on the log page, fed by the client's session id

### DIFF
--- a/packages/api/src/connectors/libsql/connector.test.ts
+++ b/packages/api/src/connectors/libsql/connector.test.ts
@@ -838,6 +838,28 @@ describe('logs', () => {
     expect(older.start_time).toBe(1000);
   });
 
+  it('filters on the trace, which is the session of a client that names one', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    await logs.createLog(c, {
+      ...logParams(agent.id, skill.id, 1000),
+      trace_id: 'ses_1',
+    });
+    await logs.createLog(c, {
+      ...logParams(agent.id, skill.id, 2000),
+      trace_id: 'ses_2',
+    });
+    await logs.createLog(c, {
+      ...logParams(agent.id, skill.id, 3000),
+      trace_id: 'ses_1',
+    });
+
+    const session = await logs.getLogs(c, { trace_id: 'ses_1', order: 'asc' });
+    expect(session.map((l) => l.start_time)).toEqual([1000, 3000]);
+  });
+
   it('filters on embeddings being present', async () => {
     const { c } = await freshDatabase();
     const agent = await seedAgent(c);

--- a/packages/api/src/connectors/libsql/logs.ts
+++ b/packages/api/src/connectors/libsql/logs.ts
@@ -36,6 +36,7 @@ export const libsqlLogsStorageConnector: LogsStorageConnector = {
     eq('cluster_id', queryParams.cluster_id);
     eq('arm_id', queryParams.arm_id);
     eq('app_id', queryParams.app_id);
+    eq('trace_id', queryParams.trace_id);
     eq('id', queryParams.id);
     eq('method', queryParams.method);
     eq('endpoint', queryParams.endpoint);

--- a/packages/api/src/connectors/supabase/supabase.test.ts
+++ b/packages/api/src/connectors/supabase/supabase.test.ts
@@ -592,4 +592,17 @@ describe('supabaseLogsStorageConnector - getLogs', () => {
     expect(params.get('start_time')).toBe('gte.2001');
     expect(params.get('limit')).toBe('1');
   });
+
+  it('filters on the trace', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    await supabaseLogsStorageConnector.getLogs(mockContext, {
+      trace_id: 'ses_1',
+    });
+
+    expect(sentUrl().searchParams.get('trace_id')).toBe('eq.ses_1');
+  });
 });

--- a/packages/api/src/connectors/supabase/supabase.ts
+++ b/packages/api/src/connectors/supabase/supabase.ts
@@ -1399,6 +1399,9 @@ export const supabaseLogsStorageConnector: LogsStorageConnector = {
     if (queryParams.app_id) {
       postgRESTQuery.app_id = `eq.${queryParams.app_id}`;
     }
+    if (queryParams.trace_id) {
+      postgRESTQuery.trace_id = `eq.${queryParams.trace_id}`;
+    }
     if (queryParams.id) {
       postgRESTQuery.id = `eq.${queryParams.id}`;
     }

--- a/packages/api/src/middlewares/variables.test.ts
+++ b/packages/api/src/middlewares/variables.test.ts
@@ -100,6 +100,20 @@ describe('commonVariablesMiddleware', () => {
       });
     });
 
+    it('should trace a client that names its session in plain headers', async () => {
+      // OpenCode sends no sa-config, only a session id and a product token.
+      const response = await post('/v1/agents/captain_code/chat/completions', {
+        'user-agent':
+          'opencode/1.18.18 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14',
+        'x-session-id': 'ses_fa0504e30ffe',
+      });
+
+      expect(response.status).toBe(200);
+      const body = await readBody(response);
+      expect(body.config.trace_id).toBe('ses_fa0504e30ffe');
+      expect(body.config.app_id).toBe('opencode/1.18.18');
+    });
+
     it('should default to auto optimization when no target is given', async () => {
       const response = await post(
         '/v1/agents/captain_code/skills/programming/chat/completions',

--- a/packages/api/src/middlewares/variables.ts
+++ b/packages/api/src/middlewares/variables.ts
@@ -1,5 +1,6 @@
 import type { AppContext } from '@api/types/hono';
 import type { HttpMethod } from '@api/types/http';
+import { withClientTracing } from '@api/utils/super-agents/client-tracing';
 import { SuperAgentsConfigPreProcessed } from '@shared/types/api/request/headers';
 import {
   InvalidRequestBodyError,
@@ -58,7 +59,7 @@ export const commonVariablesMiddleware = createMiddleware(
         // The path always wins over the header so that a client pointed at a
         // skill's base URL cannot accidentally target another skill. A path
         // that names only the agent leaves a skill from the header in place.
-        const config = agentSkillScope
+        const scopedConfig = agentSkillScope
           ? {
               ...rawConfig,
               agent_name: agentSkillScope.agent_name,
@@ -67,6 +68,8 @@ export const commonVariablesMiddleware = createMiddleware(
                 : {}),
             }
           : rawConfig;
+        // Tracing a client sends as plain headers rather than in the config
+        const config = withClientTracing(scopedConfig, c.req.raw.headers);
 
         const saConfigPreProcessed = SuperAgentsConfigPreProcessed.safeParse(
           config,

--- a/packages/api/src/utils/super-agents/client-tracing.test.ts
+++ b/packages/api/src/utils/super-agents/client-tracing.test.ts
@@ -1,0 +1,42 @@
+import { withClientTracing } from '@api/utils/super-agents/client-tracing';
+import { describe, expect, it } from 'vitest';
+
+// What OpenCode 1.18.18 sends, captured at the gateway
+const opencode = () =>
+  new Headers({
+    'user-agent':
+      'opencode/1.18.18 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14',
+    'x-session-id': 'ses_fa0504e30ffe',
+  });
+
+describe('withClientTracing', () => {
+  it('traces a client that names its session by session and product', () => {
+    expect(withClientTracing({ agent_name: 'a' }, opencode())).toEqual({
+      agent_name: 'a',
+      trace_id: 'ses_fa0504e30ffe',
+      app_id: 'opencode/1.18.18',
+    });
+  });
+
+  it('leaves what sa-config says in place', () => {
+    expect(
+      withClientTracing({ trace_id: 'trace-1', app_id: 'my-app' }, opencode()),
+    ).toEqual({ trace_id: 'trace-1', app_id: 'my-app' });
+  });
+
+  it('leaves a request without a session id alone', () => {
+    const config = { agent_name: 'a' };
+    expect(
+      withClientTracing(
+        config,
+        new Headers({ 'user-agent': 'OpenAI/JS 6.15.0' }),
+      ),
+    ).toBe(config);
+  });
+
+  it('takes the session alone when there is no user-agent', () => {
+    expect(
+      withClientTracing({}, new Headers({ 'x-session-id': 'ses_1' })),
+    ).toEqual({ trace_id: 'ses_1' });
+  });
+});

--- a/packages/api/src/utils/super-agents/client-tracing.ts
+++ b/packages/api/src/utils/super-agents/client-tracing.ts
@@ -1,0 +1,24 @@
+/**
+ * Tracing a client sends outside `sa-config`.
+ *
+ * OpenCode, for one, names its session on every request (`x-session-id`)
+ * and itself in the user-agent (`opencode/1.18.18 ai-sdk/...`) but knows
+ * nothing of `sa-config`, so its logs would each get a random trace and no
+ * app. A session is a trace, and a client that names one is an application,
+ * which its user-agent's product token names. Whatever `sa-config` says
+ * wins, and a request without a session id is left alone: a bare SDK or
+ * curl user-agent names a library, not an app.
+ */
+export function withClientTracing(
+  config: Record<string, unknown>,
+  headers: Headers,
+): Record<string, unknown> {
+  const sessionId = headers.get('x-session-id');
+  if (!sessionId) return config;
+  const product = headers.get('user-agent')?.split(' ')[0];
+  return {
+    ...config,
+    trace_id: config.trace_id ?? sessionId,
+    ...(config.app_id === undefined && product ? { app_id: product } : {}),
+  };
+}

--- a/packages/shared/src/types/data/log.ts
+++ b/packages/shared/src/types/data/log.ts
@@ -113,6 +113,8 @@ export const LogsQueryParams = z.object({
   cluster_id: z.uuid().optional(),
   arm_id: z.uuid().optional(),
   app_id: z.uuid().optional(),
+  /** The trace -- for a client that names its session, the session. */
+  trace_id: z.string().optional(),
   after: z
     .string()
     .transform((val) => (val ? Number(val) : undefined))

--- a/packages/web/src/api/v1/super-agents/observability/logs.ts
+++ b/packages/web/src/api/v1/super-agents/observability/logs.ts
@@ -15,6 +15,7 @@ export async function queryLogs(params: LogsQueryParams): Promise<Log[]> {
       agent_id: params.agent_id,
       skill_id: params.skill_id,
       cluster_id: params.cluster_id,
+      trace_id: params.trace_id,
       id: params.id,
       ids: params.ids,
       app_id: params.app_id,

--- a/packages/web/src/components/agents/skills/logs/components/session-map.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/session-map.test.tsx
@@ -1,0 +1,129 @@
+import type { Log } from '@shared/types/data/log';
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  formatDuration,
+  SessionMap,
+} from '@web/components/agents/skills/logs/components/session-map';
+import { describe, expect, it, vi } from 'vitest';
+
+const log = (id: string, start_time: number, extra: Partial<Log> = {}): Log =>
+  ({
+    id,
+    start_time,
+    duration: 1_000,
+    status: 200,
+    model: 'gpt-5.6-sol',
+    avg_eval_score: null,
+    span_name: null,
+    ...extra,
+  }) as Log;
+
+// A coding-agent turn: a title call beside the real one, then a failure
+const logs = [
+  log('a', 1_000_000, { avg_eval_score: 0.87 }),
+  log('b', 1_000_300, { duration: 12_000 }),
+  log('c', 1_240_300, { status: 500, duration: 100 }),
+];
+
+const renderMap = (props: Partial<Parameters<typeof SessionMap>[0]> = {}) =>
+  render(
+    <SessionMap
+      logs={logs}
+      currentId="b"
+      hasEarlier={false}
+      hasLater={false}
+      traceId="ses_1"
+      labelOf={() => null}
+      onSelect={vi.fn()}
+      {...props}
+    />,
+  );
+
+describe('SessionMap', () => {
+  it('lists the requests with the current one marked', () => {
+    renderMap();
+
+    expect(screen.getAllByTitle(/^HTTP /)).toHaveLength(3);
+    // Each bar is read off at its tip, so a length is never taken for a score
+    expect(screen.getByRole('button', { current: true })).toHaveTextContent(
+      '12.0s',
+    );
+    // First request to the end of the last: 240.4s
+    expect(screen.getByText('3 requests · 4m')).toBeInTheDocument();
+  });
+
+  it('shows a failure by its status and a good request by its score', () => {
+    renderMap();
+
+    expect(screen.getByText('500')).toHaveClass('text-red-500');
+    expect(screen.getByText('87%')).toHaveClass('text-green-500');
+    expect(screen.queryByText('200')).not.toBeInTheDocument();
+  });
+
+  it('colours a weak score apart from a failure', () => {
+    renderMap({
+      logs: [log('weak', 1_000_000, { avg_eval_score: 0.4 })],
+      currentId: 'weak',
+    });
+
+    expect(screen.getByText('40%')).toHaveClass('text-amber-500');
+  });
+
+  it('opens a request', () => {
+    const onSelect = vi.fn();
+    renderMap({ onSelect });
+
+    const [first] = screen.getAllByTitle(/^HTTP /);
+    fireEvent.click(first);
+    expect(onSelect).toHaveBeenCalledWith(logs[0]);
+    expect(first).toHaveAttribute(
+      'title',
+      'HTTP 200 · 1.0s · gpt-5.6-sol · scored 87%',
+    );
+  });
+
+  it('steps through the session with its own arrows, earlier being up', () => {
+    const onSelect = vi.fn();
+    renderMap({ onSelect });
+
+    expect(screen.getByText('2 of 3')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Earlier request in this session'));
+    expect(onSelect).toHaveBeenLastCalledWith(logs[0]);
+
+    fireEvent.click(screen.getByLabelText('Later request in this session'));
+    expect(onSelect).toHaveBeenLastCalledWith(logs[2]);
+  });
+
+  it('stops at the ends of the session', () => {
+    renderMap({ currentId: 'c' });
+
+    expect(screen.getByText('3 of 3')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Later request in this session'),
+    ).toBeDisabled();
+    expect(
+      screen.getByLabelText('Earlier request in this session'),
+    ).toBeEnabled();
+  });
+
+  it('says when the session goes on past the window', () => {
+    renderMap({ hasEarlier: true, hasLater: true });
+
+    expect(screen.getByText('Earlier requests not shown')).toBeInTheDocument();
+    expect(screen.getByText('Later requests not shown')).toBeInTheDocument();
+    expect(screen.getByText('3+ requests')).toBeInTheDocument();
+    // With the window cut, a position would be a guess
+    expect(screen.queryByText(/of 3/)).not.toBeInTheDocument();
+  });
+});
+
+describe('formatDuration', () => {
+  it('reads as a request, or as a whole session', () => {
+    expect(formatDuration(320)).toBe('320ms');
+    expect(formatDuration(16_771)).toBe('16.8s');
+    expect(formatDuration(252_000)).toBe('4m 12s');
+    expect(formatDuration(240_000)).toBe('4m');
+    expect(formatDuration(5_400_000)).toBe('1h 30m');
+  });
+});

--- a/packages/web/src/components/agents/skills/logs/components/session-map.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/session-map.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import type { Log } from '@shared/types/data/log';
+import { Button } from '@web/components/ui/button';
+import { formatClockTime } from '@web/utils/time';
+import { cn } from '@web/utils/ui/utils';
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
+import type { ReactElement } from 'react';
+import { useEffect, useRef } from 'react';
+
+/** A length of time, in the unit a reader would say: a request's, or a session's */
+export function formatDuration(ms: number): string {
+  if (ms < 1_000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1_000).toFixed(1)}s`;
+  if (ms < 3_600_000) {
+    const minutes = Math.floor(ms / 60_000);
+    const seconds = Math.round((ms % 60_000) / 1_000);
+    return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(ms / 3_600_000);
+  const minutes = Math.floor((ms % 3_600_000) / 60_000);
+  return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+/** The score a request has to reach to count as good; the logs table's line too */
+const GOOD_SCORE = 0.7;
+
+type Tone = 'failed' | 'good' | 'poor' | 'unscored';
+
+/**
+ * The colour a request is read by: red when it failed, green or amber by
+ * its score, none until it has been judged. A weak answer and a failed
+ * request are different news, so they are different colours.
+ */
+function toneOf(log: Log): Tone {
+  if (log.status >= 400) return 'failed';
+  const score = log.avg_eval_score;
+  if (score === null || score === undefined) return 'unscored';
+  return score >= GOOD_SCORE ? 'good' : 'poor';
+}
+
+const TEXT_TONE: Record<Tone, string> = {
+  failed: 'text-red-500',
+  good: 'text-green-500',
+  poor: 'text-amber-500',
+  unscored: 'text-muted-foreground',
+};
+
+const BAR_TONE: Record<Tone, string> = {
+  failed: 'bg-red-500',
+  good: 'bg-green-500',
+  poor: 'bg-amber-500',
+  unscored: 'bg-muted-foreground/40',
+};
+
+interface SessionMapProps {
+  /** The session's requests, oldest first */
+  logs: Log[];
+  currentId: string;
+  /** The session goes on past what is shown, on that side */
+  hasEarlier: boolean;
+  hasLater: boolean;
+  traceId: string;
+  appId?: string | null;
+  /** A line under a request's time: what it was, when that is known */
+  labelOf: (log: Log) => string | null;
+  onSelect: (log: Log) => void;
+}
+
+/**
+ * A session's requests as a rail beside the one being read: each a time, a
+ * score or failing status in its colour, and a bar as long as the request
+ * took, its length written at the tip so it cannot be read as a score. The
+ * rail carries its own arrows, so stepping through the session is never
+ * confused with the page's arrows, which step through the list.
+ */
+export function SessionMap({
+  logs,
+  currentId,
+  hasEarlier,
+  hasLater,
+  traceId,
+  appId,
+  labelOf,
+  onSelect,
+}: SessionMapProps): ReactElement {
+  const currentRef = useRef<HTMLButtonElement>(null);
+  const longest = Math.max(1, ...logs.map((log) => log.duration));
+
+  // Keep the request being read in view as the reader steps through
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll when the current request changes
+  useEffect(() => {
+    currentRef.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [currentId]);
+
+  // How many, and -- when all of them are here -- how long they spanned
+  const cut = hasEarlier || hasLater;
+  const first = logs[0];
+  const last = logs[logs.length - 1];
+  const span =
+    first && last && !cut
+      ? ` · ${formatDuration(last.start_time + last.duration - first.start_time)}`
+      : '';
+  const count = `${logs.length}${cut ? '+' : ''} requests${span}`;
+
+  // The session's own arrows, in its order: earlier is up the rail
+  const index = logs.findIndex((log) => log.id === currentId);
+  const earlier = index > 0 ? logs[index - 1] : undefined;
+  const later = index >= 0 ? logs[index + 1] : undefined;
+  // A position only means something once the whole session is here
+  const position = !cut && index >= 0 ? `${index + 1} of ${logs.length}` : null;
+
+  return (
+    <nav
+      aria-label="Session"
+      className="hidden md:flex flex-col w-52 shrink-0 border-r bg-background"
+    >
+      <div className="px-3 pt-3 pb-2 border-b">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+            Session
+          </span>
+          {appId && (
+            <span
+              className="text-[10px] text-muted-foreground truncate"
+              title={appId}
+            >
+              {appId}
+            </span>
+          )}
+        </div>
+        <div className="mt-1 flex items-baseline justify-between gap-2">
+          <span
+            className="font-mono text-[11px] truncate select-all cursor-text"
+            title={traceId}
+          >
+            {traceId}
+          </span>
+          <span className="text-[11px] text-muted-foreground shrink-0 tabular-nums">
+            {count}
+          </span>
+        </div>
+      </div>
+      <div className="flex items-center justify-between px-1.5 py-1 border-b">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          aria-label="Earlier request in this session"
+          disabled={!earlier}
+          onClick={() => earlier && onSelect(earlier)}
+        >
+          <ChevronLeftIcon className="h-3.5 w-3.5" />
+        </Button>
+        {position && (
+          <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+            {position}
+          </span>
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          aria-label="Later request in this session"
+          disabled={!later}
+          onClick={() => later && onSelect(later)}
+        >
+          <ChevronRightIcon className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      {/* The list's own padding and margins are reset: it is a rail, not prose */}
+      <ol className="flex-1 overflow-y-auto m-0 py-1 pl-0 list-none">
+        {hasEarlier && (
+          <li className="px-3 py-1 text-[10px] text-muted-foreground">
+            Earlier requests not shown
+          </li>
+        )}
+        {logs.map((log) => {
+          const current = log.id === currentId;
+          const tone = toneOf(log);
+          const score = log.avg_eval_score;
+          const label = labelOf(log);
+          const time = formatClockTime(log.start_time);
+          const duration = formatDuration(log.duration);
+          const tooltip = [`HTTP ${log.status}`, duration, log.model]
+            .concat(
+              score !== null && score !== undefined
+                ? [`scored ${Math.round(score * 100)}%`]
+                : [],
+            )
+            .join(' · ');
+          return (
+            <li key={log.id}>
+              <button
+                type="button"
+                ref={current ? currentRef : undefined}
+                aria-current={current ? 'true' : undefined}
+                onClick={() => onSelect(log)}
+                title={tooltip}
+                className={cn(
+                  'w-full text-left px-3 py-1.5 border-l-2 transition-colors',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+                  current
+                    ? 'border-primary bg-accent'
+                    : 'border-transparent hover:bg-muted/60',
+                )}
+              >
+                <div className="flex items-baseline justify-between gap-2 font-mono text-[11px] tabular-nums">
+                  <span
+                    className={
+                      current ? 'text-foreground' : 'text-muted-foreground'
+                    }
+                  >
+                    {time}
+                  </span>
+                  {tone === 'failed' ? (
+                    <span className={cn('font-medium', TEXT_TONE.failed)}>
+                      {log.status}
+                    </span>
+                  ) : (
+                    score !== null &&
+                    score !== undefined && (
+                      <span className={cn('font-medium', TEXT_TONE[tone])}>
+                        {Math.round(score * 100)}%
+                      </span>
+                    )
+                  )}
+                </div>
+                {label && (
+                  <div className="truncate text-[10px] text-muted-foreground">
+                    {label}
+                  </div>
+                )}
+                <div className="mt-1 flex items-center gap-1.5">
+                  <div
+                    className={cn(
+                      'h-[3px] rounded-full min-w-[3px] shrink-0',
+                      BAR_TONE[tone],
+                    )}
+                    // The longest request reaches the label's reserve; the
+                    // rest are to scale, each read off at its own tip
+                    style={{
+                      width: `calc((100% - 2.75rem) * ${log.duration / longest})`,
+                    }}
+                  />
+                  <span className="text-[10px] tabular-nums text-muted-foreground shrink-0">
+                    {duration}
+                  </span>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+        {hasLater && (
+          <li className="px-3 py-1 text-[10px] text-muted-foreground">
+            Later requests not shown
+          </li>
+        )}
+      </ol>
+    </nav>
+  );
+}

--- a/packages/web/src/components/agents/skills/logs/log-details-view.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-details-view.tsx
@@ -9,6 +9,7 @@ import { extractSystemPrompt } from '@shared/utils/system-prompt';
 import { CompletionViewer } from '@web/components/agents/skills/logs/components/completion-viewer';
 import { GenericViewer } from '@web/components/agents/skills/logs/components/generic-viewer';
 import { MessagesView } from '@web/components/agents/skills/logs/components/messages-view';
+import { SessionMap } from '@web/components/agents/skills/logs/components/session-map';
 import { LogFeedback } from '@web/components/agents/skills/logs/log-feedback';
 import { LogNavigation } from '@web/components/agents/skills/logs/log-navigation';
 import { Badge } from '@web/components/ui/badge';
@@ -17,6 +18,7 @@ import { Card, CardContent, CardHeader } from '@web/components/ui/card';
 import { PageHeader } from '@web/components/ui/page-header';
 import { Separator } from '@web/components/ui/separator';
 import { Skeleton } from '@web/components/ui/skeleton';
+import { useLogSession } from '@web/hooks/use-log-session';
 import { useSmartBack } from '@web/hooks/use-smart-back';
 import { useAgents } from '@web/providers/agents';
 import { useLogs } from '@web/providers/logs';
@@ -88,6 +90,7 @@ export function LogDetailsView(): ReactElement {
   const { selectedLog, newerLog, olderLog, isLoading, setAgentId, setSkillId } =
     useLogs();
   const { replaceToLogDetail, navigateToSkillDashboard } = useNavigation();
+  const session = useLogSession(selectedLog);
   const { clusters, setSkillId: setClustersSkillId } =
     useSkillOptimizationClusters();
   const {
@@ -251,6 +254,21 @@ export function LogDetailsView(): ReactElement {
 
   const openLog = (log: Log): void => {
     if (selectedAgent) replaceToLogDetail(selectedAgent.name, log.id);
+  };
+
+  // What a request in the session was: its span, or what varied across the
+  // session -- the skill it was routed to, the model that answered it
+  const sessionSpansSkills =
+    new Set(session.logs.map((log) => log.skill_id)).size > 1;
+  const sessionSpansModels =
+    new Set(session.logs.map((log) => log.model)).size > 1;
+  const sessionLabelOf = (log: Log): string | null => {
+    if (log.span_name) return log.span_name;
+    const parts = [
+      sessionSpansSkills ? skillNameOf(log) : null,
+      sessionSpansModels ? log.model : null,
+    ].filter((part): part is string => !!part);
+    return parts.length ? parts.join(' · ') : null;
   };
 
   const handleBack = () => {
@@ -573,6 +591,18 @@ export function LogDetailsView(): ReactElement {
             </div>
           )}
           <CardContent className="flex flex-row p-0 h-full relative overflow-hidden">
+            {selectedLog.trace_id && session.logs.length > 1 && (
+              <SessionMap
+                logs={session.logs}
+                currentId={selectedLog.id}
+                hasEarlier={session.hasEarlier}
+                hasLater={session.hasLater}
+                traceId={selectedLog.trace_id}
+                appId={selectedLog.app_id}
+                labelOf={sessionLabelOf}
+                onSelect={openLog}
+              />
+            )}
             <div className="inset-0 flex flex-col flex-1 w-full min-w-0 p-4 gap-4 overflow-hidden overflow-y-auto">
               {selectedLog && originalSystemPrompt && (
                 <GenericViewer

--- a/packages/web/src/hooks/use-log-session.test.tsx
+++ b/packages/web/src/hooks/use-log-session.test.tsx
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const queryLogs = vi.fn();
+vi.mock('@web/api/v1/super-agents/observability/logs', () => ({
+  queryLogs: (...args: unknown[]) => queryLogs(...args),
+}));
+
+vi.mock('@shared/types/data/log', () => ({
+  // Pass params through so the tests can see what was queried
+  LogsQueryParams: { parse: (params: unknown) => params },
+}));
+
+import type { Log } from '@shared/types/data/log';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { SESSION_WINDOW, useLogSession } from '@web/hooks/use-log-session';
+import type { ReactNode } from 'react';
+
+const log = (id: string, start_time: number): Log =>
+  ({ id, agent_id: 'agent-1', trace_id: 'ses_1', start_time }) as Log;
+
+const renderSession = (current: Log | undefined) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return {
+    queryClient,
+    ...renderHook((log: Log | undefined) => useLogSession(log), {
+      wrapper,
+      initialProps: current,
+    }),
+  };
+};
+
+describe('useLogSession', () => {
+  it('fetches a window around the log on each side of its trace', async () => {
+    const current = log('b', 2000);
+    queryLogs.mockImplementation((params: { before?: string }) =>
+      Promise.resolve(
+        params.before
+          ? [current, log('a', 1000)] // newest first
+          : [current, log('c', 3000)], // oldest first
+      ),
+    );
+
+    const { result, queryClient } = renderSession(current);
+
+    await waitFor(() => {
+      expect(result.current.logs.map((l) => l.id)).toEqual(['a', 'b', 'c']);
+    });
+    expect(result.current.hasEarlier).toBe(false);
+    expect(result.current.hasLater).toBe(false);
+
+    const scope = {
+      agent_id: 'agent-1',
+      trace_id: 'ses_1',
+      limit: String(SESSION_WINDOW),
+    };
+    expect(queryLogs).toHaveBeenCalledWith({ ...scope, before: '2000' });
+    expect(queryLogs).toHaveBeenCalledWith({
+      ...scope,
+      after: '2000',
+      order: 'asc',
+    });
+    // The others are seeded, so stepping to one renders without a fetch
+    expect(queryClient.getQueryData(['logs', 'detail', 'c'])).toMatchObject({
+      id: 'c',
+    });
+  });
+
+  it('says when the session goes on past the window', async () => {
+    const current = log('x', 100_000);
+    queryLogs.mockImplementation((params: { before?: string }) =>
+      Promise.resolve(
+        params.before
+          ? Array.from({ length: SESSION_WINDOW }, (_, i) =>
+              log(`e${i}`, 100_000 - i),
+            )
+          : [current],
+      ),
+    );
+
+    const { result } = renderSession(current);
+
+    await waitFor(() => {
+      expect(result.current.hasEarlier).toBe(true);
+    });
+    expect(result.current.hasLater).toBe(false);
+  });
+
+  it('keeps the rail up while stepping within the session', async () => {
+    // The window is centred on the log, so stepping changes the query; the
+    // previous window is the same session and must stay until the new one
+    // arrives, or the rail unmounts and the page jumps for a moment.
+    const a = log('a', 1000);
+    const b = log('b', 2000);
+    queryLogs.mockImplementation((params: { before?: string }) =>
+      Promise.resolve(params.before ? [b, a] : [b, log('c', 3000)]),
+    );
+    const { result, rerender } = renderSession(b);
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(3);
+    });
+
+    queryLogs.mockImplementation(() => new Promise(() => undefined)); // never lands
+    rerender(a);
+    expect(result.current.logs.map((l) => l.id)).toEqual(['a', 'b', 'c']);
+
+    // A log of another session gets nothing of it
+    rerender({ ...log('z', 9000), trace_id: 'ses_other' });
+    expect(result.current.logs).toEqual([]);
+  });
+
+  it('has no session for a log without a trace', () => {
+    queryLogs.mockClear();
+    const { result } = renderSession({
+      ...log('lone', 1000),
+      trace_id: null,
+    });
+
+    expect(result.current.logs).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(queryLogs).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/hooks/use-log-session.ts
+++ b/packages/web/src/hooks/use-log-session.ts
@@ -1,0 +1,93 @@
+'use client';
+
+import { type Log, LogsQueryParams } from '@shared/types/data/log';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryLogs } from '@web/api/v1/super-agents/observability/logs';
+import { logsQueryKeys } from '@web/providers/logs';
+
+/**
+ * Requests fetched on each side of the log. A session longer than that is
+ * shown as a window around the log, and says so at the cut ends.
+ */
+export const SESSION_WINDOW = 50;
+
+export interface LogSession {
+  /** The session's logs oldest first, the given log among them */
+  logs: Log[];
+  /** The window was cut on that side: the session goes on past it */
+  hasEarlier: boolean;
+  hasLater: boolean;
+  isLoading: boolean;
+}
+
+const NO_SESSION = { logs: [] as Log[], hasEarlier: false, hasLater: false };
+
+/**
+ * The session a log belongs to: every log of the same agent sharing its
+ * trace, which for a client that names its session (`x-session-id`) is that
+ * session. Fetched as a window around the log rather than whole, because
+ * every row carries its request and response bodies. The rows are seeded
+ * into the detail cache, so stepping to one renders at once.
+ */
+export function useLogSession(log: Log | undefined): LogSession {
+  const queryClient = useQueryClient();
+  const { data = NO_SESSION, isLoading } = useQuery({
+    queryKey: [
+      ...logsQueryKeys.all,
+      'session',
+      log?.agent_id,
+      log?.trace_id,
+      log?.id,
+    ] as const,
+    queryFn: async () => {
+      if (!log?.trace_id) return NO_SESSION;
+      const scope = {
+        agent_id: log.agent_id,
+        trace_id: log.trace_id,
+        limit: String(SESSION_WINDOW),
+      };
+      const [earlier, later] = await Promise.all([
+        queryLogs(
+          LogsQueryParams.parse({ ...scope, before: String(log.start_time) }),
+        ),
+        queryLogs(
+          LogsQueryParams.parse({
+            ...scope,
+            after: String(log.start_time),
+            order: 'asc',
+          }),
+        ),
+      ]);
+      // Both bounds are inclusive, so the log itself -- and anything sharing
+      // its start time -- comes back on both sides.
+      const byId = new Map<string, Log>();
+      for (const row of [...earlier, ...later, log]) byId.set(row.id, row);
+      const logs = [...byId.values()].sort(
+        (a, b) => a.start_time - b.start_time || a.id.localeCompare(b.id),
+      );
+      for (const row of logs) {
+        if (row.id !== log.id) {
+          queryClient.setQueryData(logsQueryKeys.detail(row.id), row);
+        }
+      }
+      return {
+        logs,
+        hasEarlier: earlier.length >= SESSION_WINDOW,
+        hasLater: later.length >= SESSION_WINDOW,
+      };
+    },
+    enabled: !!log?.trace_id,
+    // Stepping within a session changes the key (the window is centred on
+    // the log), which would empty the rail for a moment and unmount it.
+    // The previous window is the same session and already holds the new
+    // log, so keep it until the re-centred one arrives -- but only within
+    // the same session, so another session's rail never shows for a log.
+    placeholderData: (previous, previousQuery) => {
+      const [, , agentId, traceId] = previousQuery?.queryKey ?? [];
+      return agentId === log?.agent_id && traceId === log?.trace_id
+        ? previous
+        : undefined;
+    },
+  });
+  return { ...data, isLoading };
+}


### PR DESCRIPTION
## Problem

A coding agent such as OpenCode sends no `sa-config`, only an `x-session-id` header and a product token at the front of its `user-agent`. Nothing in the gateway read them, so every request of a session was recorded as an unrelated log, and there was no way to follow a session in the dashboard.

## Solution

- **Gateway.** `withClientTracing` (`utils/super-agents/client-tracing.ts`), applied in `commonVariablesMiddleware`: when a request carries `x-session-id` and its config names no trace, the session id becomes `trace_id`; the first token of `user-agent` becomes `app_id` when none is set. The config always wins over the headers.
- **Logs query** accepts `trace_id` on both backends, and the web client passes it through.
- **Session rail** on the log page, for a log whose trace is shared with at least one other log. Each request is a time, its score or failing status in colour (green from 70%, amber below, red for a failed status), and a bar to scale with its duration, labelled at the tip so a length is never read as a score. The rail has its own earlier/later arrows, so stepping through the session is never confused with the page's arrows, which step through the list. Its header shows the app, the trace id (select-all, for grepping the client's own logs), the request count and the session's span.
- **`useLogSession`** loads a window of 50 requests around the log, seeds each into the detail cache so opening one renders at once instead of flashing, and keeps the previous rail on screen while the next loads when it's the same session.

## Tests

- Unit tests for `withClientTracing`, and a middleware test with the headers OpenCode 1.18.18 actually sends.
- Connector tests for the trace filter on libSQL and Supabase.
- `SessionMap` and `useLogSession` tests.
- `pnpm check`, `pnpm typecheck` and the full `pnpm test` (180 files) pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7nkpUM1RjfcuHjy8E8MFR
