### PR TITLE
feat: configurable skill arbiter model and timeout, per system and per agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,11 @@ an agent without skills, no arbiter asked -- becomes a new skill through
 (`agent_models`), and seeded with the caller's system prompt
 (`skills.seed_system_prompt`), which `handleGenerateArms` uses verbatim so the
 skill starts as a pass-through. `max_auto_created_skills` caps this per agent.
+The arbiter's model and per-attempt timeout are system settings
+(`skill_arbiter_model_id`, the reflection model when unset, and
+`skill_arbiter_timeout_ms`), which an agent overrides with columns of the same
+names; the arbiter is asked under the skill-creation lease, so the lease
+stretches by twice the timeout to cover it.
 Creating happens under the agent's `skill_creation_leases` row
 (`withSkillCreationLease`), after a second look at the skills, so concurrent
 first requests produce one skill rather than one each. Intent embeddings are

--- a/packages/api/src/connectors/evaluations/__mocks__/mock-storage-connector.ts
+++ b/packages/api/src/connectors/evaluations/__mocks__/mock-storage-connector.ts
@@ -14,6 +14,8 @@ export function createMockStorageConnector(): UserDataStorageConnector {
       reflection_model_id: 'model-123',
       evaluation_generation_model_id: 'model-123',
       embedding_model_id: 'embed-123',
+      skill_arbiter_model_id: null,
+      skill_arbiter_timeout_ms: 15_000,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     }),

