### PR TITLE
fix(api): restate the JSON schema for pass-through providers, and retry the judge past the cache

### DIFF
--- a/packages/api/src/connectors/evaluations/llm-judge.test.ts
+++ b/packages/api/src/connectors/evaluations/llm-judge.test.ts
@@ -188,6 +188,42 @@ describe('LLM Judge', () => {
     expect(config.targets[0].custom_host).toBe('http://localhost:11434');
   });
 
+  it('bypasses the cache when it retries a bad answer', async () => {
+    // The judge caches its answers, and a retry sends the identical request:
+    // without a forced refresh it would be served the same essay again.
+    mockParse
+      .mockResolvedValueOnce({
+        choices: [
+          { message: { content: '# Evaluation\n\nThe answer was fine.' } },
+        ],
+      })
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({ score: 0.8, reasoning: 'Fine' }),
+            },
+          },
+        ],
+      });
+
+    const evaluatePromise = llmJudge.evaluate({
+      text: 'This is a test evaluation.',
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await evaluatePromise;
+
+    expect(result.score).toBe(0.8);
+    const configs = vi
+      .mocked(mockWithOptions)
+      .mock.calls.map((call) =>
+        JSON.parse(call[0].defaultHeaders['sa-config']),
+      );
+    expect(configs).toHaveLength(2);
+    expect(configs[0].force_refresh).toBeUndefined();
+    expect(configs[1].force_refresh).toBe(true);
+  });
+
   it('should handle API errors gracefully', async () => {
     mockParse.mockRejectedValue(
       new Error('OpenAI API error: 500 Internal Server Error - API Error'),

--- a/packages/api/src/evaluations/llm-judge.ts
+++ b/packages/api/src/evaluations/llm-judge.ts
@@ -266,27 +266,30 @@ Provide a score between 0 and 1 with detailed reasoning for your evaluation.`;
       });
     }
 
-    const saConfig = {
-      targets: [
-        {
-          provider: provider,
-          model: judgeConfig.model,
-          cache: {
-            mode: CacheMode.SIMPLE,
-          },
-          ...(apiKey ? { api_key: apiKey } : {}),
-          ...(customHost ? { custom_host: customHost } : {}),
-        },
-      ],
-      agent_name: 'super-agents',
-      skill_name: 'judge',
-    };
-
     let lastError: unknown;
     let retryCount = 0;
     for (let i = 0; i < LLM_JUDGE_MAX_RETRIES; i++) {
       try {
         const prompt = generateEvaluationPrompt(input);
+        // Identical requests share a cache entry, and a retry is identical to
+        // the attempt whose answer was no good. It has to bypass the cache or
+        // it is handed that same answer again; the fresh one takes its place.
+        const saConfig = {
+          targets: [
+            {
+              provider: provider,
+              model: judgeConfig.model,
+              cache: {
+                mode: CacheMode.SIMPLE,
+              },
+              ...(apiKey ? { api_key: apiKey } : {}),
+              ...(customHost ? { custom_host: customHost } : {}),
+            },
+          ],
+          agent_name: 'super-agents',
+          skill_name: 'judge',
+          ...(i > 0 ? { force_refresh: true } : {}),
+        };
         const clientWithHeaders = client.withOptions({
           defaultHeaders: {
             'sa-config': JSON.stringify(saConfig),

--- a/packages/api/src/handlers/handler-utils.test.ts
+++ b/packages/api/src/handlers/handler-utils.test.ts
@@ -404,11 +404,12 @@ describe('tryPost Error Handling', () => {
 
   describe('the JSON instructions added for `response_format`', () => {
     /**
-     * Restating the schema in the system prompt is a fallback for providers
-     * that cannot express the constraint at all. Handing it to a provider that
-     * carries `response_format` itself only buries the skill's own prompt --
-     * for `json_schema` the block was prepended, so the skill's instructions
-     * ended up behind gateway boilerplate.
+     * Restating the schema in the system prompt is what makes a model that
+     * ignores `response_format` answer in JSON anyway. Only a provider that
+     * enforces the format itself can do without it; a host that merely forwards
+     * the field to whatever model sits behind it cannot be trusted to, and a
+     * judge on such a host answered markdown essays the moment the block went
+     * missing. Where it is added, it follows the skill's own prompt.
      */
     afterEach(() => {
       vi.mocked(transformToProviderRequest).mockReset();
@@ -464,7 +465,7 @@ describe('tryPost Error Handling', () => {
       mockSuperAgentsTarget.configuration.system_prompt = 'You are helpful.';
     };
 
-    it('are left out when the provider forwards `response_format`', async () => {
+    it('are left out when the provider enforces `response_format` itself', async () => {
       const seen = captureProviderBody(nativeResponseFormat);
       askForJson();
 
@@ -480,6 +481,28 @@ describe('tryPost Error Handling', () => {
         role: ChatCompletionMessageRole.SYSTEM,
         content: 'You are helpful.',
       });
+    });
+
+    it('are added, after the skill prompt, when the provider only forwards `response_format`', async () => {
+      // Ollama forwards the field, but whether the model behind it honours the
+      // constraint is up to that model.
+      mockSuperAgentsTarget.configuration.ai_provider = AIProvider.OLLAMA;
+      const seen = captureProviderBody(nativeResponseFormat);
+      askForJson();
+
+      await tryPost(
+        mockContext,
+        mockSuperAgentsConfig,
+        mockSuperAgentsTarget,
+        mockSuperAgentsRequestData,
+        0,
+      );
+
+      const systemPrompt = seen.messages?.[0].content as string;
+      expect(systemPrompt.startsWith('You are helpful.')).toBe(true);
+      expect(systemPrompt).toContain('strictly conforms to the following');
+      expect(systemPrompt).toContain('"a"');
+      expect(systemPrompt).not.toContain('__json_output');
     });
 
     it('are left out for Anthropic, which builds the tool itself', async () => {
@@ -502,6 +525,7 @@ describe('tryPost Error Handling', () => {
     });
 
     it('are added when the provider has no way to ask for JSON', async () => {
+      mockSuperAgentsTarget.configuration.ai_provider = AIProvider.BEDROCK;
       const seen = captureProviderBody();
       askForJson();
 

--- a/packages/api/src/handlers/handler-utils.ts
+++ b/packages/api/src/handlers/handler-utils.ts
@@ -230,6 +230,31 @@ function dropUnsupportedParameters(
 }
 
 /**
+ * The providers that constrain the output to a `response_format` themselves,
+ * so a request carrying one comes back as JSON without any help from the
+ * prompt: the ones whose structured outputs are documented as enforced, and
+ * Anthropic, which has no such field and instead builds the `__json_output`
+ * tool, forces it through `tool_choice` and explains it in a system
+ * instruction of its own (see ai-providers/anthropic/chat-complete.ts).
+ *
+ * Forwarding the field is not enforcing it. Ollama, OpenRouter, Together and
+ * the other pass-through hosts hand `response_format` to whatever model sits
+ * behind them, and a model that ignores it answers a `json_schema` request with
+ * prose -- glm-5.3-flash through Ollama cloud wrote markdown essays where the
+ * judge expected `{"score", "reasoning"}`. Those providers keep the schema
+ * restated in the system prompt, which is what such models actually follow.
+ */
+const STRUCTURED_OUTPUT_ENFORCED_BY: ReadonlySet<AIProvider> = new Set([
+  AIProvider.ANTHROPIC,
+  AIProvider.OPENAI,
+  AIProvider.AZURE_OPENAI,
+  AIProvider.GOOGLE,
+  AIProvider.GOOGLE_VERTEX_AI,
+  AIProvider.MISTRAL_AI,
+  AIProvider.XAI,
+]);
+
+/**
  * Makes a POST request to a provider and returns the response.
  * The POST request is constructed using the provider, apiKey, and requestBody parameters.
  * The fn parameter is the type of request being made (e.g., "complete", "chatComplete").
@@ -260,34 +285,20 @@ export async function tryPost(
       overriddenSuperAgentsRequestBody as Record<string, unknown>,
     );
 
-    // `response_format` is an OpenAI concept, and most providers carry it
-    // themselves: either as a parameter their config forwards, or -- Anthropic,
-    // which has no such field -- as the `__json_output` tool that config builds,
-    // forces through `tool_choice`, and explains in a system instruction of its
-    // own (see ai-providers/anthropic/chat-complete.ts). Where the provider is
-    // already constraining the output, restating the schema in the system prompt
-    // adds nothing and crowds out the prompt the skill was configured with.
-    const providerCarriesResponseFormat = ((): boolean => {
-      const provider = saTarget.configuration.ai_provider;
-      if (provider === AIProvider.ANTHROPIC) return true;
+    // Where the provider constrains the output itself, restating the schema in
+    // the system prompt adds nothing and only crowds out the prompt the skill
+    // was configured with. Everywhere else it is what gets the JSON answered.
+    const providerEnforcesResponseFormat = STRUCTURED_OUTPUT_ENFORCED_BY.has(
+      saTarget.configuration.ai_provider,
+    );
 
-      const providerConfig = providerConfigs[provider];
-      const functionConfig = providerConfig?.getConfig
-        ? providerConfig.getConfig(overriddenSuperAgentsRequestBody)[
-            saRequestData.functionName
-          ]
-        : providerConfig?.[saRequestData.functionName];
-
-      return Boolean(functionConfig && 'response_format' in functionConfig);
-    })();
-
-    // Helper to generate JSON schema instructions for response_format.
-    // Only for the providers that cannot express the constraint at all
-    // (Bedrock, Replicate, Workers AI, ...), which have to be asked in prose.
+    // The JSON instructions asked for in prose: the schema, for the providers
+    // that cannot express the constraint at all (Bedrock, Replicate, Workers
+    // AI, ...) and for the ones that only forward it to the model behind them.
     const getJsonSchemaInstructions = (
       responseFormat: ChatCompletionRequestBody['response_format'],
     ): string => {
-      if (!responseFormat || providerCarriesResponseFormat) return '';
+      if (!responseFormat || providerEnforcesResponseFormat) return '';
 
       // Telling a provider to call a tool it was never given is how answers end
       // up narrated or wrapped in a ```json fence, so ask for the bare object.
@@ -316,18 +327,14 @@ export async function tryPost(
       // Handle system prompt with template variables
       let systemPrompt = saTarget.configuration.system_prompt;
 
-      // Augment system prompt with JSON schema instructions if response_format is present
+      // The JSON instructions, where they are needed, follow the skill's own
+      // prompt: they describe the shape of the answer, not the job, and a
+      // prompt that opens with gateway boilerplate reads as if the schema were
+      // the point.
       const responseFormat = (
         overriddenSuperAgentsRequestBody as ChatCompletionRequestBody
       ).response_format;
-      const jsonSchemaInstructions = getJsonSchemaInstructions(responseFormat);
-
-      // For strict JSON schema, prepend the instructions to ensure they override learned behavior
-      if (responseFormat?.type === 'json_schema' && jsonSchemaInstructions) {
-        systemPrompt = `${jsonSchemaInstructions}\n\n${systemPrompt}`;
-      } else {
-        systemPrompt += jsonSchemaInstructions;
-      }
+      systemPrompt += getJsonSchemaInstructions(responseFormat);
 
       // Add system prompt if not overridden by the user
       switch (saRequestData.functionName) {


### PR DESCRIPTION
## Problem

Every judge evaluation against a model on Ollama cloud was failing with `The judge did not answer valid JSON`, and each failure took three attempts to report. Two faults, one exposed by the other.

**Forwarding `response_format` is not enforcing it.** #259 stopped restating the schema in the system prompt for any provider whose config forwards `response_format`, on the reasoning that such a provider constrains the output itself. Ollama, OpenRouter, Together and the other pass-through hosts hand the field to whatever model sits behind them, and `glm-5.3-flash:cloud` through Ollama ignores it. Measured on the local logs table: with the prose block in the prompt, 49 of 50 judge calls answered JSON; without it, 0 of 4 did, and the model wrote 3,000-character markdown essays where the judge expected `{"score", "reasoning"}`. `extract-task-and-outcome` went the same way (24 of 25 → 0 of 2).

**Retries were served from the cache.** The judge sends `cache: { mode: 'simple' }` and retries with an identical body, so attempts two and three were cache hits — the same essay again, in about a second. No retry could ever recover from a bad answer.

## Solution

- `STRUCTURED_OUTPUT_ENFORCED_BY` in `packages/api/src/handlers/handler-utils.ts` is the set of providers whose structured outputs are documented as enforced (OpenAI, Azure OpenAI, Google, Vertex, Mistral, xAI) plus Anthropic, which builds the `__json_output` tool instead. Only those skip the prose instructions. Everyone else — the providers with no way to ask for JSON and the ones that only forward the field — gets the schema restated.
- Where the block is added, it now follows the skill's own prompt instead of being prepended, which keeps what #173 asked for: the configured prompt comes first.
- Judge retries send `force_refresh: true` in their `sa-config`, so a retry bypasses the cache and its fresh answer replaces the cached one.

## Test notes

- `handler-utils.test.ts`: the "forwards `response_format`" case becomes "enforces it" (OpenAI, no injection); a new Ollama case asserts the block is added after the skill prompt with the schema in it; the no-support case now runs as Bedrock.
- `llm-judge.test.ts`: a markdown first answer followed by a JSON one succeeds, and the two `sa-config` headers differ only by `force_refresh` on the retry.
- `pnpm typecheck` — clean
- `pnpm check` — clean apart from the pre-existing unused `StructuredOutputResponse` alias in `task-and-outcome.ts`
- `pnpm test` — 182 files passed
- `pnpm test:e2e` — 61 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNyvYYzLSRu67DXCoYSVoS
