### PR TITLE
fix(web): readable code in dark mode, and keep the log page header put

### DIFF
--- a/packages/web/src/components/agents/skills/logs/log-details-view.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-details-view.tsx
@@ -318,7 +318,7 @@ export function LogDetailsView(): ReactElement {
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-1 min-h-0 flex-col">
       <PageHeader
         title="Log Details"
         description={formatLogTimestamp(selectedLog.start_time)}

--- a/packages/web/src/components/text-editor/extensions/index.tsx
+++ b/packages/web/src/components/text-editor/extensions/index.tsx
@@ -41,12 +41,12 @@ export const defaultExtensions = (): (Extension | Node | Mark)[] => [
     codeBlock: {
       HTMLAttributes: {
         class:
-          'rounded-sm p-5 font-mono font-medium text-stone-800 whitespace-pre overflow-x-auto',
+          'rounded-sm p-5 font-mono font-medium text-foreground whitespace-pre overflow-x-auto',
       },
     },
     code: {
       HTMLAttributes: {
-        class: 'rounded-md px-1.5 py-1 font-mono font-medium text-stone-900',
+        class: 'rounded-md px-1.5 py-1 font-mono font-medium text-foreground',
         spellcheck: 'false',
       },
     },
@@ -129,7 +129,7 @@ export const jinjaExtensions = (): (Extension | Node | Mark)[] => [
     heading: false, // Disable headings for system prompts
     code: {
       HTMLAttributes: {
-        class: 'rounded-md px-1.5 py-1 font-mono font-medium text-stone-900',
+        class: 'rounded-md px-1.5 py-1 font-mono font-medium text-foreground',
         spellcheck: 'false',
       },
     },

--- a/packages/web/src/styles/editor.css
+++ b/packages/web/src/styles/editor.css
@@ -330,7 +330,7 @@ ul[data-type="taskList"] li[data-checked="true"] > div > p {
 }
 
 .editor .ProseMirror pre {
-  @apply whitespace-pre rounded-md bg-stone-100;
+  @apply whitespace-pre rounded-md bg-muted;
 }
 
 .editor .ProseMirror blockquote {


### PR DESCRIPTION
## Problem

Two bugs on the log details page (`/agents/$agentName/logs/$logId`), both reproduced in the browser at `http://localhost:3000/agents/coder-agent/logs/b8957a44-...`:

1. **Inline code was invisible in dark mode.** The tiptap extensions hard-code the code mark and code block to light-mode stone values. `text-stone-900` resolves to `oklch(0.216 0.006 56.043)` — *exactly* the dark-mode `--card` value — so every `` `inline code` `` span rendered as dark text on an identically dark card. Whole bullet lines read as blank space.

2. **The breadcrumb header scrolled away.** `LogDetailsView` sized its root with `h-full`, which resolves to 100% of `<main>`'s height. `<main>` is the `overflow-y-auto` `SidebarInset` and *also* holds the 64px `h-16` header, so its content was exactly one header taller than itself: `main.scrollHeight` 1277 vs `clientHeight` 1213. The whole page scrolled and took the breadcrumb with it.

## Solution

- The three hard-coded code classes in `text-editor/extensions/index.tsx` become `text-foreground`, and `.editor .ProseMirror pre` becomes `bg-muted` — otherwise dark mode gets a glaring white block where the code block is. Light mode is unchanged in practice (stone-900 → stone-950).
- `LogDetailsView`'s root becomes `flex-1 min-h-0` so it fills the *remaining* space rather than the full height of `<main>`.

## Test notes

Verified in Chrome against `pnpm dev`, dark and light:

- Inline code now renders `oklch(0.985 0.001 106.423)` (stone-50) on the dark card; `git status --short`, `git diff --stat`, `find`/`grep`/`cat` etc. are legible again.
- `main.scrollHeight` now equals `clientHeight` (1213 = 1213, was 1277). The breadcrumb stays put and scrolling happens inside the card, as intended.
- Checked the other pages under this layout — `agents-view.tsx` has a different root structure and does not overflow `<main>`, so it needed no change.

`pnpm typecheck` passes. `pnpm check` reports one pre-existing warning in `packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts`, untouched by this PR.

No screenshots attached: the fix is the *absence* of a rendering bug, and both effects are stated above as measured values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR5nakamD4JzgnJgAaehHb
