### PR TITLE
fix(api): judge the requests answered before a new skill had evaluations

### DIFF
--- a/packages/api/src/connectors/libsql/connector.test.ts
+++ b/packages/api/src/connectors/libsql/connector.test.ts
@@ -870,6 +870,31 @@ describe('logs', () => {
     expect(session.map((l) => l.start_time)).toEqual([1000, 3000]);
   });
 
+  it('lists the logs that have no evaluation run yet', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+
+    const judged = await logs.createLog(c, logParams(agent.id, skill.id, 1000));
+    const skipped = await logs.createLog(
+      c,
+      logParams(agent.id, skill.id, 2000),
+    );
+    await store.createSkillOptimizationEvaluationRun(c, {
+      agent_id: agent.id,
+      skill_id: skill.id,
+      cluster_id: null,
+      log_id: judged.id,
+      results: [],
+    });
+
+    const backlog = await logs.getLogs(c, {
+      skill_id: skill.id,
+      unjudged: true,
+    });
+    expect(backlog.map((l) => l.id)).toEqual([skipped.id]);
+  });
+
   it('filters on embeddings being present', async () => {
     const { c } = await freshDatabase();
     const agent = await seedAgent(c);

--- a/packages/api/src/connectors/libsql/logs.ts
+++ b/packages/api/src/connectors/libsql/logs.ts
@@ -47,6 +47,9 @@ export const libsqlLogsStorageConnector: LogsStorageConnector = {
     if (queryParams.embedding_not_null) {
       conditions.push('embedding IS NOT NULL');
     }
+    if (queryParams.unjudged) {
+      conditions.push('eval_run_count = 0');
+    }
     if (queryParams.after !== undefined) {
       conditions.push('start_time >= ?');
       args.push(queryParams.after);

--- a/packages/api/src/connectors/supabase/supabase.test.ts
+++ b/packages/api/src/connectors/supabase/supabase.test.ts
@@ -605,4 +605,17 @@ describe('supabaseLogsStorageConnector - getLogs', () => {
 
     expect(sentUrl().searchParams.get('trace_id')).toBe('eq.ses_1');
   });
+
+  it('lists the logs that have no evaluation run yet', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    await supabaseLogsStorageConnector.getLogs(mockContext, {
+      unjudged: true,
+    });
+
+    expect(sentUrl().searchParams.get('eval_run_count')).toBe('eq.0');
+  });
 });

--- a/packages/api/src/connectors/supabase/supabase.ts
+++ b/packages/api/src/connectors/supabase/supabase.ts
@@ -1427,6 +1427,9 @@ export const supabaseLogsStorageConnector: LogsStorageConnector = {
       postgRESTQuery.offset = queryParams.offset.toString();
     }
 
+    if (queryParams.unjudged) {
+      postgRESTQuery.eval_run_count = 'eq.0';
+    }
     if (queryParams.embedding_not_null) {
       postgRESTQuery.embedding = 'not.is.null';
     }

--- a/packages/api/src/middlewares/optimizer/early-regeneration-create.test.ts
+++ b/packages/api/src/middlewares/optimizer/early-regeneration-create.test.ts
@@ -8,6 +8,7 @@ import type {
   LogsStorageConnector,
   UserDataStorageConnector,
 } from '@api/types/connector';
+import { judgeLogsWithoutRuns } from '@api/utils/super-agents/judge-backlog';
 import { FunctionName } from '@shared/types/api/request';
 import type { Skill } from '@shared/types/data';
 import type { Log } from '@shared/types/data/log';
@@ -39,6 +40,9 @@ vi.mock('@api/optimization/utils/evaluations', async (importOriginal) => ({
   regenerateEvaluationsWithExamples: vi.fn(),
 }));
 vi.mock('@api/utils/sse-event-manager', () => ({ emitSSEEvent: vi.fn() }));
+vi.mock('@api/utils/super-agents/judge-backlog', () => ({
+  judgeLogsWithoutRuns: vi.fn().mockResolvedValue(0),
+}));
 vi.mock('@api/optimization/utils/describe-skill', () => ({
   repairSkillNaming: vi.fn().mockResolvedValue(null),
 }));
@@ -197,6 +201,21 @@ describe('checkAndRegenerateEvaluationsEarly, past the guards', () => {
         }),
       );
     }
