### PR TITLE
feat(web): open a breadcrumb's picker from the keyboard

### DIFF
--- a/packages/web/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/web/src/components/breadcrumb/breadcrumb.tsx
@@ -83,6 +83,34 @@ const createAgentAvatar = (agentName: string) => {
 };
 
 // ============================================================================
+// Dropdown Keyboard Handling
+// ============================================================================
+
+/**
+ * The keyboard half of a breadcrumb dropdown. The button itself navigates, and
+ * the picker opens on a right click, which a keyboard cannot make: ArrowDown
+ * opens it instead, the combobox convention. Closing it puts focus back on the
+ * button, which Radix does on its own only for a `PopoverTrigger`.
+ */
+function useDropdownKeyboard(setComboboxOpen: (open: boolean) => void) {
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setComboboxOpen(true);
+    }
+  };
+
+  const handleCloseAutoFocus = (event: Event) => {
+    event.preventDefault();
+    triggerRef.current?.focus();
+  };
+
+  return { triggerRef, handleKeyDown, handleCloseAutoFocus };
+}
+
+// ============================================================================
 // Agent Breadcrumb Components
 // ============================================================================
 
@@ -145,6 +173,8 @@ function AgentCombobox<T extends { id: string; name: string }>({
   onCreateClick: () => void;
 }): ReactElement {
   const modifierKey = useModifierKey();
+  const { triggerRef, handleKeyDown, handleCloseAutoFocus } =
+    useDropdownKeyboard(setComboboxOpen);
 
   return (
     <BreadcrumbItem>
@@ -163,6 +193,10 @@ function AgentCombobox<T extends { id: string; name: string }>({
               event.preventDefault();
               setComboboxOpen(true);
             }}
+            onKeyDown={handleKeyDown}
+            ref={triggerRef}
+            aria-haspopup="dialog"
+            aria-expanded={comboboxOpen}
           >
             <img
               src={agentAvatars.get(activeAgent.name) || ''}
@@ -179,6 +213,7 @@ function AgentCombobox<T extends { id: string; name: string }>({
           align="start"
           side="bottom"
           sideOffset={4}
+          onCloseAutoFocus={handleCloseAutoFocus}
         >
           <Command>
             <CommandInput placeholder="Search agents..." className="h-9" />
@@ -333,6 +368,9 @@ function SkillCombobox<T extends { id: string; name: string }>({
   onSkillSelect: (skill: T) => void;
   onCreateClick: () => void;
 }): ReactElement {
+  const { triggerRef, handleKeyDown, handleCloseAutoFocus } =
+    useDropdownKeyboard(setComboboxOpen);
+
   return (
     <BreadcrumbItem>
       <Popover open={comboboxOpen} onOpenChange={setComboboxOpen}>
@@ -350,6 +388,10 @@ function SkillCombobox<T extends { id: string; name: string }>({
               event.preventDefault();
               setComboboxOpen(true);
             }}
+            onKeyDown={handleKeyDown}
+            ref={triggerRef}
+            aria-haspopup="dialog"
+            aria-expanded={comboboxOpen}
           >
             <img
               src={skillAvatars.get(activeSkill.name) || ''}
@@ -366,6 +408,7 @@ function SkillCombobox<T extends { id: string; name: string }>({
           align="start"
           side="bottom"
           sideOffset={4}
+          onCloseAutoFocus={handleCloseAutoFocus}
         >
           <Command>
             <CommandInput placeholder="Search skills..." className="h-9" />
@@ -493,6 +536,8 @@ function ClusterDropdownBreadcrumb(): ReactElement {
   const { selectedAgent } = useAgents();
   const { selectedSkill } = useSkills();
   const [comboboxOpen, setComboboxOpen] = React.useState(false);
+  const { triggerRef, handleKeyDown, handleCloseAutoFocus } =
+    useDropdownKeyboard(setComboboxOpen);
 
   const clusterAvatars = useMemo(() => {
     const avatars = new Map<string, string>();
@@ -575,6 +620,10 @@ function ClusterDropdownBreadcrumb(): ReactElement {
               event.preventDefault();
               setComboboxOpen(true);
             }}
+            onKeyDown={handleKeyDown}
+            ref={triggerRef}
+            aria-haspopup="dialog"
+            aria-expanded={comboboxOpen}
           >
             <img
               src={clusterAvatars.get(activeCluster.name) || ''}
@@ -591,6 +640,7 @@ function ClusterDropdownBreadcrumb(): ReactElement {
           align="start"
           side="bottom"
           sideOffset={4}
+          onCloseAutoFocus={handleCloseAutoFocus}
         >
           <Command>
             <CommandInput placeholder="Search partitions..." className="h-9" />
@@ -634,6 +684,8 @@ function ArmDropdownBreadcrumb(): ReactElement {
   const { selectedSkill } = useSkills();
   const { selectedCluster } = useSkillOptimizationClusters();
   const [comboboxOpen, setComboboxOpen] = React.useState(false);
+  const { triggerRef, handleKeyDown, handleCloseAutoFocus } =
+    useDropdownKeyboard(setComboboxOpen);
 
   const armAvatars = useMemo(() => {
     const avatars = new Map<string, string>();
@@ -714,6 +766,10 @@ function ArmDropdownBreadcrumb(): ReactElement {
               event.preventDefault();
               setComboboxOpen(true);
             }}
+            onKeyDown={handleKeyDown}
+            ref={triggerRef}
+            aria-haspopup="dialog"
+            aria-expanded={comboboxOpen}
           >
             <img
               src={armAvatars.get(activeArm.name) || ''}
@@ -730,6 +786,7 @@ function ArmDropdownBreadcrumb(): ReactElement {
           align="start"
           side="bottom"
           sideOffset={4}
+          onCloseAutoFocus={handleCloseAutoFocus}
         >
           <Command>
             <CommandInput

--- a/packages/web/src/components/breadcrumbs/breadcrumb.test.tsx
+++ b/packages/web/src/components/breadcrumbs/breadcrumb.test.tsx
@@ -1,7 +1,7 @@
 import type { Agent } from '@shared/types/data';
 import type { Skill } from '@shared/types/data/skill';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { BreadcrumbComponent } from '@web/components/breadcrumb/breadcrumb';
 import { AgentsProvider } from '@web/providers/agents';
 import { NavigationProvider } from '@web/providers/navigation';
@@ -344,17 +344,9 @@ const mockLocalStorage: Storage = {
   length: 0,
 };
 
-// Mock window with proper typing
-const mockWindow = {
-  ...window,
-  localStorage: mockLocalStorage,
-};
-
-Object.defineProperty(global, 'window', {
-  value: mockWindow,
-  writable: true,
-});
-
+// Only localStorage is mocked: replacing `window` wholesale with a spread of
+// itself drops every prototype method, `getComputedStyle` among them, which
+// Radix needs to place a popover.
 Object.defineProperty(window, 'localStorage', {
   value: mockLocalStorage,
   writable: true,
@@ -559,6 +551,35 @@ describe('BreadcrumbComponent', () => {
       // Avatar should have SVG data (using encodeURIComponent now)
       const src = skillAvatar?.getAttribute('src');
       expect(src).toContain('data:image/svg+xml');
+    });
+  });
+  describe('Dropdown keyboard access', () => {
+    it('opens the picker on ArrowDown, where a click navigates', async () => {
+      setMockBreadcrumbs([{ label: 'Agent', path: '', isAgentDropdown: true }]);
+      setMockSelectedAgent(mockAgents[0]);
+
+      await act(() => {
+        renderWithProviders(<BreadcrumbComponent />);
+      });
+
+      const trigger = screen.getByRole('button', { name: /Test Agent 1/ });
+
+      // A click goes to the agent rather than opening the picker
+      await act(() => {
+        fireEvent.click(trigger);
+      });
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: `/agents/${encodeURIComponent('Test Agent 1')}`,
+      });
+      expect(screen.queryByPlaceholderText('Search agents...')).toBeNull();
+
+      // ArrowDown stands in for the right click a keyboard cannot make
+      await act(() => {
+        fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+      });
+      expect(
+        screen.getByPlaceholderText('Search agents...'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -169,6 +169,13 @@ global.ResizeObserver = class ResizeObserver {
   }
 };
 
+// jsdom has no scrollIntoView, which cmdk calls as its list highlights an item
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = (): void => {
+    // Mock implementation
+  };
+}
+
 // Soften noisy React warnings that don't affect assertions in our suite.
 // These warnings can flood output and cause OOM in CI when many async state
 // updates happen during provider effects.


### PR DESCRIPTION
Follow-up to #270, which left one loose end: the breadcrumb dropdowns open on a right click, and a keyboard cannot make one.

## Solution

**ArrowDown opens the picker** — the combobox convention — while Enter and Space still activate the button, which navigates, same as a click. Closing the picker puts focus back on the button: Radix does that on its own only for a `PopoverTrigger`, and these dropdowns hang off a `PopoverAnchor` so the button is free to navigate. The button also carries `aria-haspopup="dialog"` and `aria-expanded`, which the anchor doesn't supply.

The three bits live in one `useDropdownKeyboard` hook rather than four copies, one per dropdown (agent, skill, partition, configuration).

## Test notes

A new case in the breadcrumb suite asserts both halves: a click navigates and leaves the picker shut, ArrowDown opens it.

Two jsdom gaps stood between that test and the picker, both fixed here:

- `scrollIntoView` doesn't exist in jsdom, and cmdk calls it as its list highlights an item. Stubbed in `vitest.setup.tsx` beside the existing `ResizeObserver` stub, so any cmdk-based test gets it.
- The breadcrumb suite replaced `window` with `{ ...window, localStorage }`. Spreading a `Window` copies only own enumerable properties, so every prototype method is lost — including `getComputedStyle`, without which Radix cannot place a popover. Only localStorage needed mocking, which the very next statement already did, so the wholesale replacement is gone.

`pnpm typecheck`, `pnpm check` and `pnpm test` (184 files, 2911 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5ucwsrQ1rRRESbqteMUhc
