### PR TITLE
feat(web): breadcrumbs that navigate, with avatars for partitions and configurations

### DIFF
--- a/packages/web/src/components/agents/agent-logs-view.tsx
+++ b/packages/web/src/components/agents/agent-logs-view.tsx
@@ -17,7 +17,7 @@ import { useLogs } from '@web/providers/logs';
 import { useNavigation } from '@web/providers/navigation';
 import { useSkillOptimizationClusters } from '@web/providers/skill-optimization-clusters';
 import { useSkills } from '@web/providers/skills';
-import { createSkillAvatar } from '@web/utils/skill-avatar';
+import { createSkillAvatar } from '@web/utils/avatars';
 import { LayersIcon } from 'lucide-react';
 import type { ReactElement } from 'react';
 import { useEffect } from 'react';

--- a/packages/web/src/components/agents/agent-view.tsx
+++ b/packages/web/src/components/agents/agent-view.tsx
@@ -46,7 +46,7 @@ import { usePermissiveNavigate } from '@web/hooks/use-permissive-navigate';
 import { useAgents } from '@web/providers/agents';
 import { useNavigation } from '@web/providers/navigation';
 import { useSkills } from '@web/providers/skills';
-import { createSkillAvatar } from '@web/utils/skill-avatar';
+import { createSkillAvatar } from '@web/utils/avatars';
 import {
   BarChart3Icon,
   Clock,

--- a/packages/web/src/components/agents/skills/clusters/cluster-arms-view.tsx
+++ b/packages/web/src/components/agents/skills/clusters/cluster-arms-view.tsx
@@ -42,10 +42,12 @@ import { useSkillOptimizationArms } from '@web/providers/skill-optimization-arms
 import { useSkillOptimizationClusters } from '@web/providers/skill-optimization-clusters';
 import { useSkillOptimizationEvaluations } from '@web/providers/skill-optimization-evaluations';
 import { useSkills } from '@web/providers/skills';
+import { createArmAvatar, createClusterAvatar } from '@web/utils/avatars';
 import {
   ArrowUpDown,
   BoxIcon,
   Clock,
+  LayersIcon,
   MoreVertical,
   PaletteIcon,
   RefreshCwIcon,
@@ -511,7 +513,20 @@ export function ClusterArmsView(): ReactElement {
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <BoxIcon className="h-5 w-5" />
+                {selectedSkill ? (
+                  <img
+                    src={createClusterAvatar(
+                      selectedSkill.name,
+                      selectedCluster.name,
+                    )}
+                    alt={`Partition ${selectedCluster.name} icon`}
+                    width={20}
+                    height={20}
+                    className="size-5 rounded-sm shrink-0"
+                  />
+                ) : (
+                  <LayersIcon className="h-5 w-5" />
+                )}
                 Partition Information
               </CardTitle>
               <CardDescription>
@@ -786,7 +801,20 @@ export function ClusterArmsView(): ReactElement {
                     }
                   >
                     <CardHeader>
-                      <CardTitle className="text-lg leading-none mb-2">
+                      <CardTitle className="text-lg leading-none mb-2 flex items-center gap-2">
+                        {selectedSkill && selectedCluster && (
+                          <img
+                            src={createArmAvatar(
+                              selectedSkill.name,
+                              selectedCluster.name,
+                              arm.name,
+                            )}
+                            alt={`Configuration ${arm.name} icon`}
+                            width={24}
+                            height={24}
+                            className="size-6 rounded-sm shrink-0"
+                          />
+                        )}
                         {arm.name}
                       </CardTitle>
                       <CardDescription className="leading-none m-0">

--- a/packages/web/src/components/agents/skills/logs/log-details-view.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-details-view.tsx
@@ -26,7 +26,7 @@ import { useNavigation } from '@web/providers/navigation';
 import { useSkillOptimizationClusters } from '@web/providers/skill-optimization-clusters';
 import { useSkillOptimizationEvaluationRuns } from '@web/providers/skill-optimization-evaluation-runs';
 import { useSkills } from '@web/providers/skills';
-import { createSkillAvatar } from '@web/utils/skill-avatar';
+import { createSkillAvatar } from '@web/utils/avatars';
 import {
   describeSkillRouting,
   readSkillRouting,

--- a/packages/web/src/components/agents/skills/skill-dashboard-view.tsx
+++ b/packages/web/src/components/agents/skills/skill-dashboard-view.tsx
@@ -53,7 +53,7 @@ import { useNavigation } from '@web/providers/navigation';
 import { useSkillEvents } from '@web/providers/skill-events';
 import { useSkillOptimizationClusters } from '@web/providers/skill-optimization-clusters';
 import { useSkills } from '@web/providers/skills';
-import { createSkillAvatar } from '@web/utils/skill-avatar';
+import { createClusterAvatar, createSkillAvatar } from '@web/utils/avatars';
 import {
   AlertCircle,
   CalendarIcon,
@@ -624,7 +624,17 @@ export function SkillDashboardView(): ReactElement {
                   }
                 >
                   <CardHeader className="pb-2">
-                    <CardTitle className="text-lg leading-none mb-2">
+                    <CardTitle className="text-lg leading-none mb-2 flex items-center gap-2">
+                      <img
+                        src={createClusterAvatar(
+                          selectedSkill.name,
+                          cluster.name,
+                        )}
+                        alt={`Partition ${cluster.name} icon`}
+                        width={24}
+                        height={24}
+                        className="size-6 rounded-sm shrink-0"
+                      />
                       {cluster.name}
                     </CardTitle>
                   </CardHeader>

--- a/packages/web/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/web/src/components/breadcrumb/breadcrumb.tsx
@@ -22,8 +22,8 @@ import {
 } from '@web/components/ui/command';
 import {
   Popover,
+  PopoverAnchor,
   PopoverContent,
-  PopoverTrigger,
 } from '@web/components/ui/popover';
 import { useModifierKey } from '@web/hooks/use-keyboard-shortcuts';
 import { usePermissiveNavigate } from '@web/hooks/use-permissive-navigate';
@@ -33,8 +33,20 @@ import { useNavigation } from '@web/providers/navigation';
 import { useSkillOptimizationArms } from '@web/providers/skill-optimization-arms';
 import { useSkillOptimizationClusters } from '@web/providers/skill-optimization-clusters';
 import { useSkills } from '@web/providers/skills';
-import { createSkillAvatar } from '@web/utils/skill-avatar';
-import { Bot, ChevronRight, Plus, PlusCircleIcon } from 'lucide-react';
+import {
+  createArmAvatar,
+  createClusterAvatar,
+  createSkillAvatar,
+} from '@web/utils/avatars';
+import { cn } from '@web/utils/ui/utils';
+import {
+  Bot,
+  BoxIcon,
+  ChevronRight,
+  LayersIcon,
+  Plus,
+  PlusCircleIcon,
+} from 'lucide-react';
 import React, { type ReactElement, useMemo } from 'react';
 
 // ============================================================================
@@ -137,11 +149,20 @@ function AgentCombobox<T extends { id: string; name: string }>({
   return (
     <BreadcrumbItem>
       <Popover open={comboboxOpen} onOpenChange={setComboboxOpen}>
-        <PopoverTrigger asChild>
+        <PopoverAnchor asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-sidebar-accent hover:text-sidebar-accent-foreground data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            className={cn(
+              'h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+              comboboxOpen &&
+                'bg-sidebar-accent text-sidebar-accent-foreground',
+            )}
+            onClick={() => onAgentSelect(activeAgent)}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              setComboboxOpen(true);
+            }}
           >
             <img
               src={agentAvatars.get(activeAgent.name) || ''}
@@ -152,7 +173,7 @@ function AgentCombobox<T extends { id: string; name: string }>({
             />
             <span className="truncate font-medium">{activeAgent.name}</span>
           </Button>
-        </PopoverTrigger>
+        </PopoverAnchor>
         <PopoverContent
           className="w-[300px] p-0"
           align="start"
@@ -315,11 +336,20 @@ function SkillCombobox<T extends { id: string; name: string }>({
   return (
     <BreadcrumbItem>
       <Popover open={comboboxOpen} onOpenChange={setComboboxOpen}>
-        <PopoverTrigger asChild>
+        <PopoverAnchor asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-sidebar-accent hover:text-sidebar-accent-foreground data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            className={cn(
+              'h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+              comboboxOpen &&
+                'bg-sidebar-accent text-sidebar-accent-foreground',
+            )}
+            onClick={() => onSkillSelect(activeSkill)}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              setComboboxOpen(true);
+            }}
           >
             <img
               src={skillAvatars.get(activeSkill.name) || ''}
@@ -330,7 +360,7 @@ function SkillCombobox<T extends { id: string; name: string }>({
             />
             <span className="truncate font-medium">{activeSkill.name}</span>
           </Button>
-        </PopoverTrigger>
+        </PopoverAnchor>
         <PopoverContent
           className="w-[300px] p-0"
           align="start"
@@ -464,6 +494,25 @@ function ClusterDropdownBreadcrumb(): ReactElement {
   const { selectedSkill } = useSkills();
   const [comboboxOpen, setComboboxOpen] = React.useState(false);
 
+  const clusterAvatars = useMemo(() => {
+    const avatars = new Map<string, string>();
+    if (!selectedSkill) {
+      return avatars;
+    }
+    for (const cluster of [
+      ...(selectedCluster ? [selectedCluster] : []),
+      ...clusters,
+    ]) {
+      if (!avatars.has(cluster.name)) {
+        avatars.set(
+          cluster.name,
+          createClusterAvatar(selectedSkill.name, cluster.name),
+        );
+      }
+    }
+    return avatars;
+  }, [clusters, selectedCluster, selectedSkill]);
+
   const handleClusterSelect = (cluster: (typeof clusters)[0]) => {
     if (selectedAgent && selectedSkill) {
       navigateToClusterArms(
@@ -484,7 +533,7 @@ function ClusterDropdownBreadcrumb(): ReactElement {
           disabled
           className="h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-transparent"
         >
-          <Bot className="size-5" />
+          <LayersIcon className="size-5" />
           <span className="truncate font-medium">No partitions</span>
         </Button>
       </BreadcrumbItem>
@@ -502,7 +551,7 @@ function ClusterDropdownBreadcrumb(): ReactElement {
           disabled
           className="h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-transparent"
         >
-          <Bot className="size-5" />
+          <LayersIcon className="size-5" />
           <span className="truncate font-medium">Loading...</span>
         </Button>
       </BreadcrumbItem>
@@ -512,16 +561,31 @@ function ClusterDropdownBreadcrumb(): ReactElement {
   return (
     <BreadcrumbItem>
       <Popover open={comboboxOpen} onOpenChange={setComboboxOpen}>
-        <PopoverTrigger asChild>
+        <PopoverAnchor asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-sidebar-accent hover:text-sidebar-accent-foreground data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            className={cn(
+              'h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+              comboboxOpen &&
+                'bg-sidebar-accent text-sidebar-accent-foreground',
+            )}
+            onClick={() => handleClusterSelect(activeCluster)}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              setComboboxOpen(true);
+            }}
           >
-            <Bot className="size-5" />
+            <img
+              src={clusterAvatars.get(activeCluster.name) || ''}
+              alt={`Partition ${activeCluster.name} icon`}
+              width={20}
+              height={20}
+              className="size-5 rounded-sm shrink-0"
+            />
             <span className="truncate font-medium">{activeCluster.name}</span>
           </Button>
-        </PopoverTrigger>
+        </PopoverAnchor>
         <PopoverContent
           className="w-[300px] p-0"
           align="start"
@@ -538,7 +602,15 @@ function ClusterDropdownBreadcrumb(): ReactElement {
                     key={cluster.id}
                     value={cluster.name}
                     onSelect={() => handleClusterSelect(cluster)}
+                    className="gap-2"
                   >
+                    <img
+                      src={clusterAvatars.get(cluster.name) || ''}
+                      alt={`Partition ${cluster.name} icon`}
+                      width={20}
+                      height={20}
+                      className="size-5 rounded-sm shrink-0"
+                    />
                     <span className="flex-1 truncate">{cluster.name}</span>
                   </CommandItem>
                 ))}
@@ -563,6 +635,22 @@ function ArmDropdownBreadcrumb(): ReactElement {
   const { selectedCluster } = useSkillOptimizationClusters();
   const [comboboxOpen, setComboboxOpen] = React.useState(false);
 
+  const armAvatars = useMemo(() => {
+    const avatars = new Map<string, string>();
+    if (!selectedSkill || !selectedCluster) {
+      return avatars;
+    }
+    for (const arm of [...(selectedArm ? [selectedArm] : []), ...arms]) {
+      if (!avatars.has(arm.name)) {
+        avatars.set(
+          arm.name,
+          createArmAvatar(selectedSkill.name, selectedCluster.name, arm.name),
+        );
+      }
+    }
+    return avatars;
+  }, [arms, selectedArm, selectedSkill, selectedCluster]);
+
   const handleArmSelect = (arm: (typeof arms)[0]) => {
     if (selectedAgent && selectedSkill && selectedCluster) {
       navigateToArmDetail(
@@ -584,7 +672,7 @@ function ArmDropdownBreadcrumb(): ReactElement {
           disabled
           className="h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-transparent"
         >
-          <Bot className="size-5" />
+          <BoxIcon className="size-5" />
           <span className="truncate font-medium">No configurations</span>
         </Button>
       </BreadcrumbItem>
@@ -602,7 +690,7 @@ function ArmDropdownBreadcrumb(): ReactElement {
           disabled
           className="h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-transparent"
         >
-          <Bot className="size-5" />
+          <BoxIcon className="size-5" />
           <span className="truncate font-medium">Loading...</span>
         </Button>
       </BreadcrumbItem>
@@ -612,16 +700,31 @@ function ArmDropdownBreadcrumb(): ReactElement {
   return (
     <BreadcrumbItem>
       <Popover open={comboboxOpen} onOpenChange={setComboboxOpen}>
-        <PopoverTrigger asChild>
+        <PopoverAnchor asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-sidebar-accent hover:text-sidebar-accent-foreground data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            className={cn(
+              'h-8 py-1 px-2 gap-2 justify-start bg-transparent hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+              comboboxOpen &&
+                'bg-sidebar-accent text-sidebar-accent-foreground',
+            )}
+            onClick={() => handleArmSelect(activeArm)}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              setComboboxOpen(true);
+            }}
           >
-            <Bot className="size-5" />
+            <img
+              src={armAvatars.get(activeArm.name) || ''}
+              alt={`Configuration ${activeArm.name} icon`}
+              width={20}
+              height={20}
+              className="size-5 rounded-sm shrink-0"
+            />
             <span className="truncate font-medium">{activeArm.name}</span>
           </Button>
-        </PopoverTrigger>
+        </PopoverAnchor>
         <PopoverContent
           className="w-[300px] p-0"
           align="start"
@@ -641,7 +744,15 @@ function ArmDropdownBreadcrumb(): ReactElement {
                     key={arm.id}
                     value={arm.name}
                     onSelect={() => handleArmSelect(arm)}
+                    className="gap-2"
                   >
+                    <img
+                      src={armAvatars.get(arm.name) || ''}
+                      alt={`Configuration ${arm.name} icon`}
+                      width={20}
+                      height={20}
+                      className="size-5 rounded-sm shrink-0"
+                    />
                     <span className="flex-1 truncate">{arm.name}</span>
                   </CommandItem>
                 ))}

--- a/packages/web/src/components/ui/popover.tsx
+++ b/packages/web/src/components/ui/popover.tsx
@@ -8,6 +8,8 @@ const Popover = PopoverPrimitive.Root;
 
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
 const PopoverContent = React.forwardRef<
   React.ComponentRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
@@ -27,4 +29,4 @@ const PopoverContent = React.forwardRef<
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverContent, PopoverTrigger };
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/packages/web/src/providers/navigation/index.tsx
+++ b/packages/web/src/providers/navigation/index.tsx
@@ -282,19 +282,6 @@ export function NavigationProvider({
         });
       }
 
-      // Add Skills breadcrumb if we're on a skill route
-      if (
-        newState.selectedAgentName &&
-        (newState.selectedSkillName ||
-          currentView === 'agent-view' ||
-          currentView === 'create-skill')
-      ) {
-        breadcrumbs.push({
-          label: 'Skills',
-          path: `/agents/${encodeURIComponent(newState.selectedAgentName)}`,
-        });
-      }
-
       if (newState.selectedAgentName && newState.selectedSkillName) {
         breadcrumbs.push({
           label: newState.selectedSkillName,
@@ -320,15 +307,6 @@ export function NavigationProvider({
             label: 'Datasets',
             path: `/agents/${encodeURIComponent(newState.selectedAgentName)}/skills/${encodeURIComponent(newState.selectedSkillName)}/datasets`,
           });
-        } else if (
-          currentView === 'configurations' ||
-          currentView === 'create-configuration' ||
-          currentView === 'edit-configuration'
-        ) {
-          breadcrumbs.push({
-            label: 'Configurations',
-            path: `/agents/${encodeURIComponent(newState.selectedAgentName)}/skills/${encodeURIComponent(newState.selectedSkillName)}/configurations`,
-          });
         } else if (currentView === 'models') {
           breadcrumbs.push({
             label: 'Models',
@@ -339,16 +317,10 @@ export function NavigationProvider({
             label: 'Events',
             path: `/agents/${encodeURIComponent(newState.selectedAgentName)}/skills/${encodeURIComponent(newState.selectedSkillName)}/events`,
           });
-        } else if (currentView === 'clusters') {
-          breadcrumbs.push({
-            label: 'Partitions',
-            path: `/agents/${encodeURIComponent(newState.selectedAgentName)}/skills/${encodeURIComponent(newState.selectedSkillName)}/clusters`,
-          });
-        } else if (currentView === 'cluster-arms') {
-          breadcrumbs.push({
-            label: 'Partitions',
-            path: `/agents/${encodeURIComponent(newState.selectedAgentName)}/skills/${encodeURIComponent(newState.selectedSkillName)}/clusters`,
-          });
+        } else if (
+          currentView === 'cluster-arms' ||
+          currentView === 'arm-detail'
+        ) {
           if (newState.selectedClusterName) {
             breadcrumbs.push({
               label: newState.selectedClusterName,
@@ -356,26 +328,6 @@ export function NavigationProvider({
               isClusterDropdown: true,
             });
           }
-          breadcrumbs.push({
-            label: 'Configurations',
-            path: `/agents/${encodeURIComponent(newState.selectedAgentName)}/skills/${encodeURIComponent(newState.selectedSkillName)}/clusters/${encodeURIComponent(newState.selectedClusterName!)}/configurations`,
-          });
-        } else if (currentView === 'arm-detail') {
-          breadcrumbs.push({
-            label: 'Partitions',
-            path: `/agents/${encodeURIComponent(newState.selectedAgentName)}/skills/${encodeURIComponent(newState.selectedSkillName)}/clusters`,
-          });
-          if (newState.selectedClusterName) {
-            breadcrumbs.push({
-              label: newState.selectedClusterName,
-              path: `/agents/${encodeURIComponent(newState.selectedAgentName)}/skills/${encodeURIComponent(newState.selectedSkillName)}/clusters/${encodeURIComponent(newState.selectedClusterName)}/configurations`,
-              isClusterDropdown: true,
-            });
-          }
-          breadcrumbs.push({
-            label: 'Configurations',
-            path: `/agents/${encodeURIComponent(newState.selectedAgentName)}/skills/${encodeURIComponent(newState.selectedSkillName)}/clusters/${encodeURIComponent(newState.selectedClusterName!)}/configurations`,
-          });
           if (newState.selectedArmName) {
             breadcrumbs.push({
               label: newState.selectedArmName,

--- a/packages/web/src/utils/avatars.test.ts
+++ b/packages/web/src/utils/avatars.test.ts
@@ -1,4 +1,8 @@
-import { createSkillAvatar } from '@web/utils/skill-avatar';
+import {
+  createArmAvatar,
+  createClusterAvatar,
+  createSkillAvatar,
+} from '@web/utils/avatars';
 import { describe, expect, it } from 'vitest';
 
 describe('createSkillAvatar', () => {
@@ -7,5 +11,39 @@ describe('createSkillAvatar', () => {
     expect(avatar).toMatch(/^data:image\/svg\+xml,/);
     expect(createSkillAvatar('answer-simple-questions')).toBe(avatar);
     expect(createSkillAvatar('another-skill')).not.toBe(avatar);
+  });
+});
+
+describe('createClusterAvatar', () => {
+  it('draws the same avatar for the same partition of the same skill', () => {
+    const avatar = createClusterAvatar('answer-simple-questions', '1');
+    expect(avatar).toMatch(/^data:image\/svg\+xml,/);
+    expect(createClusterAvatar('answer-simple-questions', '1')).toBe(avatar);
+    expect(createClusterAvatar('answer-simple-questions', '2')).not.toBe(
+      avatar,
+    );
+  });
+
+  it('tells the first partition of one skill from the first of another', () => {
+    expect(createClusterAvatar('another-skill', '1')).not.toBe(
+      createClusterAvatar('answer-simple-questions', '1'),
+    );
+  });
+});
+
+describe('createArmAvatar', () => {
+  it('draws the same avatar for the same configuration', () => {
+    const avatar = createArmAvatar('answer-simple-questions', '1', '2');
+    expect(avatar).toMatch(/^data:image\/svg\+xml,/);
+    expect(createArmAvatar('answer-simple-questions', '1', '2')).toBe(avatar);
+    expect(createArmAvatar('answer-simple-questions', '1', '3')).not.toBe(
+      avatar,
+    );
+  });
+
+  it('tells configurations of sibling partitions apart', () => {
+    expect(createArmAvatar('answer-simple-questions', '2', '1')).not.toBe(
+      createArmAvatar('answer-simple-questions', '1', '1'),
+    );
   });
 });

--- a/packages/web/src/utils/avatars.ts
+++ b/packages/web/src/utils/avatars.ts
@@ -1,4 +1,4 @@
-import { shapes } from '@dicebear/collection';
+import { identicon, rings, shapes } from '@dicebear/collection';
 import { createAvatar } from '@dicebear/core';
 
 const BACKGROUNDS = [
@@ -23,12 +23,35 @@ const BACKGROUNDS = [
   '3949ab',
 ];
 
-/** A skill's avatar, drawn from its name, as an image URL. */
-export const createSkillAvatar = (skillName: string): string => {
-  const svg = createAvatar(shapes, {
-    seed: skillName,
+type AvatarStyle = Parameters<typeof createAvatar>[0];
+
+const createEntityAvatar = (style: AvatarStyle, seed: string): string => {
+  const svg = createAvatar(style, {
+    seed,
     size: 24,
     backgroundColor: BACKGROUNDS,
   }).toString();
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 };
+
+/** A skill's avatar, drawn from its name, as an image URL. */
+export const createSkillAvatar = (skillName: string): string =>
+  createEntityAvatar(shapes, skillName);
+
+/**
+ * A partition's avatar, as an image URL. Partitions are named `1`, `2`, `3`
+ * within their skill, so the skill's name is part of the seed: without it
+ * every skill's first partition would wear the same face.
+ */
+export const createClusterAvatar = (
+  skillName: string,
+  clusterName: string,
+): string => createEntityAvatar(rings, `${skillName}/${clusterName}`);
+
+/** A configuration's avatar, seeded down the same path as its partition. */
+export const createArmAvatar = (
+  skillName: string,
+  clusterName: string,
+  armName: string,
+): string =>
+  createEntityAvatar(identicon, `${skillName}/${clusterName}/${armName}`);


### PR DESCRIPTION
## Problem

Three things about the breadcrumb, all of them friction:

1. **Clicking a breadcrumb didn't take you there.** The agent, skill, partition and configuration crumbs were popover triggers, so a click opened a picker. To actually visit the thing the crumb names you had to click the static crumb beside it, or pick the already-selected item out of the list.
2. **Those static crumbs were noise.** `Skills` pointed at `/agents/:agent` — exactly where the agent crumb goes. `Partitions` and `Configurations` sat in front of the dropdowns that name the same pages. On a configuration page the trail read `Agents › agent › Skills › skill › Partitions › 2 › Configurations › 3`.
3. **Partitions and configurations shared one generic `Bot` glyph**, next to labels that are bare numbers — two identical robots in a row.

## Solution

**Left click navigates, right click opens the picker.** Each dropdown hangs off a `PopoverAnchor` instead of a `PopoverTrigger`, so the button is free to carry an `onClick` that reuses the same select handler the list items use. `onContextMenu` opens the popover. The open highlight moved from `data-[state=open]` (Radix only sets that on a trigger) to the controlled `comboboxOpen` state.

**The static crumbs are gone**, including the leaf `Partitions` and `Configurations` labels. With them removed the `cluster-arms` and `arm-detail` branches were identical, so they're one branch with the arm crumb still guarded by `selectedArmName`.

| Page | Before | After |
| --- | --- | --- |
| Agent | Agents › **agent** › Skills | Agents › **agent** |
| Skill | Agents › **agent** › Skills › **skill** | Agents › **agent** › **skill** |
| Partition | … › Skills › **skill** › Partitions › **2** › Configurations | … › **skill** › **2** |
| Configuration | …as above… › **3** | … › **skill** › **2** › **3** |

`Evaluations`, `Datasets`, `Models` and `Events` are untouched.

**Partitions and configurations get generated avatars**, the language agents (`bottts`) and skills (`shapes`) already use: `rings` for a partition, `identicon` for a configuration, on the shared palette. Both are named `1`, `2`, `3` *within their parent*, so the seed is the path — `skill/1` for a partition, `skill/1/2` for a configuration. Without that scoping every skill's first partition would wear the same face, and short numeric seeds make `identicon` degenerate into a blank square. They appear in the breadcrumb, in both pickers (previously text-only rows), on the partition cards on the skill dashboard and on the configuration cards on the partition page — all of which were bare numbers.

The `Partition Information` header carried a `BoxIcon`, which elsewhere in the app means *configuration*; it now carries the partition's own avatar. Placeholder states keep semantic icons since there's no name to seed from: `Layers` for partitions, `Box` for configurations, matching the dashboard and arm-detail empty states.

`packages/web/src/utils/skill-avatar.ts` is now `avatars.ts` — it is no longer skill-only — and `PopoverAnchor` is re-exported from `components/ui/popover.tsx`. `PopoverTrigger` is untouched for its other users.

## Notes

- Right-click-to-open isn't reachable by keyboard. Happy to add an arrow-down handler on the trigger if that matters.
- `packages/web/src/utils/avatars.test.ts` covers the two scoping properties: partition `1` of skill A ≠ partition `1` of skill B, and configuration `1` of partition 1 ≠ configuration `1` of partition 2.

## Test notes

`pnpm typecheck`, `pnpm check`, and `pnpm test packages/web` (77 files, 887 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5ucwsrQ1rRRESbqteMUhc