+    // Every request so far was answered against no evaluations: judged now
+    expect(judgeLogsWithoutRuns).toHaveBeenCalledWith(
+      mockContext,
+      userData,
+      logsStore,
+      connectorsMap,
+      skill,
+      [
+        expect.objectContaining({ id: 'made-0', evaluation_method: 'latency' }),
+        expect.objectContaining({
+          id: 'made-1',
+          evaluation_method: 'task_completion',
+        }),
+      ],
+    );
     // And the pass completed: the one-shot flag is set with the lock released.
     expect(userData.updateSkill).toHaveBeenLastCalledWith(
       mockContext,
@@ -225,6 +244,7 @@ describe('checkAndRegenerateEvaluationsEarly, past the guards', () => {
       { params: {}, weight: 1 },
     );
     expect(userData.createSkillOptimizationEvaluations).not.toHaveBeenCalled();
+    expect(judgeLogsWithoutRuns).not.toHaveBeenCalled();
     expect(console.error).not.toHaveBeenCalled();
   });
 

--- a/packages/api/src/middlewares/optimizer/evaluations.ts
+++ b/packages/api/src/middlewares/optimizer/evaluations.ts
@@ -12,6 +12,7 @@ import type {
 } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { emitSSEEvent } from '@api/utils/sse-event-manager';
+import { judgeLogsWithoutRuns } from '@api/utils/super-agents/judge-backlog';
 import { FunctionName } from '@shared/types/api/request';
 import type {
   Skill,
@@ -271,6 +272,15 @@ export async function checkAndRegenerateEvaluationsEarly(
           metadata: { evaluation_method: evaluation.evaluation_method },
         });
       }
+      // Every request so far was answered against no evaluations
+      await judgeLogsWithoutRuns(
+        c,
+        userDataStorageConnector,
+        logsStorageConnector,
+        evaluationConnectorsMap,
+        skill,
+        createdEvaluations,
+      );
     }
 
     // Update all arms in-place with new system prompts

