### PR TITLE
feat(web): show trace id with a deterministic pale color in logs table

### DIFF
--- a/packages/web/src/components/agents/logs-table-view.tsx
+++ b/packages/web/src/components/agents/logs-table-view.tsx
@@ -44,6 +44,7 @@ import {
   TooltipTrigger,
 } from '@web/components/ui/tooltip';
 import { useLogs } from '@web/providers/logs';
+import { getStringHashColor } from '@web/utils/http-method-colors';
 import { formatLogTimestamp } from '@web/utils/time';
 import {
   CalendarIcon,
@@ -234,6 +235,7 @@ export function LogsTableView({
                     <TableHead>Function</TableHead>
                     <TableHead>Endpoint</TableHead>
                     <TableHead>Model</TableHead>
+                    <TableHead>Trace ID</TableHead>
                     <TableHead>{extraColumn.header}</TableHead>
                     <TableHead>Temp</TableHead>
                     <TableHead>Reasoning</TableHead>
@@ -289,6 +291,20 @@ export function LogsTableView({
                         </TableCell>
                         <TableCell>
                           <span className="text-xs">{log.model}</span>
+                        </TableCell>
+                        <TableCell>
+                          {log.trace_id ? (
+                            <Badge
+                              variant="outline"
+                              className={`font-mono text-xs ${getStringHashColor(log.trace_id)}`}
+                            >
+                              {log.trace_id}
+                            </Badge>
+                          ) : (
+                            <span className="text-muted-foreground text-xs">
+                              —
+                            </span>
+                          )}
                         </TableCell>
                         <TableCell>{extraColumn.render(log)}</TableCell>
                         <TableCell>

--- a/packages/web/src/utils/http-method-colors.ts
+++ b/packages/web/src/utils/http-method-colors.ts
@@ -21,3 +21,32 @@ export const getHttpMethodColor = (method?: string): string => {
       return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
   }
 };
+
+/**
+ * Deterministic pale color for a given string (e.g. trace IDs).
+ * Hashes the string and picks from a palette of pale background /
+ * dark text pairs, with dark-mode variants, so identical IDs always
+ * get the same color and different IDs are easy to tell apart.
+ */
+const TRACE_COLOR_CLASSES = [
+  'bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-200',
+  'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200',
+  'bg-lime-100 text-lime-800 dark:bg-lime-950 dark:text-lime-200',
+  'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200',
+  'bg-cyan-100 text-cyan-800 dark:bg-cyan-950 dark:text-cyan-200',
+  'bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-200',
+  'bg-violet-100 text-violet-800 dark:bg-violet-950 dark:text-violet-200',
+  'bg-fuchsia-100 text-fuchsia-800 dark:bg-fuchsia-950 dark:text-fuchsia-200',
+] as const;
+
+export const getStringHashColor = (value?: string | null): string => {
+  if (!value) {
+    return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
+  }
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) | 0;
+  }
+  const index = Math.abs(hash) % TRACE_COLOR_CLASSES.length;
+  return TRACE_COLOR_CLASSES[index];
+};


### PR DESCRIPTION
Adds a Trace ID column to the logs table in the web dashboard. 

- Uses a deterministic hashing function to assign a pale background color to each trace ID, making it easy to visually group logs from the same session.
- Supports dark mode with appropriate color variants.
- Renders as a badge for better visibility.