--- a/packages/api/src/connectors/libsql/connector.test.ts
+++ b/packages/api/src/connectors/libsql/connector.test.ts
@@ -546,14 +546,24 @@ describe('agent models and routing settings', () => {
     expect(agent.auto_create_skills).toBe(false);
     expect(agent.skill_match_threshold).toBe(0.65);
     expect(agent.max_auto_created_skills).toBe(3);
+    // Unset overrides come back as null, never undefined.
+    expect(agent.skill_arbiter_model_id).toBeNull();
+    expect(agent.skill_arbiter_timeout_ms).toBeNull();
 
     const updated = await store.updateAgent(c, agent.id, {
       auto_create_skills: true,
       max_auto_created_skills: 5,
+      skill_arbiter_timeout_ms: 30_000,
     });
     expect(updated.auto_create_skills).toBe(true);
     expect(updated.max_auto_created_skills).toBe(5);
+    expect(updated.skill_arbiter_timeout_ms).toBe(30_000);
     expect(updated.description).toBe(agent.description);
+
+    const cleared = await store.updateAgent(c, agent.id, {
+      skill_arbiter_timeout_ms: null,
+    });
+    expect(cleared.skill_arbiter_timeout_ms).toBeNull();
   });
 
   it('keeps the seed prompt and the auto-created flag on a skill', async () => {

--- a/packages/api/src/connectors/libsql/libsql.test.ts
+++ b/packages/api/src/connectors/libsql/libsql.test.ts
@@ -306,6 +306,34 @@ describe('libsql schema semantics', () => {
         args: ['model-embed'],
       }),
     ).rejects.toThrow(/judge_model_id must reference a text model/);
+    await expect(
+      client.execute({
+        sql: 'UPDATE system_settings SET skill_arbiter_model_id = ?',
+        args: ['model-embed'],
+      }),
+    ).rejects.toThrow(/skill_arbiter_model_id must reference a text model/);
+
+    // An agent's own arbiter override is held to the same rule.
+    await seedAgentAndSkill(client);
+    await expect(
+      client.execute({
+        sql: 'UPDATE agents SET skill_arbiter_model_id = ?',
+        args: ['model-embed'],
+      }),
+    ).rejects.toThrow(/skill_arbiter_model_id must reference a text model/);
+  });
+
+  it('gives the skill arbiter fifteen seconds by default, and keeps it positive', async () => {
+    const { client } = await freshDatabase();
+
+    const seeded = await client.execute(
+      'SELECT skill_arbiter_timeout_ms FROM system_settings',
+    );
+    expect(Number(seeded.rows[0].skill_arbiter_timeout_ms)).toBe(15_000);
+
+    await expect(
+      client.execute('UPDATE system_settings SET skill_arbiter_timeout_ms = 0'),
+    ).rejects.toThrow();
   });
 
   it('requires embedding_dimensions exactly for embed models', async () => {

--- a/packages/api/src/connectors/libsql/schema.ts
+++ b/packages/api/src/connectors/libsql/schema.ts
@@ -60,10 +60,29 @@ const initialSchema: LibsqlMigration = {
       auto_create_skills INTEGER NOT NULL DEFAULT 1 CHECK (auto_create_skills IN (0, 1)),
       skill_match_threshold REAL NOT NULL DEFAULT 0.8,
       max_auto_created_skills INTEGER NOT NULL DEFAULT 10,
+      skill_arbiter_model_id TEXT REFERENCES models(id) ON DELETE SET NULL,
+      skill_arbiter_timeout_ms INTEGER CHECK (skill_arbiter_timeout_ms IS NULL OR skill_arbiter_timeout_ms > 0),
       created_at TEXT NOT NULL DEFAULT (${NOW_ISO}),
       updated_at TEXT NOT NULL DEFAULT (${NOW_ISO})
     )`,
     updatedAtTrigger('agents'),
+    // Postgres enforces this through `validate_agent_model_types`.
+    `CREATE TRIGGER IF NOT EXISTS agents_validate_model_types_insert
+    BEFORE INSERT ON agents
+    FOR EACH ROW
+    WHEN NEW.skill_arbiter_model_id IS NOT NULL
+    BEGIN
+      SELECT CASE WHEN (SELECT model_type FROM models WHERE id = NEW.skill_arbiter_model_id) IS NOT 'text'
+        THEN RAISE(ABORT, 'skill_arbiter_model_id must reference a text model') END;
+    END`,
+    `CREATE TRIGGER IF NOT EXISTS agents_validate_model_types_update
+    BEFORE UPDATE ON agents
+    FOR EACH ROW
+    WHEN NEW.skill_arbiter_model_id IS NOT NULL
+    BEGIN
+      SELECT CASE WHEN (SELECT model_type FROM models WHERE id = NEW.skill_arbiter_model_id) IS NOT 'text'
+        THEN RAISE(ABORT, 'skill_arbiter_model_id must reference a text model') END;
+    END`,
 
     // --------------------------------------------------------- ai_providers
     `CREATE TABLE IF NOT EXISTS ai_providers (
@@ -442,6 +461,8 @@ const initialSchema: LibsqlMigration = {
       evaluation_generation_model_id TEXT REFERENCES models(id) ON DELETE RESTRICT,
       embedding_model_id TEXT REFERENCES models(id) ON DELETE RESTRICT,
       judge_model_id TEXT REFERENCES models(id) ON DELETE RESTRICT,
+      skill_arbiter_model_id TEXT REFERENCES models(id) ON DELETE RESTRICT,
+      skill_arbiter_timeout_ms INTEGER NOT NULL DEFAULT 15000 CHECK (skill_arbiter_timeout_ms > 0),
       developer_mode INTEGER NOT NULL DEFAULT 0 CHECK (developer_mode IN (0, 1)),
       created_at TEXT NOT NULL DEFAULT (${NOW_ISO}),
       updated_at TEXT NOT NULL DEFAULT (${NOW_ISO})
@@ -466,6 +487,9 @@ const initialSchema: LibsqlMigration = {
       SELECT CASE WHEN NEW.judge_model_id IS NOT NULL
         AND (SELECT model_type FROM models WHERE id = NEW.judge_model_id) IS NOT 'text'
         THEN RAISE(ABORT, 'judge_model_id must reference a text model') END;
+      SELECT CASE WHEN NEW.skill_arbiter_model_id IS NOT NULL
+        AND (SELECT model_type FROM models WHERE id = NEW.skill_arbiter_model_id) IS NOT 'text'
+        THEN RAISE(ABORT, 'skill_arbiter_model_id must reference a text model') END;
       SELECT CASE WHEN NEW.embedding_model_id IS NOT NULL
         AND (SELECT model_type FROM models WHERE id = NEW.embedding_model_id) IS NOT 'embed'
         THEN RAISE(ABORT, 'embedding_model_id must reference an embed model') END;
@@ -483,6 +507,9 @@ const initialSchema: LibsqlMigration = {
       SELECT CASE WHEN NEW.judge_model_id IS NOT NULL
         AND (SELECT model_type FROM models WHERE id = NEW.judge_model_id) IS NOT 'text'
         THEN RAISE(ABORT, 'judge_model_id must reference a text model') END;
+      SELECT CASE WHEN NEW.skill_arbiter_model_id IS NOT NULL
+        AND (SELECT model_type FROM models WHERE id = NEW.skill_arbiter_model_id) IS NOT 'text'
+        THEN RAISE(ABORT, 'skill_arbiter_model_id must reference a text model') END;
       SELECT CASE WHEN NEW.embedding_model_id IS NOT NULL
         AND (SELECT model_type FROM models WHERE id = NEW.embedding_model_id) IS NOT 'embed'
         THEN RAISE(ABORT, 'embedding_model_id must reference an embed model') END;
@@ -513,7 +540,10 @@ const initialSchema: LibsqlMigration = {
         WHERE system_prompt_reflection_model_id = NEW.id
            OR evaluation_generation_model_id = NEW.id
            OR judge_model_id = NEW.id
+           OR skill_arbiter_model_id = NEW.id
            OR embedding_model_id = NEW.id
+      ) OR EXISTS (
+        SELECT 1 FROM agents WHERE skill_arbiter_model_id = NEW.id
       ) OR EXISTS (
         SELECT 1 FROM skill_optimization_evaluations WHERE model_id = NEW.id
       ) OR EXISTS (

--- a/packages/api/src/middlewares/agent-and-skill.test.ts
+++ b/packages/api/src/middlewares/agent-and-skill.test.ts
@@ -103,6 +103,8 @@ describe('agentAndSkillMiddleware', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       };
 
       const mockSkill: Skill = {
@@ -195,6 +197,8 @@ describe('agentAndSkillMiddleware', () => {
           auto_create_skills: true,
           skill_match_threshold: 0.8,
           max_auto_created_skills: 10,
+          skill_arbiter_model_id: null,
+          skill_arbiter_timeout_ms: null,
         };
 
         const mockSkill: Skill = {
@@ -319,6 +323,8 @@ describe('agentAndSkillMiddleware', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       };
 
       const customMockContext = {

--- a/packages/api/src/utils/evaluation-model-resolver.test.ts
+++ b/packages/api/src/utils/evaluation-model-resolver.test.ts
@@ -59,6 +59,8 @@ describe('Evaluation Model Resolver', () => {
     embedding_model_id: 'embed-1111-2222-3333-444455556666',
     system_prompt_reflection_model_id: 'model-1111-2222-3333-444455556666',
     evaluation_generation_model_id: 'model-1111-2222-3333-444455556666',
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: 15_000,
     developer_mode: false,
     created_at: '2023-01-01T00:00:00Z',
     updated_at: '2023-01-01T00:00:00Z',
@@ -267,6 +269,69 @@ describe('Evaluation Model Resolver', () => {
         apiKey: undefined,
         customHost: 'http://localhost:11434',
       });
+    });
+
+    it('resolves the skill arbiter to its own model when one is chosen', async () => {
+      const arbiterModelId = 'arbiter-111-2222-3333-444455556666';
+      vi.mocked(mockConnector.getSystemSettings).mockResolvedValue({
+        ...mockSystemSettings,
+        skill_arbiter_model_id: arbiterModelId,
+      });
+      vi.mocked(mockConnector.getModels).mockResolvedValue([
+        { ...mockModel, id: arbiterModelId, model_name: 'gpt-5-mini' },
+      ]);
+      vi.mocked(mockConnector.getAIProviderAPIKeys).mockResolvedValue([
+        mockProvider,
+      ]);
+
+      const result = await resolveSystemSettingsModel(
+        mockContext,
+        'skill_arbiter',
+        mockConnector,
+      );
+
+      expect(mockConnector.getModels).toHaveBeenCalledWith(mockContext, {
+        id: arbiterModelId,
+      });
+      expect(result?.model).toBe('gpt-5-mini');
+    });
+
+    it('falls back to the reflection model for the skill arbiter when none is chosen', async () => {
+      vi.mocked(mockConnector.getSystemSettings).mockResolvedValue(
+        mockSystemSettings,
+      );
+      vi.mocked(mockConnector.getModels).mockResolvedValue([mockModel]);
+      vi.mocked(mockConnector.getAIProviderAPIKeys).mockResolvedValue([
+        mockProvider,
+      ]);
+
+      const result = await resolveSystemSettingsModel(
+        mockContext,
+        'skill_arbiter',
+        mockConnector,
+      );
+
+      expect(mockConnector.getModels).toHaveBeenCalledWith(mockContext, {
+        id: mockSystemSettings.system_prompt_reflection_model_id,
+      });
+      expect(result?.model).toBe('gpt-4');
+    });
+
+    it('reads the settings it is handed instead of storage', async () => {
+      vi.mocked(mockConnector.getModels).mockResolvedValue([mockModel]);
+      vi.mocked(mockConnector.getAIProviderAPIKeys).mockResolvedValue([
+        mockProvider,
+      ]);
+
+      const result = await resolveSystemSettingsModel(
+        mockContext,
+        'judge',
+        mockConnector,
+        mockSystemSettings,
+      );
+
+      expect(mockConnector.getSystemSettings).not.toHaveBeenCalled();
+      expect(result?.model).toBe('gpt-4');
     });
   });
 

--- a/packages/api/src/utils/evaluation-model-resolver.ts
+++ b/packages/api/src/utils/evaluation-model-resolver.ts
@@ -4,7 +4,11 @@ import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { warn } from '@shared/console-logging';
 import type { AIProvider } from '@shared/types/constants';
-import type { Model, SkillOptimizationEvaluation } from '@shared/types/data';
+import type {
+  Model,
+  SkillOptimizationEvaluation,
+  SystemSettings,
+} from '@shared/types/data';
 
 /**
  * Model configuration resolved from system settings or evaluation.
@@ -36,7 +40,8 @@ export type SystemSettingsModelType =
   | 'judge'
   | 'embedding'
   | 'system_prompt_reflection'
-  | 'evaluation_generation';
+  | 'evaluation_generation'
+  | 'skill_arbiter';
 
 /**
  * Resolves a model configuration from a model ID.
@@ -46,7 +51,7 @@ export type SystemSettingsModelType =
  * @param logPrefix - Prefix for log messages
  * @returns The model configuration or null if not found
  */
-async function resolveModelById(
+export async function resolveModelById(
   c: AppContext,
   modelId: string,
   connector: UserDataStorageConnector,
@@ -96,17 +101,20 @@ async function resolveModelById(
  *
  * @param modelType - The type of model to resolve from system settings
  * @param connector - The storage connector to look up models and settings
+ * @param settings - The system settings, when the caller already read them
  * @returns The model configuration or null if not configured
  */
 export async function resolveSystemSettingsModel(
   c: AppContext,
   modelType: SystemSettingsModelType,
   connector: UserDataStorageConnector,
+  settings?: SystemSettings,
 ): Promise<ResolvedModelConfig | null> {
   const logPrefix = `MODEL_RESOLVER_${modelType.toUpperCase()}`;
-  const systemSettings = await connector.getSystemSettings(c);
+  const systemSettings = settings ?? (await connector.getSystemSettings(c));
 
   let modelId: string | null = null;
+  let configured = `${modelType}_model_id`;
 
   switch (modelType) {
     case 'judge':
@@ -121,12 +129,19 @@ export async function resolveSystemSettingsModel(
     case 'evaluation_generation':
       modelId = systemSettings.evaluation_generation_model_id;
       break;
+    case 'skill_arbiter':
+      // The arbiter has a model of its own only when one is chosen for it;
+      // otherwise it borrows the reflection model, as it always did.
+      modelId =
+        systemSettings.skill_arbiter_model_id ??
+        systemSettings.system_prompt_reflection_model_id;
+      configured =
+        'skill_arbiter_model_id or system_prompt_reflection_model_id';
+      break;
   }
 
   if (!modelId) {
-    warn(
-      `[${logPrefix}] No ${modelType}_model_id configured in system settings`,
-    );
+    warn(`[${logPrefix}] No ${configured} configured in system settings`);
     return null;
   }
 

--- a/packages/api/src/utils/super-agents/agents.test.ts
+++ b/packages/api/src/utils/super-agents/agents.test.ts
@@ -144,6 +144,8 @@ describe('getAgent', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       };
 
       vi.mocked(mockConnector.getAgents).mockResolvedValue([existingAgent]);
@@ -173,6 +175,8 @@ describe('getAgent', () => {
           auto_create_skills: true,
           skill_match_threshold: 0.8,
           max_auto_created_skills: 10,
+          skill_arbiter_model_id: null,
+          skill_arbiter_timeout_ms: null,
         },
         {
           id: '223e4567-e89b-12d3-a456-426614174000',
@@ -184,6 +188,8 @@ describe('getAgent', () => {
           auto_create_skills: true,
           skill_match_threshold: 0.8,
           max_auto_created_skills: 10,
+          skill_arbiter_model_id: null,
+          skill_arbiter_timeout_ms: null,
         },
       ];
 
@@ -212,6 +218,8 @@ describe('getAgent', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       };
 
       vi.mocked(mockConnector.getAgents).mockResolvedValue([]);
@@ -265,6 +273,8 @@ describe('getAgent', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       };
 
       vi.mocked(mockConnector.getAgents).mockResolvedValue([agent]);
@@ -309,6 +319,8 @@ describe('getAgent', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       };
 
       vi.mocked(mockConnector.getAgents).mockResolvedValue([agent]);
@@ -335,6 +347,8 @@ describe('getAgent', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       };
 
       vi.mocked(mockConnector.getAgents).mockResolvedValue([existingAgent]);

--- a/packages/api/src/utils/super-agents/skill-arbiter.test.ts
+++ b/packages/api/src/utils/super-agents/skill-arbiter.test.ts
@@ -1,10 +1,14 @@
 import { createMockContext } from '@api/test-utils/mock-context';
 import type { UserDataStorageConnector } from '@api/types/connector';
-import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
+import {
+  resolveModelById,
+  resolveSystemSettingsModel,
+} from '@api/utils/evaluation-model-resolver';
 import { arbitrateSkillForRequest } from '@api/utils/super-agents/skill-arbiter';
 import { AIProvider } from '@shared/types/constants';
-import type { Agent, Skill } from '@shared/types/data';
+import type { Agent, Skill, SystemSettings } from '@shared/types/data';
 import type { RequestIntent } from '@shared/utils/request-intent';
+import OpenAI from 'openai';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
@@ -29,6 +33,7 @@ vi.mock('@api/constants', async (importOriginal) => ({
 }));
 
 vi.mock('@api/utils/evaluation-model-resolver', () => ({
+  resolveModelById: vi.fn(),
   resolveSystemSettingsModel: vi.fn(),
 }));
 
@@ -55,6 +60,11 @@ const intent: RequestIntent = {
   tools: 'Tools: read, write',
   conversation: 'User: create a new draft post about the renaming',
 };
+const settings = {
+  skill_arbiter_model_id: null,
+  skill_arbiter_timeout_ms: 42_000,
+  system_prompt_reflection_model_id: 'reflection-model',
+} as SystemSettings;
 
 const answer = (skillName: string | null) => ({
   choices: [{ message: { parsed: { skill_name: skillName } } }],
@@ -77,7 +87,60 @@ describe('arbitrateSkillForRequest', () => {
       agent,
       skills,
       intent,
+      settings,
     );
+
+  it('takes its model and timeout from the settings it is handed', async () => {
+    mockParse.mockResolvedValue(answer(null));
+
+    await arbitrate();
+
+    expect(resolveSystemSettingsModel).toHaveBeenCalledWith(
+      expect.anything(),
+      'skill_arbiter',
+      connector,
+      settings,
+    );
+    // One attempt within the configured time, and one retry.
+    expect(vi.mocked(OpenAI).mock.calls[0][0]).toMatchObject({
+      timeout: 42_000,
+      maxRetries: 1,
+    });
+  });
+
+  it("prefers the agent's own arbiter model and timeout", async () => {
+    vi.mocked(resolveModelById).mockResolvedValue({
+      model: 'agent-model',
+      provider: AIProvider.OPENAI,
+      apiKey: 'key',
+    });
+    mockParse.mockResolvedValue(answer(null));
+
+    await arbitrateSkillForRequest(
+      createMockContext(),
+      connector,
+      {
+        ...agent,
+        skill_arbiter_model_id: 'agent-arbiter-model',
+        skill_arbiter_timeout_ms: 7_000,
+      },
+      skills,
+      intent,
+      settings,
+    );
+
+    expect(resolveModelById).toHaveBeenCalledWith(
+      expect.anything(),
+      'agent-arbiter-model',
+      connector,
+      expect.any(String),
+    );
+    expect(resolveSystemSettingsModel).not.toHaveBeenCalled();
+    expect(vi.mocked(OpenAI).mock.calls[0][0]).toMatchObject({
+      timeout: 7_000,
+    });
+    expect(mockParse.mock.calls[0][0]).toMatchObject({ model: 'agent-model' });
+  });
 
   it('maps a named skill to an existing verdict', async () => {
     mockParse.mockResolvedValue(answer('generate-thread-titles'));

--- a/packages/api/src/utils/super-agents/skill-arbiter.ts
+++ b/packages/api/src/utils/super-agents/skill-arbiter.ts
@@ -1,9 +1,12 @@
 import { getApiUrl, SA_SKILL_REQUEST_PARAMS } from '@api/constants';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
-import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
+import {
+  resolveModelById,
+  resolveSystemSettingsModel,
+} from '@api/utils/evaluation-model-resolver';
 import { warn } from '@shared/console-logging';
-import type { Agent, Skill } from '@shared/types/data';
+import type { Agent, Skill, SystemSettings } from '@shared/types/data';
 import type { RequestIntent } from '@shared/utils/request-intent';
 import OpenAI from 'openai';
 import { z } from 'zod';
@@ -27,9 +30,16 @@ const ArbiterAnswer = z.object({
   skill_name: z.union([z.null(), z.string()]),
 });
 
-/** One attempt; the client retries once. Bounded so that arbitration plus
- * skill creation still finish inside the creation lease. */
-const ARBITER_TIMEOUT_MS = 15_000;
+/**
+ * How long one arbiter attempt may take for this agent: its own setting when
+ * it has one, otherwise the system's.
+ */
+export function skillArbiterTimeoutMs(
+  agent: Agent,
+  settings: SystemSettings,
+): number {
+  return agent.skill_arbiter_timeout_ms ?? settings.skill_arbiter_timeout_ms;
+}
 
 const PROMPT_EXCERPT = 1500;
 const CONVERSATION_EXCERPT = 1500;
@@ -83,6 +93,12 @@ function arbiterUserMessage(
  * through the internal `route-or-create` skill like the other generation
  * steps. Anything going wrong answers `unavailable`, and the caller routes to
  * the closest skill rather than creating one -- the conservative side.
+ *
+ * The agent chooses its model and how long one attempt may take (the client
+ * retries once), falling back to the system settings -- and, for the model,
+ * to the reflection model when neither names one. The caller passes the
+ * settings because it needs the timeout too: the arbiter is asked under the
+ * skill-creation lease, which has to outlast it.
  */
 export async function arbitrateSkillForRequest(
   c: AppContext,
@@ -90,16 +106,25 @@ export async function arbitrateSkillForRequest(
   agent: Agent,
   skills: Skill[],
   intent: RequestIntent,
+  settings: SystemSettings,
 ): Promise<SkillArbiterVerdict> {
   try {
-    const modelConfig = await resolveSystemSettingsModel(
-      c,
-      'system_prompt_reflection',
-      connector,
-    );
+    const modelConfig = agent.skill_arbiter_model_id
+      ? await resolveModelById(
+          c,
+          agent.skill_arbiter_model_id,
+          connector,
+          'MODEL_RESOLVER_SKILL_ARBITER',
+        )
+      : await resolveSystemSettingsModel(
+          c,
+          'skill_arbiter',
+          connector,
+          settings,
+        );
     if (!modelConfig) {
       warn(
-        '[SKILL_ROUTING] No system prompt reflection model configured; routing to the closest skill without arbitration',
+        '[SKILL_ROUTING] No skill arbiter model configured, for the agent or the system; routing to the closest skill without arbitration',
       );
       return { kind: 'unavailable' };
     }
@@ -107,7 +132,7 @@ export async function arbitrateSkillForRequest(
     const client = new OpenAI({
       apiKey: '',
       baseURL: `${getApiUrl(c)}/v1`,
-      timeout: ARBITER_TIMEOUT_MS,
+      timeout: skillArbiterTimeoutMs(agent, settings),
       maxRetries: 1,
     });
     const saConfig = {

--- a/packages/api/src/utils/super-agents/skill-creation-lease.ts
+++ b/packages/api/src/utils/super-agents/skill-creation-lease.ts
@@ -7,7 +7,9 @@ import type { Agent } from '@shared/types/data';
  * How long a lease lasts, and how long a request waits for one. Longer than
  * creating a skill takes, the `describe-skill` call included (that client is
  * given a timeout for this reason), so a lease outlives its work; short
- * enough that a holder that died does not hold everyone up for long.
+ * enough that a holder that died does not hold everyone up for long. Work
+ * that does more under the lease -- routing asks the arbiter there, with a
+ * timeout of the user's choosing -- passes a longer duration.
  */
 export const SKILL_CREATION_LEASE_MS = 45_000;
 const POLL_INTERVAL_MS = 250;
@@ -25,13 +27,12 @@ async function claimLease(
   connector: UserDataStorageConnector,
   agent: Agent,
   holder: string,
+  leaseMs: number,
 ): Promise<boolean> {
-  const deadline = Date.now() + SKILL_CREATION_LEASE_MS;
+  const deadline = Date.now() + leaseMs;
   for (;;) {
     const now = new Date();
-    const until = new Date(
-      now.getTime() + SKILL_CREATION_LEASE_MS,
-    ).toISOString();
+    const until = new Date(now.getTime() + leaseMs).toISOString();
     if (
       await connector.claimSkillCreationLease(
         c,
@@ -61,19 +62,23 @@ async function claimLease(
  * Waiting has a limit, after which the request goes ahead without the lease:
  * a duplicate skill is a smaller failure than a request that never returns,
  * and same-name races are handled where the skill is created.
+ *
+ * `leaseMs` is how long the lease lasts and how long a request waits for one;
+ * it has to outlast everything `work` does.
  */
 export async function withSkillCreationLease<T>(
   c: AppContext,
   connector: UserDataStorageConnector,
   agent: Agent,
   work: () => Promise<T>,
+  leaseMs: number = SKILL_CREATION_LEASE_MS,
 ): Promise<T> {
   // Coined per claim, so this request recognises its own lease and releases
   // only that -- not one a later claimant took after this one expired.
   const holder = crypto.randomUUID();
-  if (!(await claimLease(c, connector, agent, holder))) {
+  if (!(await claimLease(c, connector, agent, holder, leaseMs))) {
     warn(
-      `[SKILL_CREATION] Waited ${SKILL_CREATION_LEASE_MS}ms for the skill-creation lease of agent ${agent.name}; going ahead without it`,
+      `[SKILL_CREATION] Waited ${leaseMs}ms for the skill-creation lease of agent ${agent.name}; going ahead without it`,
     );
     return work();
   }

--- a/packages/api/src/utils/super-agents/skill-routing.test.ts
+++ b/packages/api/src/utils/super-agents/skill-routing.test.ts
@@ -28,7 +28,10 @@ vi.mock('@api/utils/evaluation-model-resolver', () => ({
 vi.mock('@api/utils/super-agents/skill-creation', () => ({
   createSkillForRequest: vi.fn(),
 }));
-vi.mock('@api/utils/super-agents/skill-arbiter', () => ({
+vi.mock('@api/utils/super-agents/skill-arbiter', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@api/utils/super-agents/skill-arbiter')
+  >()),
   arbitrateSkillForRequest: vi.fn(),
 }));
 
@@ -126,9 +129,11 @@ const routingConnector = (): RoutingConnector => {
       stored.set(params.skill_id, row);
       return Promise.resolve(row);
     }),
-    getSystemSettings: vi
-      .fn()
-      .mockResolvedValue({ embedding_model_id: MODEL_ID }),
+    getSystemSettings: vi.fn().mockResolvedValue({
+      embedding_model_id: MODEL_ID,
+      skill_arbiter_model_id: null,
+      skill_arbiter_timeout_ms: 15_000,
+    }),
     claimSkillCreationLease: vi.fn().mockResolvedValue(true),
     releaseSkillCreationLease: vi.fn(),
   };
@@ -422,6 +427,19 @@ describe('routeRequestToSkill', () => {
       );
     });
 
+    it('holds the lease long enough for the arbiter to answer', async () => {
+      connector.getSkills.mockResolvedValue([skill('s1', 'translate')]);
+      // The agent's own arbiter timeout wins over the system's 15 seconds.
+      const patient = { ...growing, skill_arbiter_timeout_ms: 30_000 } as Agent;
+
+      await route(patient, chat('Draw a picture of a cat.'));
+
+      // Creation's own budget, plus one arbiter attempt and its retry.
+      const [, , , now, until] = connector.claimSkillCreationLease.mock
+        .calls[0] as string[];
+      expect(Date.parse(until) - Date.parse(now)).toBe(45_000 + 2 * 30_000);
+    });
+
     it('takes the skill another request created while it waited for the lease', async () => {
       const translate = skill('s1', 'translate');
       connector.getSkills
@@ -527,6 +545,8 @@ describe('routeRequestToSkill', () => {
         growing,
         [translate, sql],
         expect.objectContaining({ systemPrompt: 'Draw a picture of a cat.' }),
+        // The system settings, read once and handed on.
+        expect.objectContaining({ skill_arbiter_timeout_ms: 15_000 }),
       );
       expect(createSkillForRequest).toHaveBeenCalledWith(
         c,

--- a/packages/api/src/utils/super-agents/skill-routing.ts
+++ b/packages/api/src/utils/super-agents/skill-routing.ts
@@ -8,9 +8,15 @@ import {
   embedRequestIntent,
   type RequestIntentEmbedding,
 } from '@api/utils/super-agents/intent-embeddings';
-import { arbitrateSkillForRequest } from '@api/utils/super-agents/skill-arbiter';
+import {
+  arbitrateSkillForRequest,
+  skillArbiterTimeoutMs,
+} from '@api/utils/super-agents/skill-arbiter';
 import { createSkillForRequest } from '@api/utils/super-agents/skill-creation';
-import { withSkillCreationLease } from '@api/utils/super-agents/skill-creation-lease';
+import {
+  SKILL_CREATION_LEASE_MS,
+  withSkillCreationLease,
+} from '@api/utils/super-agents/skill-creation-lease';
 import { warn } from '@shared/console-logging';
 import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
 import type {
@@ -505,7 +511,13 @@ export async function routeRequestToSkill(
     return first.result;
   }
 
-  return withSkillCreationLease(c, connector, agent, async () => {
+  // The arbiter is asked under the lease, so the lease has to outlast its
+  // budget -- one attempt and the client's one retry -- on top of creation.
+  const settings = await connector.getSystemSettings(c);
+  const leaseMs =
+    SKILL_CREATION_LEASE_MS + 2 * skillArbiterTimeoutMs(agent, settings);
+
+  const underLease = async (): Promise<SkillRoutingResult> => {
     const again = await routeOnce(c, connector, agent, requestIntent);
     if (again.kind === 'routed') {
       return again.result;
@@ -529,6 +541,7 @@ export async function routeRequestToSkill(
         agent,
         again.skills,
         requestIntent,
+        settings,
       );
       if (verdict.kind === 'existing') {
         // Teach the router, so the next such request needs no arbiter.
@@ -570,7 +583,9 @@ export async function routeRequestToSkill(
       ),
       decision: decision('created'),
     };
-  });
+  };
+
+  return withSkillCreationLease(c, connector, agent, underLease, leaseMs);
 }
 
 /** When each skill last learned from a request that named it. */

--- a/packages/api/src/v1/super-agents/models.test.ts
+++ b/packages/api/src/v1/super-agents/models.test.ts
@@ -301,6 +301,8 @@ describe('Models API Status Codes', () => {
       evaluation_generation_model_id: null,
       embedding_model_id: null,
       judge_model_id: null,
+      skill_arbiter_model_id: null,
+      skill_arbiter_timeout_ms: 15_000,
       developer_mode: false,
       created_at: '2023-01-01T00:00:00.000Z',
       updated_at: '2023-01-01T00:00:00.000Z',
@@ -319,13 +321,16 @@ describe('Models API Status Codes', () => {
         ...systemSettings,
         system_prompt_reflection_model_id: modelId,
         judge_model_id: modelId,
+        skill_arbiter_model_id: modelId,
       });
 
       const res = await client[':id'].$delete({ param: { id: modelId } });
 
       expect(res.status).toBe(409);
       const data = (await res.json()) as { error: string };
-      expect(data.error).toContain('System Prompt Reflection and Judge model');
+      expect(data.error).toContain(
+        'System Prompt Reflection, Judge and Skill Arbiter model',
+      );
     });
 
     it('should leave the skills alone when the delete is refused', async () => {

--- a/packages/api/src/v1/super-agents/models.ts
+++ b/packages/api/src/v1/super-agents/models.ts
@@ -25,6 +25,7 @@ const SYSTEM_SETTINGS_MODEL_SLOTS = [
   ['evaluation_generation_model_id', 'Evaluation Generation'],
   ['embedding_model_id', 'Embedding'],
   ['judge_model_id', 'Judge'],
+  ['skill_arbiter_model_id', 'Skill Arbiter'],
 ] as const;
 
 /** "A", "A and B", "A, B and C". */

--- a/packages/api/src/v1/super-agents/skills.test.ts
+++ b/packages/api/src/v1/super-agents/skills.test.ts
@@ -150,6 +150,8 @@ describe('Skills API Status Codes', () => {
       judge_model_id: null,
       system_prompt_reflection_model_id: null,
       evaluation_generation_model_id: null,
+      skill_arbiter_model_id: null,
+      skill_arbiter_timeout_ms: 15_000,
     });
   });
 

--- a/packages/api/src/v1/super-agents/system-settings.test.ts
+++ b/packages/api/src/v1/super-agents/system-settings.test.ts
@@ -30,6 +30,8 @@ describe('System Settings API', () => {
     evaluation_generation_model_id: 'model-2222-3333-4444-555566667777',
     embedding_model_id: 'model-3333-4444-5555-666677778888',
     judge_model_id: 'model-4444-5555-6666-777788889999',
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: 15_000,
     developer_mode: false,
     created_at: '2023-01-01T00:00:00Z',
     updated_at: '2023-01-01T00:00:00Z',
@@ -154,6 +156,38 @@ describe('System Settings API', () => {
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data).toEqual(updatedSettings);
+    });
+
+    it('should accept a skill arbiter timeout within bounds', async () => {
+      mockUserDataStorageConnector.updateSystemSettings.mockResolvedValue({
+        ...mockSettings,
+        skill_arbiter_timeout_ms: 120_000,
+      });
+
+      const res = await client.index.$patch({
+        json: { skill_arbiter_timeout_ms: 120_000 },
+      });
+
+      expect(res.status).toBe(200);
+      expect(
+        mockUserDataStorageConnector.updateSystemSettings,
+      ).toHaveBeenCalledWith(expect.anything(), {
+        skill_arbiter_timeout_ms: 120_000,
+      });
+    });
+
+    it('should return 400 for a skill arbiter timeout out of bounds', async () => {
+      // Below a second, above ten minutes, and not a whole millisecond.
+      for (const skill_arbiter_timeout_ms of [0, 500, 600_001, 15_000.5]) {
+        const res = await client.index.$patch({
+          json: { skill_arbiter_timeout_ms },
+        });
+
+        expect(res.status).toBe(400);
+      }
+      expect(
+        mockUserDataStorageConnector.updateSystemSettings,
+      ).not.toHaveBeenCalled();
     });
 
     it('should return 400 for invalid UUID format', async () => {

--- a/packages/shared/src/types/data/agent.test.ts
+++ b/packages/shared/src/types/data/agent.test.ts
@@ -512,6 +512,8 @@ describe('Agent Data Transforms and Validation', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       };
 
       const result = Agent.parse(validAgent);
@@ -527,6 +529,8 @@ describe('Agent Data Transforms and Validation', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
         created_at: '2023-01-01T00:00:00.000+00:00',
         updated_at: '2023-01-02T12:30:45.123-05:00',
       };
@@ -582,6 +586,8 @@ describe('Agent Data Transforms and Validation', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
         created_at: '2023-01-01T00:00:00.000Z',
         updated_at: '2023-01-01T00:00:00.000Z',
       };
@@ -611,6 +617,8 @@ describe('Agent Data Transforms and Validation', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
         created_at: '2023-01-01T00:00:00.000Z',
         updated_at: '2023-01-01T00:00:00.000Z',
       };
@@ -630,6 +638,18 @@ describe('automatic skill settings', () => {
       skill_match_threshold: 0.8,
       max_auto_created_skills: 10,
     });
+  });
+
+  it('leave the arbiter to the system settings unless overridden', () => {
+    const created = AgentCreateParams.parse(minimal);
+    expect(created.skill_arbiter_model_id).toBeUndefined();
+    expect(created.skill_arbiter_timeout_ms).toBeUndefined();
+    expect(() =>
+      AgentCreateParams.parse({ ...minimal, skill_arbiter_timeout_ms: 500 }),
+    ).toThrow();
+    expect(AgentUpdateParams.parse({ skill_arbiter_timeout_ms: null })).toEqual(
+      { skill_arbiter_timeout_ms: null },
+    );
   });
 
   it('keep the threshold between 0 and 1 and the cap a whole, non-negative number', () => {

--- a/packages/shared/src/types/data/agent.ts
+++ b/packages/shared/src/types/data/agent.ts
@@ -1,4 +1,15 @@
 import { z } from 'zod';
+import {
+  MAX_SKILL_ARBITER_TIMEOUT_MS,
+  MIN_SKILL_ARBITER_TIMEOUT_MS,
+} from './system-settings';
+
+/** The agent's own arbiter timeout, in milliseconds; null means the system setting. */
+const SkillArbiterTimeoutOverride = z
+  .int()
+  .min(MIN_SKILL_ARBITER_TIMEOUT_MS)
+  .max(MAX_SKILL_ARBITER_TIMEOUT_MS)
+  .nullable();
 
 export const Agent = z.object({
   id: z.uuid(),
@@ -17,6 +28,14 @@ export const Agent = z.object({
   /** How many skills the gateway may create for the agent. Past it, requests
    * go to the closest skill however far it is. */
   max_auto_created_skills: z.int().min(0),
+
+  /** The model the skill arbiter asks for this agent's requests; null means
+   * the system setting. */
+  skill_arbiter_model_id: z.uuid().nullable(),
+
+  /** How long one arbiter attempt may take for this agent; null means the
+   * system setting. */
+  skill_arbiter_timeout_ms: SkillArbiterTimeoutOverride,
 
   created_at: z.iso.datetime({ offset: true }),
   updated_at: z.iso.datetime({ offset: true }),
@@ -61,6 +80,8 @@ export const AgentCreateParams = z
     auto_create_skills: z.boolean().default(true),
     skill_match_threshold: z.number().min(0).max(1).default(0.8),
     max_auto_created_skills: z.int().min(0).default(10),
+    skill_arbiter_model_id: z.uuid().nullable().optional(),
+    skill_arbiter_timeout_ms: SkillArbiterTimeoutOverride.optional(),
   })
   .strict();
 
@@ -73,6 +94,8 @@ export const AgentUpdateParams = z
     auto_create_skills: z.boolean().optional(),
     skill_match_threshold: z.number().min(0).max(1).optional(),
     max_auto_created_skills: z.int().min(0).optional(),
+    skill_arbiter_model_id: z.uuid().nullable().optional(),
+    skill_arbiter_timeout_ms: SkillArbiterTimeoutOverride.optional(),
   })
   .strict()
   .refine(
@@ -83,6 +106,8 @@ export const AgentUpdateParams = z
         'auto_create_skills',
         'skill_match_threshold',
         'max_auto_created_skills',
+        'skill_arbiter_model_id',
+        'skill_arbiter_timeout_ms',
       ];
       return updateFields.some(
         (field) => data[field as keyof typeof data] !== undefined,

--- a/packages/shared/src/types/data/system-settings.ts
+++ b/packages/shared/src/types/data/system-settings.ts
@@ -1,11 +1,27 @@
 import { z } from 'zod';
 
+/**
+ * Bounds on how long one skill-arbiter attempt may take. The arbiter answers
+ * on the request path -- a request no skill matches closely waits for it -- so
+ * the ceiling is generous for slow self-hosted models but not unbounded.
+ */
+export const DEFAULT_SKILL_ARBITER_TIMEOUT_MS = 15_000;
+export const MIN_SKILL_ARBITER_TIMEOUT_MS = 1_000;
+export const MAX_SKILL_ARBITER_TIMEOUT_MS = 600_000;
+
 export const SystemSettings = z.object({
   id: z.uuid(),
   system_prompt_reflection_model_id: z.uuid().nullable(),
   evaluation_generation_model_id: z.uuid().nullable(),
   embedding_model_id: z.uuid().nullable(),
   judge_model_id: z.uuid().nullable(),
+  /**
+   * The model the skill arbiter asks when a request matches no skill closely.
+   * Null defers to the system prompt reflection model.
+   */
+  skill_arbiter_model_id: z.uuid().nullable(),
+  /** How long one arbiter attempt may take, in milliseconds. */
+  skill_arbiter_timeout_ms: z.number().int().positive(),
   developer_mode: z.boolean(),
   created_at: z.iso.datetime({ offset: true }),
   updated_at: z.iso.datetime({ offset: true }),
@@ -18,6 +34,13 @@ export const SystemSettingsUpdateParams = z
     evaluation_generation_model_id: z.uuid().nullable().optional(),
     embedding_model_id: z.uuid().nullable().optional(),
     judge_model_id: z.uuid().nullable().optional(),
+    skill_arbiter_model_id: z.uuid().nullable().optional(),
+    skill_arbiter_timeout_ms: z
+      .number()
+      .int()
+      .min(MIN_SKILL_ARBITER_TIMEOUT_MS)
+      .max(MAX_SKILL_ARBITER_TIMEOUT_MS)
+      .optional(),
     developer_mode: z.boolean().optional(),
   })
   .strict();

--- a/packages/web/src/api/v1/super-agents/agents.test.ts
+++ b/packages/web/src/api/v1/super-agents/agents.test.ts
@@ -112,6 +112,8 @@ describe('Agents Client API', () => {
           auto_create_skills: true,
           skill_match_threshold: 0.8,
           max_auto_created_skills: 10,
+          skill_arbiter_model_id: null,
+          skill_arbiter_timeout_ms: null,
         },
       ];
 
@@ -192,6 +194,8 @@ describe('Agents Client API', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       };
 
       const mockResponse = {
@@ -240,6 +244,8 @@ describe('Agents Client API', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       };
 
       const mockResponse = {

--- a/packages/web/src/components/agents/agents-list-view.test.tsx
+++ b/packages/web/src/components/agents/agents-list-view.test.tsx
@@ -42,6 +42,8 @@ const mockAgents: Agent[] = [
     auto_create_skills: true,
     skill_match_threshold: 0.8,
     max_auto_created_skills: 10,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: null,
   },
   {
     id: 'agent-2',
@@ -53,6 +55,8 @@ const mockAgents: Agent[] = [
     auto_create_skills: true,
     skill_match_threshold: 0.8,
     max_auto_created_skills: 10,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: null,
   },
 ];
 

--- a/packages/web/src/components/agents/agents-view.test.tsx
+++ b/packages/web/src/components/agents/agents-view.test.tsx
@@ -179,6 +179,8 @@ describe('AgentsView', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       },
     ]);
     vi.mocked(getSkills).mockResolvedValue([
@@ -250,6 +252,8 @@ describe('AgentsView', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       },
     ]);
     vi.mocked(getSkills).mockResolvedValue([
@@ -304,6 +308,8 @@ describe('AgentsView', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       },
     ]);
     vi.mocked(getSkills).mockResolvedValue([
@@ -359,6 +365,8 @@ describe('AgentsView', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       },
     ]);
     vi.mocked(getSkills).mockResolvedValue([

--- a/packages/web/src/components/agents/edit-agent-view.test.tsx
+++ b/packages/web/src/components/agents/edit-agent-view.test.tsx
@@ -35,6 +35,8 @@ const mockAgent = {
   auto_create_skills: true,
   skill_match_threshold: 0.8,
   max_auto_created_skills: 10,
+  skill_arbiter_model_id: null,
+  skill_arbiter_timeout_ms: null,
   created_at: '2023-01-01T10:30:00Z',
   updated_at: '2023-01-01T10:30:00Z',
 };
@@ -94,6 +96,19 @@ vi.mock('@web/providers/system-settings', () => ({
   })),
   SystemSettingsProvider: ({ children }: { children: React.ReactNode }) =>
     children,
+}));
+
+// The arbiter override lists the text models; none here.
+vi.mock('@web/providers/models', () => ({
+  useModels: vi.fn(() => ({
+    models: [],
+    isLoading: false,
+    setQueryParams: vi.fn(),
+  })),
+}));
+
+vi.mock('@web/providers/ai-providers', () => ({
+  useAIProviders: vi.fn(() => ({ aiProviderConfigs: [] })),
 }));
 
 describe('EditAgentView', () => {
@@ -516,7 +531,36 @@ describe('EditAgentView', () => {
           auto_create_skills: false,
           skill_match_threshold: 0.8,
           max_auto_created_skills: 3,
+          skill_arbiter_model_id: null,
+          skill_arbiter_timeout_ms: null,
         });
+      });
+    });
+
+    it('saves an arbiter timeout of its own in milliseconds, and clears it when emptied', async () => {
+      renderEditAgentView();
+
+      const timeout = screen.getByLabelText('Arbiter timeout (seconds)');
+      expect(timeout).toHaveValue(null);
+
+      fireEvent.change(timeout, { target: { value: '30' } });
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateAgent).toHaveBeenCalledWith(
+          'agent-1',
+          expect.objectContaining({ skill_arbiter_timeout_ms: 30_000 }),
+        );
+      });
+
+      fireEvent.change(timeout, { target: { value: '' } });
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateAgent).toHaveBeenLastCalledWith(
+          'agent-1',
+          expect.objectContaining({ skill_arbiter_timeout_ms: null }),
+        );
       });
     });
 

--- a/packages/web/src/components/agents/edit-agent-view.tsx
+++ b/packages/web/src/components/agents/edit-agent-view.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { type AIProvider, PrettyAIProvider } from '@shared/types/constants';
 import type { AgentUpdateParams } from '@shared/types/data';
+import {
+  MAX_SKILL_ARBITER_TIMEOUT_MS,
+  MIN_SKILL_ARBITER_TIMEOUT_MS,
+} from '@shared/types/data/system-settings';
 import { sanitizeUserInput } from '@shared/utils/security';
 import { useParams } from '@tanstack/react-router';
 import { Button } from '@web/components/ui/button';
@@ -23,14 +28,30 @@ import {
 } from '@web/components/ui/form';
 import { Input } from '@web/components/ui/input';
 import { PageHeader } from '@web/components/ui/page-header';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@web/components/ui/select';
 import { Switch } from '@web/components/ui/switch';
 import { Textarea } from '@web/components/ui/textarea';
 import { usePermissiveNavigate } from '@web/hooks/use-permissive-navigate';
 import { useAgents } from '@web/providers/agents';
+import { useAIProviders } from '@web/providers/ai-providers';
+import { useModels } from '@web/providers/models';
+import { sortModels } from '@web/utils/model-sorting';
 import { Bot, Settings } from 'lucide-react';
 import * as React from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+
+const MIN_ARBITER_TIMEOUT_SECONDS = MIN_SKILL_ARBITER_TIMEOUT_MS / 1000;
+const MAX_ARBITER_TIMEOUT_SECONDS = MAX_SKILL_ARBITER_TIMEOUT_MS / 1000;
+
+/** The select's value for "no override": a Radix item cannot be the empty string. */
+const SYSTEM_DEFAULT = '__system_default__';
 
 const EditAgentFormSchema = z
   .object({
@@ -47,6 +68,20 @@ const EditAgentFormSchema = z
       .number({ error: 'Enter a whole number' })
       .int('Must be a whole number')
       .min(0, 'Cannot be negative'),
+    // Null means the system setting applies.
+    skill_arbiter_model_id: z.string().nullable(),
+    skill_arbiter_timeout_seconds: z
+      .number({ error: 'Enter a whole number of seconds, or leave it empty' })
+      .int('Must be a whole number of seconds')
+      .min(
+        MIN_ARBITER_TIMEOUT_SECONDS,
+        `Must be at least ${MIN_ARBITER_TIMEOUT_SECONDS}`,
+      )
+      .max(
+        MAX_ARBITER_TIMEOUT_SECONDS,
+        `Must be at most ${MAX_ARBITER_TIMEOUT_SECONDS}`,
+      )
+      .nullable(),
   })
   .strict();
 
@@ -54,9 +89,37 @@ type EditAgentFormData = z.infer<typeof EditAgentFormSchema>;
 
 export function EditAgentView(): React.ReactElement {
   const { selectedAgent, updateAgent, isUpdating } = useAgents();
+  const { models, setQueryParams } = useModels();
+  const { aiProviderConfigs } = useAIProviders();
   const navigate = usePermissiveNavigate();
   const { agentName } = useParams({ strict: false }) as { agentName?: string };
   const agentNameInputId = React.useId();
+
+  // Load all models, for the arbiter override.
+  React.useEffect(() => {
+    setQueryParams({});
+  }, [setQueryParams]);
+
+  const textModelOptions = React.useMemo(
+    () =>
+      sortModels(
+        models
+          .filter((model) => model.model_type === 'text')
+          .map((model) => {
+            const provider = aiProviderConfigs.find(
+              (config) => config.id === model.ai_provider_id,
+            )?.ai_provider as AIProvider | undefined;
+            return {
+              id: model.id,
+              modelName: model.model_name,
+              providerName: provider
+                ? PrettyAIProvider[provider] || provider
+                : 'Unknown',
+            };
+          }),
+      ),
+    [models, aiProviderConfigs],
+  );
 
   const form = useForm<EditAgentFormData>({
     resolver: zodResolver(EditAgentFormSchema),
@@ -65,6 +128,8 @@ export function EditAgentView(): React.ReactElement {
       auto_create_skills: true,
       skill_match_threshold: 0.8,
       max_auto_created_skills: 10,
+      skill_arbiter_model_id: null,
+      skill_arbiter_timeout_seconds: null,
     },
   });
 
@@ -76,6 +141,11 @@ export function EditAgentView(): React.ReactElement {
         auto_create_skills: selectedAgent.auto_create_skills,
         skill_match_threshold: selectedAgent.skill_match_threshold,
         max_auto_created_skills: selectedAgent.max_auto_created_skills,
+        skill_arbiter_model_id: selectedAgent.skill_arbiter_model_id,
+        skill_arbiter_timeout_seconds:
+          selectedAgent.skill_arbiter_timeout_ms === null
+            ? null
+            : selectedAgent.skill_arbiter_timeout_ms / 1000,
       });
     }
   }, [selectedAgent, form]);
@@ -92,6 +162,11 @@ export function EditAgentView(): React.ReactElement {
         auto_create_skills: data.auto_create_skills,
         skill_match_threshold: data.skill_match_threshold,
         max_auto_created_skills: data.max_auto_created_skills,
+        skill_arbiter_model_id: data.skill_arbiter_model_id,
+        skill_arbiter_timeout_ms:
+          data.skill_arbiter_timeout_seconds === null
+            ? null
+            : data.skill_arbiter_timeout_seconds * 1000,
       };
 
       await updateAgent(selectedAgent.id, updateParams);
@@ -299,6 +374,86 @@ export function EditAgentView(): React.ReactElement {
                               onBlur={field.onBlur}
                               onChange={(e) =>
                                 field.onChange(e.target.valueAsNumber)
+                              }
+                              disabled={isUpdating}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+
+                  {/* The arbiter: the model asked when no skill matches closely */}
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <FormField
+                      control={form.control}
+                      name="skill_arbiter_model_id"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Arbiter model</FormLabel>
+                          <FormDescription>
+                            Decides whether an unfamiliar request is a new kind
+                            of job. Empty uses the system setting.
+                          </FormDescription>
+                          <Select
+                            value={field.value ?? SYSTEM_DEFAULT}
+                            onValueChange={(value) =>
+                              field.onChange(
+                                value === SYSTEM_DEFAULT ? null : value,
+                              )
+                            }
+                            disabled={isUpdating}
+                          >
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              <SelectItem value={SYSTEM_DEFAULT}>
+                                System default
+                              </SelectItem>
+                              {textModelOptions.map((model) => (
+                                <SelectItem key={model.id} value={model.id}>
+                                  {model.modelName}{' '}
+                                  <span className="text-muted-foreground">
+                                    ({model.providerName})
+                                  </span>
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="skill_arbiter_timeout_seconds"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Arbiter timeout (seconds)</FormLabel>
+                          <FormDescription>
+                            Per attempt, retried once. Empty uses the system
+                            setting.
+                          </FormDescription>
+                          <FormControl>
+                            <Input
+                              type="number"
+                              step="1"
+                              min={MIN_ARBITER_TIMEOUT_SECONDS}
+                              max={MAX_ARBITER_TIMEOUT_SECONDS}
+                              placeholder="System default"
+                              name={field.name}
+                              value={field.value ?? ''}
+                              onBlur={field.onBlur}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === ''
+                                    ? null
+                                    : e.target.valueAsNumber,
+                                )
                               }
                               disabled={isUpdating}
                             />

--- a/packages/web/src/components/agents/skills/edit-skill-view.test.tsx
+++ b/packages/web/src/components/agents/skills/edit-skill-view.test.tsx
@@ -24,6 +24,8 @@ const mockAgent = {
   auto_create_skills: true,
   skill_match_threshold: 0.8,
   max_auto_created_skills: 10,
+  skill_arbiter_model_id: null,
+  skill_arbiter_timeout_ms: null,
   created_at: '2023-01-01T10:30:00Z',
   updated_at: '2023-01-01T10:30:00Z',
 };

--- a/packages/web/src/components/agents/skills/skills-list-view.test.tsx
+++ b/packages/web/src/components/agents/skills/skills-list-view.test.tsx
@@ -83,6 +83,8 @@ const mockAgent: Agent = {
   auto_create_skills: true,
   skill_match_threshold: 0.8,
   max_auto_created_skills: 10,
+  skill_arbiter_model_id: null,
+  skill_arbiter_timeout_ms: null,
 };
 
 const mockSkills: Skill[] = [

--- a/packages/web/src/components/breadcrumbs/breadcrumb.test.tsx
+++ b/packages/web/src/components/breadcrumbs/breadcrumb.test.tsx
@@ -291,6 +291,8 @@ const mockAgents: Agent[] = [
     auto_create_skills: true,
     skill_match_threshold: 0.8,
     max_auto_created_skills: 10,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: null,
   },
   {
     id: '2',
@@ -302,6 +304,8 @@ const mockAgents: Agent[] = [
     auto_create_skills: true,
     skill_match_threshold: 0.8,
     max_auto_created_skills: 10,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: null,
   },
   {
     id: '3',
@@ -313,6 +317,8 @@ const mockAgents: Agent[] = [
     auto_create_skills: true,
     skill_match_threshold: 0.8,
     max_auto_created_skills: 10,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: null,
   },
 ];
 

--- a/packages/web/src/components/settings/model-selector.tsx
+++ b/packages/web/src/components/settings/model-selector.tsx
@@ -38,14 +38,19 @@ export interface ModelSelectorProps {
   recommendation?: string;
   /** Currently selected model ID */
   value: string | null;
-  /** Callback when model selection changes */
-  onChange: (value: string) => void;
+  /** Callback when model selection changes; null clears an optional field */
+  onChange: (value: string | null) => void;
   /** Available model options to choose from */
   modelOptions: ModelOption[];
   /** Whether the component is in loading state */
   isLoading: boolean;
   /** Whether this field is required */
   required?: boolean;
+  /**
+   * For an optional field: what leaving it empty means. Offered as a choice
+   * that clears the field, and shown in place of a selection when it is empty.
+   */
+  emptyOption?: string;
 }
 
 export function ModelSelector({
@@ -57,6 +62,7 @@ export function ModelSelector({
   modelOptions,
   isLoading,
   required = true,
+  emptyOption,
 }: ModelSelectorProps): ReactElement {
   const [open, setOpen] = useState(false);
 
@@ -122,7 +128,9 @@ export function ModelSelector({
                     </Badge>
                   </div>
                 ) : (
-                  <span className="text-muted-foreground">Select a model</span>
+                  <span className="text-muted-foreground">
+                    {emptyOption ?? 'Select a model'}
+                  </span>
                 )}
                 <ChevronsUpDownIcon
                   className="ml-2 h-4 w-4 shrink-0 opacity-50"
@@ -143,6 +151,26 @@ export function ModelSelector({
                 >
                   <CommandEmpty>No model found.</CommandEmpty>
                   <CommandGroup>
+                    {emptyOption && (
+                      <CommandItem
+                        value={emptyOption}
+                        onSelect={() => {
+                          onChange(null);
+                          setOpen(false);
+                        }}
+                        role="option"
+                        aria-selected={value === null}
+                      >
+                        <CheckIcon
+                          className={cn(
+                            'mr-2 h-4 w-4',
+                            value === null ? 'opacity-100' : 'opacity-0',
+                          )}
+                          aria-hidden="true"
+                        />
+                        <span>{emptyOption}</span>
+                      </CommandItem>
+                    )}
                     {modelOptions.map((model) => (
                       <CommandItem
                         key={model.id}

--- a/packages/web/src/components/settings/system-settings-view.test.tsx
+++ b/packages/web/src/components/settings/system-settings-view.test.tsx
@@ -1,0 +1,104 @@
+import type { SystemSettings } from '@shared/types/data/system-settings';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SystemSettingsView } from '@web/components/settings/system-settings-view';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The settings page edits the skill arbiter's timeout in seconds while the
+ * setting is stored in milliseconds. What matters here: the conversion both
+ * ways, and that an impossible value never reaches the API.
+ */
+
+const { mockUpdate, mockToast } = vi.hoisted(() => ({
+  mockUpdate: vi.fn(),
+  mockToast: vi.fn(),
+}));
+
+const settings: SystemSettings = {
+  id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  system_prompt_reflection_model_id: null,
+  evaluation_generation_model_id: null,
+  embedding_model_id: null,
+  judge_model_id: null,
+  skill_arbiter_model_id: null,
+  skill_arbiter_timeout_ms: 15_000,
+  developer_mode: false,
+  created_at: '2023-01-01T00:00:00Z',
+  updated_at: '2023-01-01T00:00:00Z',
+};
+
+vi.mock('@web/providers/system-settings', () => ({
+  useSystemSettings: () => ({
+    settings,
+    isLoading: false,
+    error: null,
+    update: mockUpdate,
+    isUpdating: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+// No models: the model selectors stay empty and nothing counts as missing,
+// so the save button exercises the timeout alone.
+vi.mock('@web/providers/models', () => ({
+  useModels: () => ({
+    models: [],
+    isLoading: false,
+    setQueryParams: vi.fn(),
+  }),
+}));
+
+vi.mock('@web/providers/ai-providers', () => ({
+  useAIProviders: () => ({ aiProviderConfigs: [] }),
+}));
+
+vi.mock('@web/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+describe('SystemSettingsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdate.mockResolvedValue(settings);
+  });
+
+  it('shows the arbiter timeout in seconds and saves it in milliseconds', async () => {
+    render(<SystemSettingsView />);
+
+    const timeout = screen.getByLabelText('Arbiter Timeout');
+    expect(timeout).toHaveValue(15);
+
+    fireEvent.change(timeout, { target: { value: '120' } });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith({
+        skill_arbiter_timeout_ms: 120_000,
+      });
+    });
+  });
+
+  it('refuses a timeout outside the allowed range', async () => {
+    render(<SystemSettingsView />);
+
+    fireEvent.change(screen.getByLabelText('Arbiter Timeout'), {
+      target: { value: '0' },
+    });
+    // The "no models" notice is an alert too, so find the message by text.
+    expect(
+      screen.getByText(/whole number of seconds between 1 and 600/),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Invalid arbiter timeout',
+          variant: 'destructive',
+        }),
+      );
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/settings/system-settings-view.tsx
+++ b/packages/web/src/components/settings/system-settings-view.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { type AIProvider, PrettyAIProvider } from '@shared/types/constants';
-import type { SystemSettingsUpdateParams } from '@shared/types/data/system-settings';
+import {
+  MAX_SKILL_ARBITER_TIMEOUT_MS,
+  MIN_SKILL_ARBITER_TIMEOUT_MS,
+  type SystemSettingsUpdateParams,
+} from '@shared/types/data/system-settings';
 import { DeveloperModeToggle } from '@web/components/settings/developer-mode-toggle';
 import {
   type ModelOption,
@@ -20,22 +24,44 @@ import {
   CardHeader,
   CardTitle,
 } from '@web/components/ui/card';
+import { Input } from '@web/components/ui/input';
+import { Label } from '@web/components/ui/label';
 import { PageHeader } from '@web/components/ui/page-header';
 import { useToast } from '@web/hooks/use-toast';
 import { useAIProviders } from '@web/providers/ai-providers';
 import { useModels } from '@web/providers/models';
 import { useSystemSettings } from '@web/providers/system-settings';
 import { sortModels } from '@web/utils/model-sorting';
-import { SaveIcon, SettingsIcon } from 'lucide-react';
+import { RouteIcon, SaveIcon, SettingsIcon } from 'lucide-react';
 import type { ReactElement } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 
-interface FormValues {
-  system_prompt_reflection_model_id: string | null;
-  evaluation_generation_model_id: string | null;
-  embedding_model_id: string | null;
-  judge_model_id: string | null;
+const MIN_ARBITER_TIMEOUT_SECONDS = MIN_SKILL_ARBITER_TIMEOUT_MS / 1000;
+const MAX_ARBITER_TIMEOUT_SECONDS = MAX_SKILL_ARBITER_TIMEOUT_MS / 1000;
+
+type ModelField =
+  | 'system_prompt_reflection_model_id'
+  | 'evaluation_generation_model_id'
+  | 'embedding_model_id'
+  | 'judge_model_id'
+  | 'skill_arbiter_model_id';
+
+interface FormValues extends Record<ModelField, string | null> {
+  /** Edited in seconds; the setting itself is in milliseconds. */
+  skill_arbiter_timeout_seconds: number;
   developer_mode: boolean;
+}
+
+/** Why the arbiter timeout cannot be saved as entered, or null when it can. */
+export function arbiterTimeoutProblem(seconds: number): string | null {
+  if (
+    Number.isInteger(seconds) &&
+    seconds >= MIN_ARBITER_TIMEOUT_SECONDS &&
+    seconds <= MAX_ARBITER_TIMEOUT_SECONDS
+  ) {
+    return null;
+  }
+  return `Enter a whole number of seconds between ${MIN_ARBITER_TIMEOUT_SECONDS} and ${MAX_ARBITER_TIMEOUT_SECONDS}.`;
 }
 
 export function SystemSettingsView(): ReactElement {
@@ -44,6 +70,8 @@ export function SystemSettingsView(): ReactElement {
     useSystemSettings();
   const { models, isLoading: isLoadingModels, setQueryParams } = useModels();
   const { aiProviderConfigs: apiKeys } = useAIProviders();
+  const timeoutId = useId();
+  const timeoutDescriptionId = `${timeoutId}-description`;
 
   // Local state for form values
   const [formValues, setFormValues] = useState<FormValues>({
@@ -51,6 +79,8 @@ export function SystemSettingsView(): ReactElement {
     evaluation_generation_model_id: null,
     embedding_model_id: null,
     judge_model_id: null,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_seconds: 15,
     developer_mode: false,
   });
 
@@ -71,6 +101,8 @@ export function SystemSettingsView(): ReactElement {
         evaluation_generation_model_id: settings.evaluation_generation_model_id,
         embedding_model_id: settings.embedding_model_id,
         judge_model_id: settings.judge_model_id,
+        skill_arbiter_model_id: settings.skill_arbiter_model_id,
+        skill_arbiter_timeout_seconds: settings.skill_arbiter_timeout_ms / 1000,
         developer_mode: settings.developer_mode,
       });
       setIsDirty(false);
@@ -108,8 +140,16 @@ export function SystemSettingsView(): ReactElement {
     [modelOptions],
   );
 
-  const handleFieldChange = (field: keyof FormValues, value: string) => {
+  const handleFieldChange = (field: ModelField, value: string | null) => {
     setFormValues((prev) => ({ ...prev, [field]: value }));
+    setIsDirty(true);
+  };
+
+  const handleTimeoutChange = (seconds: number) => {
+    setFormValues((prev) => ({
+      ...prev,
+      skill_arbiter_timeout_seconds: seconds,
+    }));
     setIsDirty(true);
   };
 
@@ -144,12 +184,24 @@ export function SystemSettingsView(): ReactElement {
 
   const isSettingsComplete = missingFields.length === 0;
 
+  const timeoutProblem = arbiterTimeoutProblem(
+    formValues.skill_arbiter_timeout_seconds,
+  );
+
   const handleSave = async () => {
     // Validate all required fields
     if (missingFields.length > 0) {
       toast({
         title: 'Missing required fields',
         description: `Please configure: ${missingFields.join(', ')}`,
+        variant: 'destructive',
+      });
+      return;
+    }
+    if (timeoutProblem) {
+      toast({
+        title: 'Invalid arbiter timeout',
+        description: timeoutProblem,
         variant: 'destructive',
       });
       return;
@@ -178,6 +230,15 @@ export function SystemSettingsView(): ReactElement {
       }
       if (formValues.judge_model_id !== settings?.judge_model_id) {
         updateParams.judge_model_id = formValues.judge_model_id;
+      }
+      if (
+        formValues.skill_arbiter_model_id !== settings?.skill_arbiter_model_id
+      ) {
+        updateParams.skill_arbiter_model_id = formValues.skill_arbiter_model_id;
+      }
+      const timeoutMs = formValues.skill_arbiter_timeout_seconds * 1000;
+      if (timeoutMs !== settings?.skill_arbiter_timeout_ms) {
+        updateParams.skill_arbiter_timeout_ms = timeoutMs;
       }
       if (formValues.developer_mode !== settings?.developer_mode) {
         updateParams.developer_mode = formValues.developer_mode;
@@ -293,6 +354,81 @@ export function SystemSettingsView(): ReactElement {
               modelOptions={textModelOptions}
               isLoading={isAnyLoading}
             />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <RouteIcon className="h-5 w-5" aria-hidden="true" />
+              Skill Routing
+            </CardTitle>
+            <CardDescription>
+              When a request names only its agent and resembles none of the
+              agent&apos;s skills closely, the arbiter decides whether it is a
+              known job on new material or a new kind of job. It answers on the
+              request path, so the request waits for it. Each agent can override
+              both settings.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ModelSelector
+              label="Skill Arbiter"
+              description="Model that makes the call. A fast model serves best; it only has to name a skill or none."
+              recommendation="gpt-5-mini or claude-haiku-4-5"
+              value={formValues.skill_arbiter_model_id}
+              onChange={(v) => handleFieldChange('skill_arbiter_model_id', v)}
+              modelOptions={textModelOptions}
+              isLoading={isAnyLoading}
+              required={false}
+              emptyOption="Same as System Prompt Reflection"
+            />
+
+            <div className="grid gap-4 md:grid-cols-[1fr,300px] items-start py-4 border-b last:border-b-0">
+              <div className="space-y-1">
+                <Label htmlFor={timeoutId} className="font-medium text-base">
+                  Arbiter Timeout
+                </Label>
+                <p
+                  id={timeoutDescriptionId}
+                  className="text-sm text-muted-foreground"
+                >
+                  Seconds one arbiter attempt may take; a timed-out attempt is
+                  retried once. Keep it as short as the model allows, since a
+                  request that matches no skill closely waits for the answer.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Input
+                    id={timeoutId}
+                    type="number"
+                    inputMode="numeric"
+                    min={MIN_ARBITER_TIMEOUT_SECONDS}
+                    max={MAX_ARBITER_TIMEOUT_SECONDS}
+                    step={1}
+                    className="w-32"
+                    value={
+                      Number.isNaN(formValues.skill_arbiter_timeout_seconds)
+                        ? ''
+                        : formValues.skill_arbiter_timeout_seconds
+                    }
+                    onChange={(e) =>
+                      handleTimeoutChange(e.target.valueAsNumber)
+                    }
+                    disabled={isAnyLoading}
+                    aria-describedby={timeoutDescriptionId}
+                    aria-invalid={timeoutProblem !== null}
+                  />
+                  <span className="text-sm text-muted-foreground">seconds</span>
+                </div>
+                {timeoutProblem && (
+                  <p className="text-sm text-destructive" role="alert">
+                    {timeoutProblem}
+                  </p>
+                )}
+              </div>
+            </div>
           </CardContent>
         </Card>
 

--- a/packages/web/src/hooks/use-agent-unready-skills.test.tsx
+++ b/packages/web/src/hooks/use-agent-unready-skills.test.tsx
@@ -30,6 +30,8 @@ describe('useAgentUnreadySkills', () => {
     auto_create_skills: true,
     skill_match_threshold: 0.8,
     max_auto_created_skills: 10,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: null,
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
   };

--- a/packages/web/src/hooks/use-agent-validation.test.tsx
+++ b/packages/web/src/hooks/use-agent-validation.test.tsx
@@ -30,6 +30,8 @@ describe('useAgentValidation', () => {
       auto_create_skills,
       skill_match_threshold: 0.8,
       max_auto_created_skills: 10,
+      skill_arbiter_model_id: null,
+      skill_arbiter_timeout_ms: null,
       created_at: '2026-01-01T00:00:00Z',
       updated_at: '2026-01-01T00:00:00Z',
     }) as const;

--- a/packages/web/src/hooks/use-settings-validation.test.tsx
+++ b/packages/web/src/hooks/use-settings-validation.test.tsx
@@ -29,6 +29,8 @@ describe('useSettingsValidation', () => {
     evaluation_generation_model_id: 'model-2222-3333-4444-555566667777',
     embedding_model_id: 'model-3333-4444-5555-666677778888',
     judge_model_id: 'model-4444-5555-6666-777788889999',
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: 15_000,
     developer_mode: false,
     created_at: '2023-01-01T00:00:00Z',
     updated_at: '2023-01-01T00:00:00Z',

--- a/packages/web/src/providers/agents.test.tsx
+++ b/packages/web/src/providers/agents.test.tsx
@@ -78,6 +78,8 @@ const mockAgents: Agent[] = [
     auto_create_skills: true,
     skill_match_threshold: 0.8,
     max_auto_created_skills: 10,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: null,
   },
   {
     id: '2',
@@ -89,6 +91,8 @@ const mockAgents: Agent[] = [
     auto_create_skills: true,
     skill_match_threshold: 0.8,
     max_auto_created_skills: 10,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: null,
   },
 ];
 
@@ -158,6 +162,8 @@ function TestComponent(): React.ReactElement {
               auto_create_skills: true,
               skill_match_threshold: 0.8,
               max_auto_created_skills: 10,
+              skill_arbiter_model_id: null,
+              skill_arbiter_timeout_ms: null,
             });
           } catch (error) {
             console.error('Create failed:', error);
@@ -243,6 +249,8 @@ describe('AgentsProvider', () => {
       auto_create_skills: true,
       skill_match_threshold: 0.8,
       max_auto_created_skills: 10,
+      skill_arbiter_model_id: null,
+      skill_arbiter_timeout_ms: null,
     });
     vi.mocked(getAgents).mockResolvedValue(mockAgents);
     vi.mocked(updateAgent).mockResolvedValue({

--- a/packages/web/src/providers/navigation.test.tsx
+++ b/packages/web/src/providers/navigation.test.tsx
@@ -164,6 +164,8 @@ const mockAgents: Agent[] = [
     auto_create_skills: true,
     skill_match_threshold: 0.8,
     max_auto_created_skills: 10,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: null,
   },
   {
     id: '2',
@@ -175,6 +177,8 @@ const mockAgents: Agent[] = [
     auto_create_skills: true,
     skill_match_threshold: 0.8,
     max_auto_created_skills: 10,
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: null,
   },
 ];
 

--- a/packages/web/src/providers/navigation/url-utils.test.ts
+++ b/packages/web/src/providers/navigation/url-utils.test.ts
@@ -97,6 +97,8 @@ describe('url-utils', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       },
       {
         id: 'agent-2',
@@ -108,6 +110,8 @@ describe('url-utils', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       },
       {
         id: 'agent-3',
@@ -119,6 +123,8 @@ describe('url-utils', () => {
         auto_create_skills: true,
         skill_match_threshold: 0.8,
         max_auto_created_skills: 10,
+        skill_arbiter_model_id: null,
+        skill_arbiter_timeout_ms: null,
       },
     ];
 
@@ -166,6 +172,8 @@ describe('url-utils', () => {
           auto_create_skills: true,
           skill_match_threshold: 0.8,
           max_auto_created_skills: 10,
+          skill_arbiter_model_id: null,
+          skill_arbiter_timeout_ms: null,
         },
       ];
       const result = getAgentByName(agentsWithSpecialChars, 'Agent & Helper');
@@ -409,6 +417,8 @@ describe('url-utils', () => {
           auto_create_skills: true,
           skill_match_threshold: 0.8,
           max_auto_created_skills: 10,
+          skill_arbiter_model_id: null,
+          skill_arbiter_timeout_ms: null,
         },
       ];
       const result = getAgentByName(mockAgents, '');
@@ -427,6 +437,8 @@ describe('url-utils', () => {
           auto_create_skills: true,
           skill_match_threshold: 0.8,
           max_auto_created_skills: 10,
+          skill_arbiter_model_id: null,
+          skill_arbiter_timeout_ms: null,
         },
       ];
       const result = getAgentByName(mockAgents, 'Agente Español 日本語');
@@ -445,6 +457,8 @@ describe('url-utils', () => {
           auto_create_skills: true,
           skill_match_threshold: 0.8,
           max_auto_created_skills: 10,
+          skill_arbiter_model_id: null,
+          skill_arbiter_timeout_ms: null,
         },
       ];
       // URL-encoded 'Test Agent'
@@ -464,6 +478,8 @@ describe('url-utils', () => {
           auto_create_skills: true,
           skill_match_threshold: 0.8,
           max_auto_created_skills: 10,
+          skill_arbiter_model_id: null,
+          skill_arbiter_timeout_ms: null,
         },
       ];
       const result = getAgentByName(mockAgents, 'test agent');

--- a/packages/web/src/providers/system-settings.test.tsx
+++ b/packages/web/src/providers/system-settings.test.tsx
@@ -39,6 +39,8 @@ describe('SystemSettingsProvider', () => {
     evaluation_generation_model_id: 'model-2222-3333-4444-555566667777',
     embedding_model_id: 'model-3333-4444-5555-666677778888',
     judge_model_id: 'model-4444-5555-6666-777788889999',
+    skill_arbiter_model_id: null,
+    skill_arbiter_timeout_ms: 15_000,
     developer_mode: false,
     created_at: '2023-01-01T00:00:00Z',
     updated_at: '2023-01-01T00:00:00Z',

--- a/supabase/migrations/20251124192123_system_settings_and_model_types.sql
+++ b/supabase/migrations/20251124192123_system_settings_and_model_types.sql
@@ -19,6 +19,11 @@ CREATE TABLE IF NOT EXISTS system_settings (
   evaluation_generation_model_id UUID REFERENCES models(id) ON DELETE RESTRICT,
   embedding_model_id UUID REFERENCES models(id) ON DELETE RESTRICT,
   judge_model_id UUID REFERENCES models(id) ON DELETE RESTRICT,
+  -- The skill arbiter: the model that decides whether a request no skill
+  -- matches closely is a new kind of job (NULL defers to the reflection
+  -- model), and how long one of its attempts may take
+  skill_arbiter_model_id UUID REFERENCES models(id) ON DELETE RESTRICT,
+  skill_arbiter_timeout_ms INTEGER NOT NULL DEFAULT 15000 CHECK (skill_arbiter_timeout_ms > 0),
   -- Developer mode: when enabled, shows the super-agents internal agent and its skills
   developer_mode BOOLEAN NOT NULL DEFAULT FALSE,
   -- Timestamps
@@ -119,6 +124,11 @@ BEGIN
     RAISE EXCEPTION 'judge_model_id must reference a text model';
   END IF;
 
+  -- Validate skill_arbiter_model_id must be a text model
+  IF NOT public.check_model_type(NEW.skill_arbiter_model_id, 'text') THEN
+    RAISE EXCEPTION 'skill_arbiter_model_id must reference a text model';
+  END IF;
+
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql
@@ -146,8 +156,17 @@ BEGIN
        OR system_prompt_reflection_model_id = NEW.id
        OR evaluation_generation_model_id = NEW.id
        OR judge_model_id = NEW.id
+       OR skill_arbiter_model_id = NEW.id
   ) THEN
     RAISE EXCEPTION 'Cannot change model_type for a model that is referenced in system_settings';
+  END IF;
+
+  -- An agent's own arbiter model has to stay a text model too
+  IF EXISTS (
+    SELECT 1 FROM public.agents
+    WHERE skill_arbiter_model_id = NEW.id
+  ) THEN
+    RAISE EXCEPTION 'Cannot change model_type for a model that an agent uses as its skill arbiter';
   END IF;
 
   -- Skill routing centroids only mean something under the model that computed them
@@ -282,3 +301,36 @@ CREATE POLICY "Allow all operations on skill_creation_leases"
   WITH CHECK (true);
 
 COMMENT ON TABLE skill_creation_leases IS 'Per-agent lease held by the request creating a skill, so concurrent requests do not each create one';
+
+-- ============================================================================
+-- PART 7: Per-agent skill arbiter overrides
+-- ============================================================================
+
+-- An agent may choose its own arbiter model and timeout; NULL means the
+-- system setting applies. A deleted model falls back rather than blocking
+-- the delete, unlike the system settings, which RESTRICT.
+ALTER TABLE agents
+ADD COLUMN IF NOT EXISTS skill_arbiter_model_id UUID REFERENCES models(id) ON DELETE SET NULL,
+ADD COLUMN IF NOT EXISTS skill_arbiter_timeout_ms INTEGER CHECK (skill_arbiter_timeout_ms IS NULL OR skill_arbiter_timeout_ms > 0);
+
+CREATE INDEX IF NOT EXISTS idx_agents_skill_arbiter_model_id ON agents(skill_arbiter_model_id);
+
+COMMENT ON COLUMN agents.skill_arbiter_model_id IS 'The model the skill arbiter asks for this agent; NULL means the system setting';
+COMMENT ON COLUMN agents.skill_arbiter_timeout_ms IS 'How long one arbiter attempt may take for this agent, in milliseconds; NULL means the system setting';
+
+CREATE OR REPLACE FUNCTION validate_agent_model_types()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NOT public.check_model_type(NEW.skill_arbiter_model_id, 'text') THEN
+    RAISE EXCEPTION 'skill_arbiter_model_id must reference a text model';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql
+SET search_path = '';
+
+CREATE TRIGGER agents_model_type_validation
+  BEFORE INSERT OR UPDATE ON agents
+  FOR EACH ROW
+  EXECUTE FUNCTION validate_agent_model_types();


### PR DESCRIPTION
## Problem

The arbiter — the `route-or-create` internal skill asked when a request names only its agent and resembles none of the agent's skills closely — borrowed the system prompt reflection model and gave each attempt a hard-coded 15 seconds (`skill-arbiter.ts`). On a slow model that meant every arbitration timed out:

```
[SKILL_ROUTING] Could not ask the arbiter; routing to the closest skill: Request timed out.
```

so the arbiter was never heard and the request went to the closest skill regardless. Neither the model nor the budget could be changed without editing code, and the same 15 seconds had to serve every agent whatever its traffic looked like.

## Solution

Both become settings, with a per-agent override.

- **System settings** gain `skill_arbiter_model_id` (nullable; null defers to the reflection model, which is what happened before) and `skill_arbiter_timeout_ms` (default 15000, bounded to 1 second through 10 minutes). The settings page edits them under a new **Skill Routing** card, in seconds. `ModelSelector` learns an optional `emptyOption` so an optional model slot can be cleared.
- **Agents** gain nullable columns of the same names, edited on the agent page under "Automatic skills", which override the system settings for that agent alone. Empty means "system default".
- `resolveSystemSettingsModel` gains a `skill_arbiter` slot and can take settings the caller already read; `resolveModelById` is exported for the agent override.
- The arbiter is asked under the skill-creation lease, so `withSkillCreationLease` takes a duration and routing stretches it by twice the effective timeout — one attempt and the client's retry — on top of creation.
- Both backends check the arbiter model is a text model. A model in a system slot cannot be deleted (the delete guard in `models.ts` names the slot); an agent override falls back to null (`ON DELETE SET NULL`).

### Schema

Per the repo's no-deployments rule, the changes are folded into the existing migrations on both backends rather than appended. **An existing libSQL dev database will fail its first request with a `StaleMigrationError`: delete `.local-data/dev.db` and let the next request recreate it.** For Supabase, `supabase db reset`.

## Test notes

- `system-settings.test.ts`: timeout accepted in range, 400 out of range or fractional
- `evaluation-model-resolver.test.ts`: arbiter resolves to its own model, falls back to the reflection model, reads handed-in settings without touching storage
- `skill-arbiter.test.ts`: model and timeout come from the settings it is handed; the agent's own override wins
- `skill-routing.test.ts`: the lease lasts creation plus twice the arbiter timeout; settings are passed on to the arbiter
- `libsql.test.ts`: both new model slots reject an embed model; the default timeout is 15000 and must stay positive
- `connector.test.ts`: the agent overrides round-trip and clear back to null
- `system-settings-view.test.tsx` (new) and `edit-agent-view.test.tsx`: seconds in the form become milliseconds on the wire, an out-of-range timeout never reaches the API, and clearing the agent field sends null
- `pnpm typecheck` — clean
- `pnpm check` — clean apart from the pre-existing unused `StructuredOutputResponse` alias in `task-and-outcome.ts`
- `pnpm test` — 183 files passed
- `pnpm test:e2e` — 61 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNyvYYzLSRu67DXCoYSVoS