--- a/packages/api/src/utils/super-agents/judge-backlog.test.ts
+++ b/packages/api/src/utils/super-agents/judge-backlog.test.ts
@@ -1,0 +1,178 @@
+import type {
+  EvaluationMethodConnector,
+  LogsStorageConnector,
+  UserDataStorageConnector,
+} from '@api/types/connector';
+import type { AppContext } from '@api/types/hono';
+import { runEvaluationsForLog } from '@api/utils/realtime-evaluations';
+import { emitSSEEvent } from '@api/utils/sse-event-manager';
+import { judgeLogsWithoutRuns } from '@api/utils/super-agents/judge-backlog';
+import type {
+  Log,
+  Skill,
+  SkillOptimizationEvaluation,
+} from '@shared/types/data';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@api/utils/realtime-evaluations', () => ({
+  runEvaluationsForLog: vi.fn(),
+}));
+vi.mock('@api/utils/sse-event-manager', () => ({ emitSSEEvent: vi.fn() }));
+
+const c = {} as AppContext;
+const skill = { id: 'skill-1', name: 'answer-questions' } as Skill;
+const connectorsMap = { latency: {} as EvaluationMethodConnector };
+
+// The evaluations landed at 12:00:10
+const evaluations = [
+  { id: 'e1', created_at: '2026-03-01T12:00:10.000Z' },
+  { id: 'e2', created_at: '2026-03-01T12:00:10.050Z' },
+] as SkillOptimizationEvaluation[];
+
+const at = (iso: string): number => Date.parse(iso);
+const log = (id: string, start: string, duration: number): Log =>
+  ({
+    id,
+    agent_id: 'agent-1',
+    skill_id: 'skill-1',
+    cluster_id: 'cluster-1',
+    status: 200,
+    start_time: at(start),
+    duration,
+  }) as Log;
+
+// Answered before the evaluations existed; answered before, but judged by
+// its own path in the meantime; still running when they landed
+const skipped = log('skipped', '2026-03-01T11:59:50.000Z', 10_000);
+const raced = log('raced', '2026-03-01T11:59:55.000Z', 1_000);
+const later = log('later', '2026-03-01T12:00:09.900Z', 500);
+
+const result = { evaluation_id: 'e1', method: 'latency', score: 1 };
+
+const setup = (): {
+  userData: UserDataStorageConnector;
+  logsStore: LogsStorageConnector;
+} => ({
+  userData: {
+    getSkillOptimizationEvaluationRuns: vi
+      .fn()
+      .mockImplementation((_c, { log_id }: { log_id: string }) =>
+        Promise.resolve(log_id === 'raced' ? [{ id: 'run-raced' }] : []),
+      ),
+    createSkillOptimizationEvaluationRun: vi
+      .fn()
+      .mockImplementation((_c, params) =>
+        Promise.resolve({ id: 'run-new', ...params }),
+      ),
+  } as unknown as UserDataStorageConnector,
+  logsStore: {
+    getLogs: vi.fn().mockResolvedValue([skipped, raced, later]),
+  } as unknown as LogsStorageConnector,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(runEvaluationsForLog).mockResolvedValue([result] as never);
+});
+
+describe('judgeLogsWithoutRuns', () => {
+  it('judges the requests answered before the evaluations existed, storing a run once', async () => {
+    const { userData, logsStore } = setup();
+
+    const judged = await judgeLogsWithoutRuns(
+      c,
+      userData,
+      logsStore,
+      connectorsMap,
+      skill,
+      evaluations,
+    );
+
+    expect(logsStore.getLogs).toHaveBeenCalledWith(c, {
+      skill_id: 'skill-1',
+      status: 200,
+      unjudged: true,
+      order: 'asc',
+      limit: 50,
+    });
+    // The request still running when they landed finds them on its own
+    const judgedIds = vi
+      .mocked(runEvaluationsForLog)
+      .mock.calls.map(([, judgedLog]) => judgedLog.id);
+    expect(judgedIds).toEqual(['skipped', 'raced']);
+    // The one its own path judged meanwhile is not stored twice
+    expect(userData.createSkillOptimizationEvaluationRun).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(userData.createSkillOptimizationEvaluationRun).toHaveBeenCalledWith(
+      c,
+      {
+        agent_id: 'agent-1',
+        skill_id: 'skill-1',
+        cluster_id: 'cluster-1',
+        log_id: 'skipped',
+        results: [result],
+      },
+    );
+    expect(emitSSEEvent).toHaveBeenCalledWith(
+      'skill-optimization:evaluation-run-created',
+      expect.objectContaining({ logId: 'skipped', skillId: 'skill-1' }),
+    );
+    expect(judged).toBe(1);
+  });
+
+  it('stores nothing for a log the judges produced no result for', async () => {
+    const { userData, logsStore } = setup();
+    vi.mocked(runEvaluationsForLog).mockResolvedValue([]);
+
+    const judged = await judgeLogsWithoutRuns(
+      c,
+      userData,
+      logsStore,
+      connectorsMap,
+      skill,
+      evaluations,
+    );
+
+    expect(
+      userData.createSkillOptimizationEvaluationRun,
+    ).not.toHaveBeenCalled();
+    expect(judged).toBe(0);
+  });
+
+  it('does nothing without a logs store, judges, or evaluations', async () => {
+    const { userData, logsStore } = setup();
+
+    expect(
+      await judgeLogsWithoutRuns(
+        c,
+        userData,
+        undefined,
+        connectorsMap,
+        skill,
+        evaluations,
+      ),
+    ).toBe(0);
+    expect(
+      await judgeLogsWithoutRuns(
+        c,
+        userData,
+        logsStore,
+        undefined,
+        skill,
+        evaluations,
+      ),
+    ).toBe(0);
+    expect(
+      await judgeLogsWithoutRuns(
+        c,
+        userData,
+        logsStore,
+        connectorsMap,
+        skill,
+        [],
+      ),
+    ).toBe(0);
+    expect(logsStore.getLogs).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/utils/super-agents/judge-backlog.ts
+++ b/packages/api/src/utils/super-agents/judge-backlog.ts
@@ -1,0 +1,106 @@
+import type {
+  EvaluationMethodConnector,
+  LogsStorageConnector,
+  UserDataStorageConnector,
+} from '@api/types/connector';
+import type { AppContext } from '@api/types/hono';
+import { runEvaluationsForLog } from '@api/utils/realtime-evaluations';
+import { emitSSEEvent } from '@api/utils/sse-event-manager';
+import { info } from '@shared/console-logging';
+import type { Skill, SkillOptimizationEvaluation } from '@shared/types/data';
+import type { EvaluationMethodName } from '@shared/types/evaluations';
+
+/** How many skipped requests one pass will judge */
+const BACKLOG_LIMIT = 50;
+
+/**
+ * Judge the logs of a skill that have no evaluation run: the requests that
+ * were answered while its evaluations were still being generated.
+ *
+ * A request is judged right after its response, against the evaluations
+ * the skill has at that moment. A skill the gateway creates gets its
+ * evaluations from a model call that runs behind the request that created
+ * it and can take tens of seconds, so that request -- and every request
+ * answered before the call returns -- was judged against nothing, and
+ * nothing came back for it. Called once the evaluations are stored, this
+ * judges those, and the same when the early pass creates them for a skill
+ * whose creation-time generation had failed.
+ *
+ * Only logs that ended before the evaluations existed are taken: one that
+ * ended after finds them on its own path. A log is checked for a run once
+ * more before its own is stored, for the request that ended a moment before
+ * the evaluations and looked them up a moment after: both paths may judge
+ * it, only one may store.
+ */
+export async function judgeLogsWithoutRuns(
+  c: AppContext,
+  connector: UserDataStorageConnector,
+  logsConnector: LogsStorageConnector | undefined,
+  evaluationConnectorsMap:
+    | Partial<Record<EvaluationMethodName, EvaluationMethodConnector>>
+    | undefined,
+  skill: Skill,
+  evaluations: SkillOptimizationEvaluation[],
+): Promise<number> {
+  if (!logsConnector || !evaluationConnectorsMap || evaluations.length === 0) {
+    return 0;
+  }
+
+  const createdAt = Math.min(
+    ...evaluations.map((evaluation) => Date.parse(evaluation.created_at)),
+  );
+  const cutoff = Number.isFinite(createdAt) ? createdAt : Date.now();
+
+  const backlog = (
+    await logsConnector.getLogs(c, {
+      skill_id: skill.id,
+      status: 200,
+      unjudged: true,
+      order: 'asc',
+      limit: BACKLOG_LIMIT,
+    })
+  ).filter((log) => log.start_time + log.duration < cutoff);
+
+  let judged = 0;
+  for (const log of backlog) {
+    const results = await runEvaluationsForLog(
+      c,
+      log,
+      evaluations,
+      evaluationConnectorsMap,
+      connector,
+    );
+    if (results.length === 0) continue;
+
+    const runs = await connector.getSkillOptimizationEvaluationRuns(c, {
+      log_id: log.id,
+    });
+    if (runs.length > 0) continue;
+
+    const evaluationRun = await connector.createSkillOptimizationEvaluationRun(
+      c,
+      {
+        agent_id: log.agent_id,
+        skill_id: log.skill_id,
+        cluster_id: log.cluster_id ?? null,
+        log_id: log.id,
+        results,
+      },
+    );
+    emitSSEEvent('skill-optimization:evaluation-run-created', {
+      evaluationRun,
+      agentId: log.agent_id,
+      skillId: log.skill_id,
+      clusterId: log.cluster_id ?? null,
+      logId: log.id,
+    });
+    judged += 1;
+  }
+
+  if (judged > 0) {
+    info(
+      `[JUDGE_BACKLOG] Judged ${judged} request(s) of skill ${skill.name} answered before it had evaluations`,
+    );
+  }
+  return judged;
+}

--- a/packages/api/src/utils/super-agents/skill-creation.test.ts
+++ b/packages/api/src/utils/super-agents/skill-creation.test.ts
@@ -4,6 +4,7 @@ import { generateEvaluationCreateParams } from '@api/optimization/utils/evaluati
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { resolveEmbeddingModelConfig } from '@api/utils/evaluation-model-resolver';
+import { judgeLogsWithoutRuns } from '@api/utils/super-agents/judge-backlog';
 import {
   adoptDefaultModels,
   createSkillForRequest,
@@ -30,6 +31,9 @@ vi.mock('@api/utils/evaluation-model-resolver', () => ({
   resolveEmbeddingModelConfig: vi.fn(),
 }));
 vi.mock('@api/utils/sse-event-manager', () => ({ emitSSEEvent: vi.fn() }));
+vi.mock('@api/utils/super-agents/judge-backlog', () => ({
+  judgeLogsWithoutRuns: vi.fn().mockResolvedValue(0),
+}));
 
 const c = {
   get: (key: string) => (key === 'evaluation_connectors_map' ? {} : undefined),
@@ -337,6 +341,17 @@ describe('adoptDefaultModels', () => {
         .map((params) => params.evaluation_method)
         .sort(),
     ).toEqual(['latency', 'task_completion']);
+    // The requests answered while that ran are judged against what it made
+    await vi.waitFor(() => {
+      expect(judgeLogsWithoutRuns).toHaveBeenCalledWith(
+        cWithMethods,
+        connector,
+        undefined,
+        { latency: {}, task_completion: {} },
+        expect.objectContaining({ id: 'bare' }),
+        created,
+      );
+    });
   });
 
   it('leaves evaluations alone when the skill already has them', async () => {

--- a/packages/api/src/utils/super-agents/skill-creation.ts
+++ b/packages/api/src/utils/super-agents/skill-creation.ts
@@ -13,6 +13,7 @@ import { resolveEmbeddingModelConfig } from '@api/utils/evaluation-model-resolve
 import { getInitialClusterCentroids } from '@api/utils/math';
 import { emitSSEEvent } from '@api/utils/sse-event-manager';
 import type { RequestIntentEmbedding } from '@api/utils/super-agents/intent-embeddings';
+import { judgeLogsWithoutRuns } from '@api/utils/super-agents/judge-backlog';
 import { error, info, warn } from '@shared/console-logging';
 import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
 import type { Agent, Skill } from '@shared/types/data';
@@ -58,8 +59,8 @@ export async function createInitialClusters(
 
 /**
  * Generates the skill's evaluations with every method the server has. Each
- * is a model call, so this runs after the request that created the skill has
- * been answered; the first few logs go unscored.
+ * is a model call, so this runs behind the request that created the skill;
+ * the requests answered before it returns are judged once it has.
  */
 async function generateEvaluations(
   c: AppContext,
@@ -105,6 +106,15 @@ async function generateEvaluations(
       metadata: { evaluation_method: evaluation.evaluation_method },
     });
   }
+
+  await judgeLogsWithoutRuns(
+    c,
+    connector,
+    c.get('logs_storage_connector'),
+    connectorsMap,
+    skill,
+    created,
+  );
 }
 
 /**

--- a/packages/shared/src/types/data/log.ts
+++ b/packages/shared/src/types/data/log.ts
@@ -132,6 +132,8 @@ export const LogsQueryParams = z.object({
     .optional(),
   cache_status: z.enum(CacheStatus).optional(),
   embedding_not_null: z.coerce.boolean().optional(),
+  /** Only logs with no evaluation run yet. */
+  unjudged: z.coerce.boolean().optional(),
   /** By `start_time`; newest first unless asked for `asc`. */
   order: z.enum(['asc', 'desc']).optional(),
   limit: z.string().default('50').transform(Number).optional(),


### PR DESCRIPTION
## Problem

A request is judged right after its response, against the evaluations its skill has at that moment. A skill the gateway auto-creates gets its evaluations from a model call that runs behind the request that created it, and that call can take tens of seconds. Every request answered before it returns finds no evaluations, records no run, and nothing ever comes back for it.

On a dev database: skill created at 10:43:42 PM, evaluations stored at 10:44:06, two requests finished in between (one of them 170 ms before the evaluations landed). Both are permanently unscored, while every request from 10:44:06 on has a score. The early-regeneration pass rewrites the evaluations later but doesn't re-judge, and the thumbs re-judge only fires on feedback.

## Solution

`judgeLogsWithoutRuns` (`utils/super-agents/judge-backlog.ts`): once a skill's evaluations are stored, judge its logs that have no evaluation run yet, oldest first, up to 50. It runs at the end of creation's background generation, and in the early-regeneration pass when it creates the evaluations for an auto-created skill whose creation-time generation had failed. Each backfilled run is stored like a feedback re-judge (the log's cluster, no arm stats) and announced over SSE so an open log page updates.

Two guards against double judging, since the normal path and this one can overlap by milliseconds:
- only logs that **ended before the evaluations were created** are taken; a log that ended after finds the evaluations on its own path;
- each log is **checked for a run again just before its own is stored**, for the request that ended a moment before the evaluations and looked them up a moment after.

The logs query gains `unjudged` (no evaluation run yet) on both backends, read off the `eval_run_count` the score view already computes.

## Tests

- `judge-backlog.test.ts`: the request answered before the evaluations is judged and stored; the one its own path judged meanwhile is judged but not stored twice; the one still running when the evaluations landed is left to its own path; a log with no judge results stores nothing; a missing logs store, judges or evaluations is a no-op.
- Connector tests for `unjudged` on libSQL (real temp database) and Supabase (query string).
- Creation and early-regeneration tests assert the pass runs with the evaluations just created, and not when evaluations were only rewritten in place.
- `pnpm check`, `pnpm typecheck` and the full `pnpm test` (184 files) pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7nkpUM1RjfcuHjy8E8MFR
