### PR TITLE
feat(settings): a reasoning effort for every internal model, and per-evaluation overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,6 +307,29 @@ Adding a setting is a change to that schema and the settings form, not to
 either backend's schema. A PATCH sends the fields it changes; the connectors
 merge them over the stored options (`mergeSystemSettingsOptions`).
 
+Every role served by a text model -- all of them but embedding, which is one
+forward pass with nothing to think about -- carries a nullable
+`reasoning_effort` beside its timeout, and the judge additionally carries its
+completion budget (`max_tokens`). `resolveSystemSettingsModel` returns a
+role's effort alongside its model and timeout, so every internal call sends
+it; null sends nothing and leaves the model at its own default, and the
+gateway drops the parameter for models that reject it. The roles are set
+independently because they ask for different work: writing a system prompt
+can be worth the thinking, while naming a skill or scoring a turn is an
+answer someone is waiting for.
+
+The judge's two settings work together. A thinking model spends the budget
+reasoning before it writes a word, and one that runs out stops on `length`
+with an empty answer -- reported as `budget_exhausted` and *not* retried,
+since the identical request under the identical budget fails the identical
+way. Raising the budget or lowering the effort is what fixes it.
+
+A single evaluation may override the judge's budget and effort through its
+own `params` (`connectors/evaluations/judge-overrides.ts`), which win over
+system settings as the more specific answer. Both are optional with no
+default, and that is load-bearing: absent means inherit, so an evaluation
+with no opinion keeps following the settings as they change.
+
 Core data models:
 - `Agent` - AI agent configurations
 - `Dataset`/`Log` - Training/evaluation data with many-to-many relationships

--- a/packages/api/src/ai-providers/ollama/chat-complete.ts
+++ b/packages/api/src/ai-providers/ollama/chat-complete.ts
@@ -75,6 +75,12 @@ export const ollamaChatCompleteConfig: AIProviderFunctionConfig = {
   tools: {
     param: 'tools',
   },
+  // Ollama's OpenAI-compatible endpoint maps this onto thinking, `none`
+  // included, which is the only way to keep a thinking model from spending
+  // a request's whole completion budget on reasoning it never shows.
+  reasoning_effort: {
+    param: 'reasoning_effort',
+  },
 };
 
 export const ollamaChatCompleteResponseTransform: ResponseTransformFunction = (

--- a/packages/api/src/ai-providers/ollama/ollama.test.ts
+++ b/packages/api/src/ai-providers/ollama/ollama.test.ts
@@ -221,6 +221,12 @@ describe('Ollama Provider Tests', () => {
       expect(config.stream).toBeDefined();
     });
 
+    it('forwards reasoning_effort, the switch that turns thinking off', () => {
+      expect(ollamaChatCompleteConfig.reasoning_effort).toEqual({
+        param: 'reasoning_effort',
+      });
+    });
+
     it('should have correct temperature limits', () => {
       const config = ollamaChatCompleteConfig;
       expect(config.temperature).toHaveProperty('min', 0);

--- a/packages/api/src/connectors/evaluations/__mocks__/mock-storage-connector.ts
+++ b/packages/api/src/connectors/evaluations/__mocks__/mock-storage-connector.ts
@@ -1,4 +1,5 @@
 import type { UserDataStorageConnector } from '@api/types/connector';
+import { SystemSettingsOptions } from '@shared/types/data/system-settings';
 import { vi } from 'vitest';
 
 /**
@@ -16,15 +17,9 @@ export function createMockStorageConnector(): UserDataStorageConnector {
       embedding_model_id: 'embed-123',
       skill_arbiter_model_id: null,
       intent_compaction_model_id: null,
-      options: {
-        system_prompt_reflection: { timeout_ms: 120_000 },
-        evaluation_generation: { timeout_ms: 120_000 },
-        embedding: { timeout_ms: 30_000 },
-        judge: { timeout_ms: 60_000, max_tokens: 4_000 },
-        skill_arbiter: { timeout_ms: 15_000 },
+      options: SystemSettingsOptions.parse({
         intent_compaction: { timeout_ms: 15_000 },
-        developer_mode: false,
-      },
+      }),
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     }),

--- a/packages/api/src/connectors/evaluations/argument-correctness/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/argument-correctness/service/evaluate.ts
@@ -1,5 +1,6 @@
 import { getArgumentCorrectnessTemplate } from '@api/connectors/evaluations/argument-correctness/templates/main';
 import { ArgumentCorrectnessEvaluationParameters } from '@api/connectors/evaluations/argument-correctness/types';
+import { judgeOverrides } from '@api/connectors/evaluations/judge-overrides';
 import type { ToolUsage } from '@api/connectors/evaluations/tool-correctness/types';
 import { createLLMJudge } from '@api/evaluations/llm-judge';
 import type { UserDataStorageConnector } from '@api/types/connector';
@@ -96,6 +97,7 @@ export async function evaluateLog(
     c,
     {
       temperature: params.temperature,
+      ...judgeOverrides(params),
     },
     modelConfig ?? undefined,
   );

--- a/packages/api/src/connectors/evaluations/argument-correctness/types.ts
+++ b/packages/api/src/connectors/evaluations/argument-correctness/types.ts
@@ -1,3 +1,4 @@
+import { JudgeOverrideParameters } from '@api/connectors/evaluations/judge-overrides';
 import { z } from 'zod';
 import { ToolUsageSchema } from '../tool-correctness/types';
 
@@ -106,6 +107,10 @@ export const ArgumentCorrectnessEvaluationParameters =
     verbose_mode: z.boolean().default(false),
     temperature: z.number().min(0).max(2).default(0.1),
     batch_size: z.number().positive().default(10),
+    // What this evaluation wants instead of the judge's system settings.
+    // Absent means inherit, so an evaluation with no opinion follows the
+    // settings as they change.
+    ...JudgeOverrideParameters.shape,
     input: z.string().optional(),
     actual_output: z.string().optional(),
     tools_called: z.array(z.record(z.string(), z.unknown())).optional(),

--- a/packages/api/src/connectors/evaluations/conversation-completeness/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/conversation-completeness/service/evaluate.ts
@@ -2,6 +2,7 @@ import type {
   ConversationCompletenessEvaluationParameters,
   ConversationCompletenessResult,
 } from '@api/connectors/evaluations/conversation-completeness/types';
+import { judgeOverrides } from '@api/connectors/evaluations/judge-overrides';
 import { humanVerdictNote } from '@api/evaluations/human-verdict';
 import {
   createLLMJudge,
@@ -51,6 +52,7 @@ export async function evaluateConversationCompleteness(
     c,
     {
       temperature: params.temperature,
+      ...judgeOverrides(params),
     },
     modelConfig ?? undefined,
   );

--- a/packages/api/src/connectors/evaluations/conversation-completeness/types.ts
+++ b/packages/api/src/connectors/evaluations/conversation-completeness/types.ts
@@ -1,3 +1,4 @@
+import { JudgeOverrideParameters } from '@api/connectors/evaluations/judge-overrides';
 import z from 'zod';
 
 export interface ConversationCompletenessResult {
@@ -31,6 +32,10 @@ export const ConversationCompletenessEvaluationParameters =
     async_mode: z.boolean().default(false),
     verbose_mode: z.boolean().default(false),
     batch_size: z.number().int().positive().default(10),
+    // What this evaluation wants instead of the judge's system settings.
+    // Absent means inherit, so an evaluation with no opinion follows the
+    // settings as they change.
+    ...JudgeOverrideParameters.shape,
   });
 
 export type ConversationCompletenessEvaluationParameters = z.infer<

--- a/packages/api/src/connectors/evaluations/judge-overrides.test.ts
+++ b/packages/api/src/connectors/evaluations/judge-overrides.test.ts
@@ -1,0 +1,87 @@
+import {
+  JudgeOverrideParameters,
+  judgeOverrides,
+} from '@api/connectors/evaluations/judge-overrides';
+import { TaskCompletionEvaluationParameters } from '@api/connectors/evaluations/task-completion/types';
+import { TurnRelevancyEvaluationParameters } from '@api/connectors/evaluations/turn-relevancy/types';
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * System settings say how the judge runs; an evaluation may disagree. What
+ * matters here is that silence is not disagreement: an evaluation that says
+ * nothing has to keep following the settings as they change.
+ */
+
+describe('judgeOverrides', () => {
+  it('sends nothing for an evaluation with no opinion', () => {
+    // Not `{ max_tokens: undefined }`: the judge merges this over the
+    // resolved model config, where an explicit undefined would read as a
+    // value and lose the setting.
+    expect(judgeOverrides({})).toEqual({});
+  });
+
+  it('sends only the fields the evaluation actually set', () => {
+    expect(judgeOverrides({ max_tokens: 16_000 })).toEqual({
+      max_tokens: 16_000,
+    });
+    expect(judgeOverrides({ reasoning_effort: ReasoningEffort.NONE })).toEqual({
+      reasoning_effort: 'none',
+    });
+    expect(
+      judgeOverrides({
+        max_tokens: 512,
+        reasoning_effort: ReasoningEffort.HIGH,
+      }),
+    ).toEqual({ max_tokens: 512, reasoning_effort: 'high' });
+  });
+});
+
+describe('JudgeOverrideParameters', () => {
+  it('leaves both absent rather than defaulting them', () => {
+    const params = JudgeOverrideParameters.parse({});
+
+    expect(params.max_tokens).toBeUndefined();
+    expect(params.reasoning_effort).toBeUndefined();
+  });
+
+  it('refuses a budget or an effort it could not honour', () => {
+    expect(JudgeOverrideParameters.safeParse({ max_tokens: 0 }).success).toBe(
+      false,
+    );
+    expect(JudgeOverrideParameters.safeParse({ max_tokens: 1.5 }).success).toBe(
+      false,
+    );
+    expect(
+      JudgeOverrideParameters.safeParse({ reasoning_effort: 'ultra' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('evaluation parameters', () => {
+  it('carries the overrides on every judge-backed method', () => {
+    // Spot-checked on two: one with its own AI parameters, one without.
+    const task = TaskCompletionEvaluationParameters.parse({
+      task: 'rebase the branch',
+      max_tokens: 16_000,
+      reasoning_effort: ReasoningEffort.LOW,
+    });
+    expect(task.max_tokens).toBe(16_000);
+    expect(task.reasoning_effort).toBe('low');
+
+    const relevancy = TurnRelevancyEvaluationParameters.parse({
+      reasoning_effort: ReasoningEffort.NONE,
+    });
+    expect(relevancy.reasoning_effort).toBe('none');
+    expect(relevancy.max_tokens).toBeUndefined();
+  });
+
+  it('leaves an evaluation that says nothing following the settings', () => {
+    const params = TaskCompletionEvaluationParameters.parse({ task: 'x' });
+
+    expect(params.max_tokens).toBeUndefined();
+    expect(params.reasoning_effort).toBeUndefined();
+    // The rest of the parameters still take their defaults.
+    expect(params.temperature).toBe(0.1);
+  });
+});

--- a/packages/api/src/connectors/evaluations/judge-overrides.ts
+++ b/packages/api/src/connectors/evaluations/judge-overrides.ts
@@ -1,0 +1,44 @@
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
+import { z } from 'zod';
+
+/**
+ * The judge settings an evaluation may override, shared by every method that
+ * asks a model to score something.
+ *
+ * System settings say how the judge runs by default -- its completion budget
+ * and how hard it may think -- and that is the right place for it: the values
+ * follow the judge model, and one model serves every evaluation. But a single
+ * evaluation can be the exception. A rubric that wants a long chain of
+ * reasoning, or one cheap enough to run with thinking off, sets its own here
+ * and the setting no longer applies to it.
+ *
+ * Both are optional with no default, and that is load-bearing: absent means
+ * inherit, so an evaluation created before these existed, or created without
+ * an opinion, keeps following the settings as they change. Only a value
+ * actually stored on the evaluation overrides one.
+ */
+export const JudgeOverrideParameters = z.object({
+  /**
+   * Completion tokens one attempt at this evaluation may spend, overriding
+   * `options.judge.max_tokens`.
+   */
+  max_tokens: z.number().int().positive().optional(),
+  /**
+   * How hard the model may think before answering this evaluation,
+   * overriding `options.judge.reasoning_effort`. `none` turns thinking off
+   * where the global setting leaves it on.
+   */
+  reasoning_effort: z.enum(ReasoningEffort).optional(),
+});
+
+export type JudgeOverrideParameters = z.infer<typeof JudgeOverrideParameters>;
+
+/** The overrides as the judge takes them, for spreading into its config. */
+export const judgeOverrides = (
+  params: JudgeOverrideParameters,
+): JudgeOverrideParameters => ({
+  ...(params.max_tokens !== undefined && { max_tokens: params.max_tokens }),
+  ...(params.reasoning_effort !== undefined && {
+    reasoning_effort: params.reasoning_effort,
+  }),
+});

--- a/packages/api/src/connectors/evaluations/knowledge-retention/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/knowledge-retention/service/evaluate.ts
@@ -1,3 +1,4 @@
+import { judgeOverrides } from '@api/connectors/evaluations/judge-overrides';
 import type { KnowledgeRetentionEvaluationParameters } from '@api/connectors/evaluations/knowledge-retention/types';
 import { humanVerdictNote } from '@api/evaluations/human-verdict';
 import { createLLMJudge } from '@api/evaluations/llm-judge';
@@ -47,6 +48,7 @@ export async function evaluateLog(
     c,
     {
       temperature: params.temperature,
+      ...judgeOverrides(params),
     },
     modelConfig ?? undefined,
   );

--- a/packages/api/src/connectors/evaluations/knowledge-retention/types.ts
+++ b/packages/api/src/connectors/evaluations/knowledge-retention/types.ts
@@ -1,3 +1,4 @@
+import { JudgeOverrideParameters } from '@api/connectors/evaluations/judge-overrides';
 import z from 'zod';
 
 export interface KnowledgeRetentionResult {
@@ -29,6 +30,10 @@ export const KnowledgeRetentionEvaluationParameters =
     async_mode: z.boolean().default(false),
     verbose_mode: z.boolean().default(false),
     batch_size: z.number().int().positive().default(10),
+    // What this evaluation wants instead of the judge's system settings.
+    // Absent means inherit, so an evaluation with no opinion follows the
+    // settings as they change.
+    ...JudgeOverrideParameters.shape,
   });
 
 export type KnowledgeRetentionEvaluationParameters = z.infer<

--- a/packages/api/src/connectors/evaluations/llm-judge.test.ts
+++ b/packages/api/src/connectors/evaluations/llm-judge.test.ts
@@ -1,5 +1,6 @@
 import { createLLMJudge } from '@api/evaluations/llm-judge';
 import { createMockContext } from '@api/test-utils/mock-context';
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { AIProvider } from '@shared/types/constants';
 import OpenAI from 'openai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -153,6 +154,120 @@ describe('LLM Judge', () => {
 
     expect(mockParse).toHaveBeenCalledTimes(2);
     expect(result.score).toBe(0.8);
+  });
+
+  it("lets an evaluation's own parameters win over the settings", async () => {
+    // System settings say how the judge runs by default; an evaluation that
+    // states a budget or an effort is the more specific answer, so it wins.
+    mockParse.mockReset();
+    mockParse.mockResolvedValue({
+      choices: [{ message: { content: '{"score":0.7,"reasoning":"ok"}' } }],
+    });
+    const fromSettings = {
+      ...mockModelConfig,
+      maxTokens: 4_000,
+      reasoningEffort: ReasoningEffort.HIGH,
+    };
+
+    await createLLMJudge(
+      mockContext,
+      { max_tokens: 16_000, reasoning_effort: ReasoningEffort.NONE },
+      fromSettings,
+    ).evaluate({ text: 'anything' } as never);
+
+    expect(mockParse.mock.calls[0][0]).toMatchObject({
+      max_tokens: 16_000,
+      reasoning_effort: 'none',
+    });
+  });
+
+  it('follows the settings for an evaluation that states neither', async () => {
+    mockParse.mockReset();
+    mockParse.mockResolvedValue({
+      choices: [{ message: { content: '{"score":0.7,"reasoning":"ok"}' } }],
+    });
+
+    await createLLMJudge(
+      mockContext,
+      { temperature: 0.42 },
+      {
+        ...mockModelConfig,
+        maxTokens: 8_000,
+        reasoningEffort: ReasoningEffort.LOW,
+      },
+    ).evaluate({ text: 'anything' } as never);
+
+    expect(mockParse.mock.calls[0][0]).toMatchObject({
+      max_tokens: 8_000,
+      reasoning_effort: 'low',
+      temperature: 0.42,
+    });
+  });
+
+  it('takes one from the evaluation and the other from the settings', async () => {
+    mockParse.mockReset();
+    mockParse.mockResolvedValue({
+      choices: [{ message: { content: '{"score":0.7,"reasoning":"ok"}' } }],
+    });
+
+    await createLLMJudge(
+      mockContext,
+      { max_tokens: 512 },
+      {
+        ...mockModelConfig,
+        maxTokens: 4_000,
+        reasoningEffort: ReasoningEffort.LOW,
+      },
+    ).evaluate({ text: 'anything' } as never);
+
+    expect(mockParse.mock.calls[0][0]).toMatchObject({
+      max_tokens: 512,
+      reasoning_effort: 'low',
+    });
+  });
+
+  it('does not retry a length stop: the same budget fails the same way', async () => {
+    // glm-5.3-flash on a transcript-sized prompt spent all 4000 completion
+    // tokens reasoning and stopped on length with nothing in `content`.
+    // Retrying sends the identical request under the identical budget.
+    mockParse.mockReset();
+    mockParse.mockResolvedValue({
+      choices: [{ finish_reason: 'length', message: { content: '' } }],
+      usage: { completion_tokens: 4000 },
+    });
+
+    const evaluatePromise = llmJudge.evaluate({ text: 'anything' } as never);
+    await vi.advanceTimersByTimeAsync(8787);
+    const result = await evaluatePromise;
+
+    expect(mockParse).toHaveBeenCalledTimes(1);
+    expect(result.metadata?.fallback).toBe(true);
+    expect(result.metadata?.errorType).toBe('budget_exhausted');
+    // The log names the two settings that fix it.
+    expect(result.metadata?.errorDetails).toContain('token budget');
+    expect(result.metadata?.errorDetails).toContain('reasoning effort');
+    expect(result.metadata?.errorDetails).toContain('4000');
+  });
+
+  it('sends the reasoning effort the settings chose, and nothing when unset', async () => {
+    mockParse.mockReset();
+    mockParse.mockResolvedValue({
+      choices: [{ message: { content: '{"score":0.7,"reasoning":"ok"}' } }],
+    });
+
+    await createLLMJudge(mockContext, {}, mockModelConfig).evaluate({
+      text: 'anything',
+    } as never);
+    expect(mockParse.mock.calls[0][0]).not.toHaveProperty('reasoning_effort');
+
+    await createLLMJudge(
+      mockContext,
+      {},
+      { ...mockModelConfig, reasoningEffort: ReasoningEffort.NONE },
+    ).evaluate({ text: 'anything' } as never);
+    expect(mockParse.mock.calls[1][0]).toMatchObject({
+      reasoning_effort: 'none',
+    });
   });
 
   it('says what an empty completion actually was', async () => {

--- a/packages/api/src/connectors/evaluations/role-adherence/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/role-adherence/service/evaluate.ts
@@ -1,3 +1,4 @@
+import { judgeOverrides } from '@api/connectors/evaluations/judge-overrides';
 import { getRoleAdherenceMainTemplate } from '@api/connectors/evaluations/role-adherence/templates/main';
 import { RoleAdherenceEvaluationParameters } from '@api/connectors/evaluations/role-adherence/types';
 import { createLLMJudge } from '@api/evaluations/llm-judge';
@@ -62,6 +63,7 @@ export async function evaluateLog(
     c,
     {
       temperature: params.temperature,
+      ...judgeOverrides(params),
     },
     modelConfig ?? undefined,
   );

--- a/packages/api/src/connectors/evaluations/role-adherence/types.ts
+++ b/packages/api/src/connectors/evaluations/role-adherence/types.ts
@@ -1,3 +1,4 @@
+import { JudgeOverrideParameters } from '@api/connectors/evaluations/judge-overrides';
 import { z } from 'zod';
 
 // Template data for role adherence evaluation
@@ -91,6 +92,10 @@ export const RoleAdherenceEvaluationParameters =
     verbose_mode: z.boolean().default(false),
     temperature: z.number().min(0).max(2).default(0.1),
     batch_size: z.number().positive().default(1000),
+    // What this evaluation wants instead of the judge's system settings.
+    // Absent means inherit, so an evaluation with no opinion follows the
+    // settings as they change.
+    ...JudgeOverrideParameters.shape,
     role_definition: z.string().optional(),
     assistant_output: z.string().optional(),
     instructions: z.string().optional(),

--- a/packages/api/src/connectors/evaluations/task-completion/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/service/evaluate.ts
@@ -1,3 +1,4 @@
+import { judgeOverrides } from '@api/connectors/evaluations/judge-overrides';
 import { extractTaskAndOutcome } from '@api/connectors/evaluations/task-completion/service/task-and-outcome';
 import getTaskCompletionVerdictTemplate from '@api/connectors/evaluations/task-completion/templates/verdict';
 import { TaskCompletionEvaluationParameters } from '@api/connectors/evaluations/task-completion/types';
@@ -143,6 +144,7 @@ export async function evaluateLog(
       c,
       {
         temperature: params.temperature,
+        ...judgeOverrides(params),
       },
       modelConfig ?? undefined,
     );

--- a/packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts
@@ -99,7 +99,15 @@ export async function extractTaskAndOutcome(
     .chat.completions.create({
       ...SA_SKILL_REQUEST_PARAMS,
       model: modelConfig.model,
-      max_tokens: modelConfig.maxTokens,
+      // Extraction is part of the task-completion evaluation, so it runs
+      // under the same overrides the scoring call does.
+      max_tokens: params.max_tokens ?? modelConfig.maxTokens,
+      ...((params.reasoning_effort ?? modelConfig.reasoningEffort)
+        ? {
+            reasoning_effort:
+              params.reasoning_effort ?? modelConfig.reasoningEffort,
+          }
+        : {}),
       messages: [
         { role: 'system', content: systemPrompt },
         {

--- a/packages/api/src/connectors/evaluations/task-completion/types.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/types.ts
@@ -1,3 +1,4 @@
+import { JudgeOverrideParameters } from '@api/connectors/evaluations/judge-overrides';
 import { z } from 'zod';
 import { ToolUsageSchema } from '../tool-correctness/types';
 
@@ -69,6 +70,10 @@ export const TaskCompletionEvaluationParameters =
     verbose_mode: z.boolean().default(false),
     temperature: z.number().min(0).max(1).default(0.1),
     batch_size: z.number().positive().default(10),
+    // What this evaluation wants instead of the judge's system settings.
+    // Absent means inherit, so an evaluation with no opinion follows the
+    // settings as they change.
+    ...JudgeOverrideParameters.shape,
   });
 
 export type TaskCompletionEvaluationParameters = z.infer<

--- a/packages/api/src/connectors/evaluations/turn-relevancy/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/turn-relevancy/service/evaluate.ts
@@ -1,3 +1,4 @@
+import { judgeOverrides } from '@api/connectors/evaluations/judge-overrides';
 import { getTurnRelevancyTemplate } from '@api/connectors/evaluations/turn-relevancy/templates/main';
 import { TurnRelevancyEvaluationParameters } from '@api/connectors/evaluations/turn-relevancy/types';
 import { humanVerdictNote } from '@api/evaluations/human-verdict';
@@ -112,6 +113,7 @@ export async function evaluateLog(
     c,
     {
       temperature: params.temperature,
+      ...judgeOverrides(params),
     },
     modelConfig ?? undefined,
   );

--- a/packages/api/src/connectors/evaluations/turn-relevancy/types.ts
+++ b/packages/api/src/connectors/evaluations/turn-relevancy/types.ts
@@ -1,3 +1,4 @@
+import { JudgeOverrideParameters } from '@api/connectors/evaluations/judge-overrides';
 import { z } from 'zod';
 
 export const TurnRelevancyResultSchema = z.object({
@@ -55,6 +56,10 @@ export const TurnRelevancyEvaluationParameters =
     async_mode: z.boolean().default(true),
     verbose_mode: z.boolean().default(false),
     batch_size: z.number().int().positive().default(10),
+    // What this evaluation wants instead of the judge's system settings.
+    // Absent means inherit, so an evaluation with no opinion follows the
+    // settings as they change.
+    ...JudgeOverrideParameters.shape,
     conversation_history: z.string().optional(),
     current_turn: z.string().optional(),
     instructions: z.string().optional(),

--- a/packages/api/src/connectors/libsql/connector.test.ts
+++ b/packages/api/src/connectors/libsql/connector.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AppContext } from '@api/types/hono';
 import type { Client } from '@libsql/client';
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 import { createLibsqlClient, resetLibsqlClients } from './client';
 import { libsqlLogsStorageConnector } from './logs';
@@ -933,6 +934,7 @@ describe('system settings', () => {
     expect(settings.options.judge).toEqual({
       timeout_ms: 60_000,
       max_tokens: 4_000,
+      reasoning_effort: null,
     });
   });
 
@@ -964,9 +966,20 @@ describe('system settings', () => {
     expect(updated.options.judge).toEqual({
       timeout_ms: 90_000,
       max_tokens: 16_000,
+      reasoning_effort: null,
     });
     expect(updated.options.developer_mode).toBe(true);
     expect(updated.options.embedding.timeout_ms).toBe(30_000);
+
+    // Null is a value here -- it clears the effort -- not an omission.
+    await store.updateSystemSettings(c, {
+      options: { judge: { reasoning_effort: ReasoningEffort.NONE } },
+    });
+    const cleared = await store.updateSystemSettings(c, {
+      options: { judge: { reasoning_effort: null } },
+    });
+    expect(cleared.options.judge.reasoning_effort).toBeNull();
+    expect(cleared.options.judge.max_tokens).toBe(16_000);
   });
 });
 

--- a/packages/api/src/evaluations/llm-judge.ts
+++ b/packages/api/src/evaluations/llm-judge.ts
@@ -12,6 +12,7 @@ import {
 } from '@api/types/evaluations/llm-judge';
 import type { AppContext } from '@api/types/hono';
 import { error, warn } from '@shared/console-logging';
+import type { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import {
   type AIProvider,
   AIProvider as AIProviderEnum,
@@ -26,9 +27,44 @@ const LLM_JUDGE_MAX_RETRIES = 3;
 const LLM_JUDGE_RETRY_DELAY_BASE = 1000; // 1 second base delay
 
 /**
+ * The judge answered nothing readable.
+ *
+ * A clean stop with an empty answer is transient: a self-hosted model can
+ * stop having emitted only reasoning, then answer the identical request
+ * properly on the retry. A `length` stop is not. The model spent its whole
+ * completion budget before it wrote the answer, and the same request under
+ * the same budget does the same thing again, so retrying it only triples the
+ * cost of finding out. What fixes it is a setting: a bigger budget, or less
+ * reasoning.
+ */
+export class JudgeEmptyCompletionError extends Error {
+  constructor(
+    public readonly finishReason: string | null,
+    public readonly completionTokens: number,
+  ) {
+    super(
+      finishReason === 'length'
+        ? `The judge spent its whole completion budget before answering (${completionTokens} completion tokens, finish_reason: length): raise the judge token budget, or lower its reasoning effort`
+        : `The judge returned an empty completion (finish_reason: ${
+            finishReason ?? 'none'
+          }, ${completionTokens} completion tokens)`,
+    );
+    this.name = 'JudgeEmptyCompletionError';
+  }
+
+  /** Whether the identical request might answer next time. */
+  get retryable(): boolean {
+    return this.finishReason !== 'length';
+  }
+}
+
+/**
  * Check if an error is retryable for LLM judge requests
  */
 function isRetryableLLMJudgeError(error: unknown): boolean {
+  if (error instanceof JudgeEmptyCompletionError) {
+    return error.retryable;
+  }
   if (error instanceof Error) {
     const message = error.message.toLowerCase();
     return (
@@ -42,11 +78,8 @@ function isRetryableLLMJudgeError(error: unknown): boolean {
       message.includes('gateway') ||
       message.includes('service unavailable') ||
       // A judge that answered garbage may answer properly the second time.
-      message.includes('valid json') ||
-      // And one that answered nothing at all is the clearer case of the same
-      // thing: a self-hosted model can stop cleanly having emitted only
-      // reasoning, then answer the identical request properly on the retry.
-      message.includes('empty completion')
+      // (An empty answer is decided above, by how the completion stopped.)
+      message.includes('valid json')
     );
   }
   return false;
@@ -160,6 +193,11 @@ export interface LLMJudgeModelConfig {
    * it answers, and one that runs out returns nothing at all.
    */
   maxTokens?: number;
+  /**
+   * How hard a reasoning model may think first, from
+   * `options.judge.reasoning_effort`. Null or absent sends nothing.
+   */
+  reasoningEffort?: ReasoningEffort | null;
 }
 
 export function createLLMJudge(
@@ -171,10 +209,13 @@ export function createLLMJudge(
   const judgeConfig = {
     model: modelConfig?.model || config.model || 'gpt-5-mini',
     temperature: config.temperature || 0.1,
-    // The resolved model carries both settings; `config` stays as the
-    // override for a caller that resolves no model of its own.
+    // The resolved model carries what system settings say; an evaluation's
+    // own parameters win over that, being the more specific answer. Absent
+    // from both, the shared default applies.
     max_tokens:
-      modelConfig?.maxTokens ?? config.max_tokens ?? DEFAULT_JUDGE_MAX_TOKENS,
+      config.max_tokens ?? modelConfig?.maxTokens ?? DEFAULT_JUDGE_MAX_TOKENS,
+    reasoning_effort:
+      config.reasoning_effort ?? modelConfig?.reasoningEffort ?? null,
     timeout: modelConfig?.timeoutMs ?? config.timeout ?? 30000,
   };
 
@@ -324,6 +365,10 @@ Provide a score between 0 and 1 with detailed reasoning for your evaluation.`;
           // evaluation's configured parameters had no effect on judging.
           temperature: judgeConfig.temperature,
           max_tokens: judgeConfig.max_tokens,
+          // Only when set: a model that takes no such parameter is left alone.
+          ...(judgeConfig.reasoning_effort
+            ? { reasoning_effort: judgeConfig.reasoning_effort }
+            : {}),
           messages: [
             { role: 'system', content: prompt.systemPrompt },
             { role: 'user', content: prompt.userPrompt },
@@ -347,11 +392,10 @@ Provide a score between 0 and 1 with detailed reasoning for your evaluation.`;
           // Distinct from the parse failure below, and carrying what tells
           // the two apart in a log: a model that burned completion tokens and
           // stopped cleanly did answer, it just answered nowhere we can read.
-          const { completion_tokens } = response.usage ?? {};
-          throw new Error(
-            `The judge returned an empty completion (finish_reason: ${
-              choice.finish_reason ?? 'none'
-            }, ${completion_tokens ?? 0} completion tokens)`,
+          // One that stopped on length never got to answer at all.
+          throw new JudgeEmptyCompletionError(
+            choice.finish_reason ?? null,
+            response.usage?.completion_tokens ?? 0,
           );
         }
         // The SDK's `.parse()` throws on anything but strict JSON, and a
@@ -406,6 +450,16 @@ Provide a score between 0 and 1 with detailed reasoning for your evaluation.`;
       });
 
       if (
+        lastError instanceof JudgeEmptyCompletionError &&
+        !lastError.retryable
+      ) {
+        return getFallbackResult(
+          'budget_exhausted',
+          lastError.message,
+          retryInfo,
+        );
+      }
+      if (
         lastError.message.includes('fetch') ||
         lastError.message.includes('network')
       ) {
@@ -458,6 +512,7 @@ function getFallbackResult(
     | 'no_api_key'
     | 'network_error'
     | 'parse_error'
+    | 'budget_exhausted'
     | 'timeout_error'
     | 'api_error'
     | 'unknown_error',
@@ -471,6 +526,8 @@ function getFallbackResult(
     no_api_key: 'Evaluation skipped - OpenAI API key not configured',
     network_error: 'Evaluation failed - network connection error',
     parse_error: 'Evaluation failed - response parsing error',
+    budget_exhausted:
+      'Evaluation failed - the judge spent its whole token budget before answering',
     timeout_error: 'Evaluation failed - request timeout',
     api_error: 'Evaluation failed - OpenAI API error',
     unknown_error: 'Evaluation failed - unknown error occurred',

--- a/packages/api/src/optimization/utils/describe-skill.ts
+++ b/packages/api/src/optimization/utils/describe-skill.ts
@@ -173,6 +173,11 @@ export async function describeSkillForRequest(
       })
       .chat.completions.parse({
         ...SA_SKILL_REQUEST_PARAMS,
+        // Only when the role's setting names one: a model that takes no such
+        // parameter is left at its own default.
+        ...(modelConfig.reasoningEffort
+          ? { reasoning_effort: modelConfig.reasoningEffort }
+          : {}),
         model: modelConfig.model,
         messages: [
           { role: 'system', content: DESCRIBER_SYSTEM_PROMPT },

--- a/packages/api/src/optimization/utils/evaluations.ts
+++ b/packages/api/src/optimization/utils/evaluations.ts
@@ -199,6 +199,11 @@ export async function generateEvaluationCreateParams(
     })
     .chat.completions.parse({
       ...SA_SKILL_REQUEST_PARAMS,
+      // Only when the role's setting names one: a model that takes no such
+      // parameter is left at its own default.
+      ...(modelConfig.reasoningEffort
+        ? { reasoning_effort: modelConfig.reasoningEffort }
+        : {}),
       model: modelConfig.model,
       messages: [
         { role: 'system', content: systemPrompt },

--- a/packages/api/src/optimization/utils/system-prompt.ts
+++ b/packages/api/src/optimization/utils/system-prompt.ts
@@ -3,6 +3,7 @@ import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
 import { warn } from '@shared/console-logging';
+import type { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import type { Skill } from '@shared/types/data';
 import OpenAI from 'openai';
 import type { ParsedChatCompletion } from 'openai/resources/chat/completions.mjs';
@@ -117,7 +118,12 @@ async function createSystemPromptClient(
     skill_name: skillName,
   };
 
-  return { client, saConfig, model: modelConfig.model };
+  return {
+    client,
+    saConfig,
+    model: modelConfig.model,
+    reasoningEffort: modelConfig.reasoningEffort,
+  };
 }
 
 /**
@@ -129,6 +135,7 @@ async function callSystemPromptAPI(
   model: string,
   systemPrompt: string,
   userMessage: string,
+  reasoningEffort?: ReasoningEffort | null,
 ): Promise<string> {
   const response: ParsedChatCompletion<StructuredOutputResponse> = await client
     .withOptions({
@@ -138,6 +145,9 @@ async function callSystemPromptAPI(
     })
     .chat.completions.parse({
       ...SA_SKILL_REQUEST_PARAMS,
+      // Only when the role's setting names one: a model that takes no such
+      // parameter is left at its own default.
+      ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
       model,
       messages: [
         { role: 'system', content: systemPrompt },
@@ -254,11 +264,8 @@ export async function generateSeedSystemPromptForSkill(
   skill: Skill,
   connector: UserDataStorageConnector,
 ) {
-  const { client, saConfig, model } = await createSystemPromptClient(
-    c,
-    'system-prompt-seeding',
-    connector,
-  );
+  const { client, saConfig, model, reasoningEffort } =
+    await createSystemPromptClient(c, 'system-prompt-seeding', connector);
 
   const systemPrompt = getSeederSystemPrompt();
   const userMessage = getSeederFirstMessage(skill.description);
@@ -269,6 +276,7 @@ export async function generateSeedSystemPromptForSkill(
     model,
     systemPrompt,
     userMessage,
+    reasoningEffort,
   );
 }
 
@@ -282,11 +290,12 @@ export async function generateSeedSystemPromptWithContext(
   allowedTemplateVariables?: string[],
   seedSystemPrompt?: string | null,
 ) {
-  const { client, saConfig, model } = await createSystemPromptClient(
-    c,
-    'system-prompt-seeding-with-context',
-    connector,
-  );
+  const { client, saConfig, model, reasoningEffort } =
+    await createSystemPromptClient(
+      c,
+      'system-prompt-seeding-with-context',
+      connector,
+    );
 
   const systemPrompt = getSeederSystemPrompt();
   const userMessage = getSeederWithContextFirstMessage(
@@ -304,6 +313,7 @@ export async function generateSeedSystemPromptWithContext(
     model,
     systemPrompt,
     userMessage,
+    reasoningEffort,
   );
 }
 
@@ -380,11 +390,8 @@ export async function generateReflectiveSystemPromptForSkill(
   allowedTemplateVariables: string[],
   connector: UserDataStorageConnector,
 ) {
-  const { client, saConfig, model } = await createSystemPromptClient(
-    c,
-    'system-prompt-reflection',
-    connector,
-  );
+  const { client, saConfig, model, reasoningEffort } =
+    await createSystemPromptClient(c, 'system-prompt-reflection', connector);
 
   const systemPrompt = getReflectorSystemPrompt();
   const userMessage = getReflectorFirstMessage(
@@ -402,5 +409,6 @@ export async function generateReflectiveSystemPromptForSkill(
     model,
     systemPrompt,
     userMessage,
+    reasoningEffort,
   );
 }

--- a/packages/api/src/types/evaluations/llm-judge.ts
+++ b/packages/api/src/types/evaluations/llm-judge.ts
@@ -1,3 +1,4 @@
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { z } from 'zod';
 
 /**
@@ -6,7 +7,13 @@ import { z } from 'zod';
 export const LLMJudgeConfigSchema = z.object({
   model: z.string().optional().default('gpt-4o-mini'),
   temperature: z.number().min(0).max(2).optional().default(0.1),
-  max_tokens: z.number().positive().optional().default(1000),
+  /**
+   * What an evaluation wants instead of the resolved model's settings. Left
+   * out, the settings apply; given, they win over them -- an evaluation's own
+   * parameters are the more specific answer.
+   */
+  max_tokens: z.number().int().positive().optional(),
+  reasoning_effort: z.enum(ReasoningEffort).nullish(),
   timeout: z.number().positive().optional().default(30000),
 });
 

--- a/packages/api/src/utils/evaluation-model-resolver.test.ts
+++ b/packages/api/src/utils/evaluation-model-resolver.test.ts
@@ -6,7 +6,9 @@ import {
   resolveJudgeModelConfig,
   resolveSystemSettingsModel,
 } from '@api/utils/evaluation-model-resolver';
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import type { Model, SkillOptimizationEvaluation } from '@shared/types/data';
+import { SystemSettingsOptions } from '@shared/types/data/system-settings';
 import { EvaluationMethodName } from '@shared/types/evaluations';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -62,15 +64,9 @@ describe('Evaluation Model Resolver', () => {
     evaluation_generation_model_id: 'model-1111-2222-3333-444455556666',
     skill_arbiter_model_id: null,
     intent_compaction_model_id: null,
-    options: {
-      system_prompt_reflection: { timeout_ms: 120_000 },
-      evaluation_generation: { timeout_ms: 120_000 },
-      embedding: { timeout_ms: 30_000 },
-      judge: { timeout_ms: 60_000, max_tokens: 4_000 },
-      skill_arbiter: { timeout_ms: 15_000 },
+    options: SystemSettingsOptions.parse({
       intent_compaction: { timeout_ms: 15_000 },
-      developer_mode: false,
-    },
+    }),
     created_at: '2023-01-01T00:00:00Z',
     updated_at: '2023-01-01T00:00:00Z',
   };
@@ -100,6 +96,7 @@ describe('Evaluation Model Resolver', () => {
         provider: 'openai',
         apiKey: 'sk-test-api-key',
         timeoutMs: 60_000,
+        reasoningEffort: null,
       });
       expect(mockConnector.getSystemSettings).toHaveBeenCalled();
       expect(mockConnector.getModels).toHaveBeenCalledWith(mockContext, {
@@ -127,6 +124,7 @@ describe('Evaluation Model Resolver', () => {
         provider: 'openai',
         apiKey: 'sk-test-api-key',
         timeoutMs: 30_000,
+        reasoningEffort: null,
       });
       expect(mockConnector.getModels).toHaveBeenCalledWith(mockContext, {
         id: mockSystemSettings.embedding_model_id,
@@ -153,6 +151,7 @@ describe('Evaluation Model Resolver', () => {
         provider: 'openai',
         apiKey: 'sk-test-api-key',
         timeoutMs: 120_000,
+        reasoningEffort: null,
       });
       expect(mockConnector.getModels).toHaveBeenCalledWith(mockContext, {
         id: mockSystemSettings.system_prompt_reflection_model_id,
@@ -179,6 +178,7 @@ describe('Evaluation Model Resolver', () => {
         provider: 'openai',
         apiKey: 'sk-test-api-key',
         timeoutMs: 120_000,
+        reasoningEffort: null,
       });
       expect(mockConnector.getModels).toHaveBeenCalledWith(mockContext, {
         id: mockSystemSettings.evaluation_generation_model_id,
@@ -282,6 +282,7 @@ describe('Evaluation Model Resolver', () => {
         apiKey: undefined,
         customHost: 'http://localhost:11434',
         timeoutMs: 120_000,
+        reasoningEffort: null,
       });
     });
 
@@ -427,6 +428,7 @@ describe('Evaluation Model Resolver', () => {
         apiKey: 'sk-test-api-key',
         timeoutMs: 60_000,
         maxTokens: 4_000,
+        reasoningEffort: null,
       });
       expect(mockConnector.getModels).toHaveBeenCalledWith(mockContext, {
         id: 'custom-model-1111-2222-333344445555',
@@ -457,6 +459,7 @@ describe('Evaluation Model Resolver', () => {
         apiKey: 'sk-test-api-key',
         timeoutMs: 60_000,
         maxTokens: 4_000,
+        reasoningEffort: null,
       });
       expect(mockConnector.getSystemSettings).toHaveBeenCalled();
     });
@@ -494,13 +497,74 @@ describe('Evaluation Model Resolver', () => {
     });
   });
 
+  describe('reasoning effort', () => {
+    beforeEach(() => {
+      vi.mocked(mockConnector.getModels).mockResolvedValue([mockModel]);
+      vi.mocked(mockConnector.getAIProviderAPIKeys).mockResolvedValue([
+        mockProvider,
+      ]);
+    });
+
+    it('carries each text role’s own effort, not one shared value', async () => {
+      // The roles ask for different work, so they are set independently and
+      // a caller must get the one belonging to the role it resolved.
+      vi.mocked(mockConnector.getSystemSettings).mockResolvedValue({
+        ...mockSystemSettings,
+        options: SystemSettingsOptions.parse({
+          judge: { reasoning_effort: ReasoningEffort.NONE },
+          system_prompt_reflection: { reasoning_effort: ReasoningEffort.HIGH },
+          skill_arbiter: { reasoning_effort: ReasoningEffort.LOW },
+        }),
+      });
+
+      for (const [role, expected] of [
+        ['judge', 'none'],
+        ['system_prompt_reflection', 'high'],
+        ['skill_arbiter', 'low'],
+        // Never set, so the model is left at its own default.
+        ['intent_compaction', null],
+      ] as const) {
+        const resolved = await resolveSystemSettingsModel(
+          mockContext,
+          role,
+          mockConnector,
+        );
+        expect(resolved?.reasoningEffort).toBe(expected);
+      }
+    });
+
+    it('resolves the embedding model without one', async () => {
+      vi.mocked(mockConnector.getSystemSettings).mockResolvedValue({
+        ...mockSystemSettings,
+        options: SystemSettingsOptions.parse({
+          judge: { reasoning_effort: ReasoningEffort.HIGH },
+        }),
+      });
+      vi.mocked(mockConnector.getModels).mockResolvedValue([mockEmbedModel]);
+
+      const resolved = await resolveSystemSettingsModel(
+        mockContext,
+        'embedding',
+        mockConnector,
+      );
+
+      // An embedding has nothing to think about; the judge's setting is not
+      // borrowed for it.
+      expect(resolved?.reasoningEffort).toBeNull();
+    });
+  });
+
   describe('resolveJudgeModelConfig', () => {
-    it('resolves the judge with its timeout and token budget', async () => {
+    it('resolves the judge with its timeout, budget and effort', async () => {
       vi.mocked(mockConnector.getSystemSettings).mockResolvedValue({
         ...mockSystemSettings,
         options: {
           ...mockSystemSettings.options,
-          judge: { timeout_ms: 90_000, max_tokens: 16_000 },
+          judge: {
+            timeout_ms: 90_000,
+            max_tokens: 16_000,
+            reasoning_effort: ReasoningEffort.LOW,
+          },
         },
       });
       vi.mocked(mockConnector.getModels).mockResolvedValue([mockModel]);
@@ -516,6 +580,7 @@ describe('Evaluation Model Resolver', () => {
         apiKey: 'sk-test-api-key',
         timeoutMs: 90_000,
         maxTokens: 16_000,
+        reasoningEffort: 'low',
       });
     });
 

--- a/packages/api/src/utils/evaluation-model-resolver.ts
+++ b/packages/api/src/utils/evaluation-model-resolver.ts
@@ -3,6 +3,7 @@ import type { LLMJudgeModelConfig } from '@api/evaluations/llm-judge';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { warn } from '@shared/console-logging';
+import type { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import type { AIProvider } from '@shared/types/constants';
 import type {
   Model,
@@ -41,6 +42,13 @@ export interface ResolvedModelConfig {
    * only from a model resolved by id alone, which has no setting of its own.
    */
   timeoutMs?: number;
+  /**
+   * How hard this role's model may think before it answers, from the effort
+   * that sits beside it in system settings. Null or absent sends nothing and
+   * leaves the model to its own default. Rides along for the same reason the
+   * timeout does: a caller that resolves a model needs the bounds on it.
+   */
+  reasoningEffort?: ReasoningEffort | null;
 }
 
 /**
@@ -126,9 +134,14 @@ export async function resolveSystemSettingsModel(
 
   let modelId: string | null = null;
   let configured = `${modelType}_model_id`;
-  // Each model setting has a timeout beside it, and the two are resolved
-  // together so a caller cannot take one without the other.
-  const timeoutMs = systemSettings.options[modelType].timeout_ms;
+  // Each model setting has its bounds beside it, and they are resolved
+  // together so a caller cannot take one without the others.
+  const roleOptions = systemSettings.options[modelType];
+  const timeoutMs = roleOptions.timeout_ms;
+  // Every role but embedding has an effort; an embedding has nothing to think
+  // about, so its options object carries none.
+  const reasoningEffort =
+    'reasoning_effort' in roleOptions ? roleOptions.reasoning_effort : null;
 
   switch (modelType) {
     case 'judge':
@@ -169,13 +182,13 @@ export async function resolveSystemSettingsModel(
   }
 
   const resolved = await resolveModelById(c, modelId, connector, logPrefix);
-  return resolved && { ...resolved, timeoutMs };
+  return resolved && { ...resolved, timeoutMs, reasoningEffort };
 }
 
 /**
- * Resolves the judge with everything a judging call needs from settings:
- * the model, its timeout, and the completion budget that lets a reasoning
- * model finish its answer.
+ * Resolves the judge with everything a judging call needs from settings: the
+ * model, its timeout and reasoning effort, and the completion budget that
+ * lets a thinking model finish its answer.
  */
 export async function resolveJudgeModelConfig(
   c: AppContext,
@@ -189,6 +202,8 @@ export async function resolveJudgeModelConfig(
     connector,
     systemSettings,
   );
+  // The effort arrives with the model, like every role's; only the budget is
+  // the judge's own.
   return (
     resolved && {
       ...resolved,
@@ -232,6 +247,7 @@ export async function resolveEvaluationModelConfig(
       ...resolved,
       timeoutMs: options.judge.timeout_ms,
       maxTokens: options.judge.max_tokens,
+      reasoningEffort: options.judge.reasoning_effort,
     };
   }
 

--- a/packages/api/src/utils/super-agents/intent-compaction.test.ts
+++ b/packages/api/src/utils/super-agents/intent-compaction.test.ts
@@ -5,6 +5,7 @@ import {
   clearCompactedPrompts,
   compactSystemPrompt,
 } from '@api/utils/super-agents/intent-compaction';
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { AIProvider } from '@shared/types/constants';
 import { SYSTEM_PROMPT_BUDGET } from '@shared/utils/request-intent';
 import OpenAI from 'openai';
@@ -64,6 +65,30 @@ describe('compactSystemPrompt', () => {
     expect(JSON.stringify(mockCreate.mock.calls[0])).toContain(
       'You are a coding CLI.',
     );
+  });
+
+  it('sends the compaction reasoning effort the settings chose', async () => {
+    vi.mocked(resolveSystemSettingsModel).mockResolvedValue({
+      model: 'reflect-model',
+      provider: AIProvider.OPENAI,
+      apiKey: 'key',
+      timeoutMs: 90_000,
+      reasoningEffort: ReasoningEffort.NONE,
+    } as never);
+
+    await compactSystemPrompt(createMockContext(), connector, longPrompt);
+
+    // Summarising is transcription rather than deliberation, and a request
+    // carrying the prompt waits for it.
+    expect(mockCreate.mock.calls[0][0]).toMatchObject({
+      reasoning_effort: 'none',
+    });
+  });
+
+  it('sends none when the role leaves the model to its default', async () => {
+    await compactSystemPrompt(createMockContext(), connector, longPrompt);
+
+    expect(mockCreate.mock.calls[0][0]).not.toHaveProperty('reasoning_effort');
   });
 
   it('waits as long as the configured compaction timeout allows', async () => {

--- a/packages/api/src/utils/super-agents/intent-compaction.ts
+++ b/packages/api/src/utils/super-agents/intent-compaction.ts
@@ -64,6 +64,11 @@ async function compactOnce(
     })
     .chat.completions.create({
       ...SA_SKILL_REQUEST_PARAMS,
+      // Only when the role's setting names one: a model that takes no such
+      // parameter is left at its own default.
+      ...(modelConfig.reasoningEffort
+        ? { reasoning_effort: modelConfig.reasoningEffort }
+        : {}),
       model: modelConfig.model,
       // Deterministic, so the summary -- and with it the identity embedding
       // -- stays put across restarts instead of drifting per process.

--- a/packages/api/src/utils/super-agents/skill-arbiter.test.ts
+++ b/packages/api/src/utils/super-agents/skill-arbiter.test.ts
@@ -5,8 +5,10 @@ import {
   resolveSystemSettingsModel,
 } from '@api/utils/evaluation-model-resolver';
 import { arbitrateSkillForRequest } from '@api/utils/super-agents/skill-arbiter';
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { AIProvider } from '@shared/types/constants';
 import type { Agent, Skill, SystemSettings } from '@shared/types/data';
+import { SystemSettingsOptions } from '@shared/types/data/system-settings';
 import type { RequestIntent } from '@shared/utils/request-intent';
 import OpenAI from 'openai';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -64,15 +66,10 @@ const settings = {
   skill_arbiter_model_id: null,
   intent_compaction_model_id: null,
   system_prompt_reflection_model_id: 'reflection-model',
-  options: {
-    system_prompt_reflection: { timeout_ms: 120_000 },
-    evaluation_generation: { timeout_ms: 120_000 },
-    embedding: { timeout_ms: 30_000 },
-    judge: { timeout_ms: 60_000, max_tokens: 4_000 },
+  options: SystemSettingsOptions.parse({
     skill_arbiter: { timeout_ms: 42_000 },
     intent_compaction: { timeout_ms: 15_000 },
-    developer_mode: false,
-  },
+  }),
 } as SystemSettings;
 
 const answer = (skillName: string | null) => ({
@@ -149,6 +146,54 @@ describe('arbitrateSkillForRequest', () => {
       timeout: 7_000,
     });
     expect(mockParse.mock.calls[0][0]).toMatchObject({ model: 'agent-model' });
+  });
+
+  it('sends the arbiter reasoning effort the settings chose', async () => {
+    // A request waits for this answer, so the setting exists to keep the
+    // model from thinking its way past the timeout.
+    vi.mocked(resolveSystemSettingsModel).mockResolvedValue({
+      model: 'arbiter-model',
+      provider: AIProvider.OPENAI,
+      apiKey: 'k',
+      timeoutMs: 42_000,
+      reasoningEffort: ReasoningEffort.NONE,
+    });
+    mockParse.mockResolvedValue(answer(null));
+
+    await arbitrateSkillForRequest(
+      createMockContext(),
+      connector,
+      agent,
+      skills,
+      intent,
+      settings,
+    );
+
+    expect(mockParse.mock.calls[0][0]).toMatchObject({
+      reasoning_effort: 'none',
+    });
+  });
+
+  it('sends none when the role leaves the model to its default', async () => {
+    vi.mocked(resolveSystemSettingsModel).mockResolvedValue({
+      model: 'arbiter-model',
+      provider: AIProvider.OPENAI,
+      apiKey: 'k',
+      timeoutMs: 42_000,
+      reasoningEffort: null,
+    });
+    mockParse.mockResolvedValue(answer(null));
+
+    await arbitrateSkillForRequest(
+      createMockContext(),
+      connector,
+      agent,
+      skills,
+      intent,
+      settings,
+    );
+
+    expect(mockParse.mock.calls[0][0]).not.toHaveProperty('reasoning_effort');
   });
 
   it('maps a named skill to an existing verdict', async () => {

--- a/packages/api/src/utils/super-agents/skill-arbiter.ts
+++ b/packages/api/src/utils/super-agents/skill-arbiter.ts
@@ -158,6 +158,11 @@ export async function arbitrateSkillForRequest(
       })
       .chat.completions.parse({
         ...SA_SKILL_REQUEST_PARAMS,
+        // Only when the role's setting names one: a model that takes no such
+        // parameter is left at its own default.
+        ...(modelConfig.reasoningEffort
+          ? { reasoning_effort: modelConfig.reasoningEffort }
+          : {}),
         model: modelConfig.model,
         messages: [
           { role: 'system', content: ARBITER_SYSTEM_PROMPT },

--- a/packages/api/src/utils/super-agents/skill-routing.test.ts
+++ b/packages/api/src/utils/super-agents/skill-routing.test.ts
@@ -16,6 +16,7 @@ import {
 import { FunctionName } from '@shared/types/api/request';
 import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
 import type { Agent, Skill, SkillRouting } from '@shared/types/data';
+import { SystemSettingsOptions } from '@shared/types/data/system-settings';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 vi.mock('@api/utils/embeddings', async (importOriginal) => ({
@@ -133,15 +134,9 @@ const routingConnector = (): RoutingConnector => {
       embedding_model_id: MODEL_ID,
       skill_arbiter_model_id: null,
       intent_compaction_model_id: null,
-      options: {
-        system_prompt_reflection: { timeout_ms: 120_000 },
-        evaluation_generation: { timeout_ms: 120_000 },
-        embedding: { timeout_ms: 30_000 },
-        judge: { timeout_ms: 60_000, max_tokens: 4_000 },
-        skill_arbiter: { timeout_ms: 15_000 },
+      options: SystemSettingsOptions.parse({
         intent_compaction: { timeout_ms: 15_000 },
-        developer_mode: false,
-      },
+      }),
     }),
     claimSkillCreationLease: vi.fn().mockResolvedValue(true),
     releaseSkillCreationLease: vi.fn(),
@@ -557,7 +552,7 @@ describe('routeRequestToSkill', () => {
         // The system settings, read once and handed on.
         expect.objectContaining({
           options: expect.objectContaining({
-            skill_arbiter: { timeout_ms: 15_000 },
+            skill_arbiter: { timeout_ms: 15_000, reasoning_effort: null },
           }),
         }),
       );

--- a/packages/api/src/v1/super-agents/models.test.ts
+++ b/packages/api/src/v1/super-agents/models.test.ts
@@ -4,6 +4,7 @@ import { createMockContext } from '@api/test-utils/mock-context';
 import type { AppEnv } from '@api/types/hono';
 import { modelsRouter } from '@api/v1/super-agents/models';
 import type { Model } from '@shared/types/data/model';
+import { SystemSettingsOptions } from '@shared/types/data/system-settings';
 import { Hono } from 'hono';
 import { createFactory } from 'hono/factory';
 import { sign } from 'hono/jwt';
@@ -303,15 +304,9 @@ describe('Models API Status Codes', () => {
       judge_model_id: null,
       skill_arbiter_model_id: null,
       intent_compaction_model_id: null,
-      options: {
-        system_prompt_reflection: { timeout_ms: 120_000 },
-        evaluation_generation: { timeout_ms: 120_000 },
-        embedding: { timeout_ms: 30_000 },
-        judge: { timeout_ms: 60_000, max_tokens: 4_000 },
-        skill_arbiter: { timeout_ms: 15_000 },
+      options: SystemSettingsOptions.parse({
         intent_compaction: { timeout_ms: 15_000 },
-        developer_mode: false,
-      },
+      }),
       created_at: '2023-01-01T00:00:00.000Z',
       updated_at: '2023-01-01T00:00:00.000Z',
     };

--- a/packages/api/src/v1/super-agents/skills.test.ts
+++ b/packages/api/src/v1/super-agents/skills.test.ts
@@ -2,6 +2,7 @@ import { BaseArmsParams } from '@api/optimization/base-arms';
 import { generateSeedSystemPromptForSkill } from '@api/optimization/utils/system-prompt';
 import type { AppEnv } from '@api/types/hono';
 import { skillsRouter } from '@api/v1/super-agents/skills';
+import { SystemSettingsOptions } from '@shared/types/data/system-settings';
 import { Hono } from 'hono';
 import { testClient } from 'hono/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -152,15 +153,9 @@ describe('Skills API Status Codes', () => {
       evaluation_generation_model_id: null,
       skill_arbiter_model_id: null,
       intent_compaction_model_id: null,
-      options: {
-        system_prompt_reflection: { timeout_ms: 120_000 },
-        evaluation_generation: { timeout_ms: 120_000 },
-        embedding: { timeout_ms: 30_000 },
-        judge: { timeout_ms: 60_000, max_tokens: 4_000 },
-        skill_arbiter: { timeout_ms: 15_000 },
+      options: SystemSettingsOptions.parse({
         intent_compaction: { timeout_ms: 15_000 },
-        developer_mode: false,
-      },
+      }),
     });
   });
 

--- a/packages/api/src/v1/super-agents/system-settings.test.ts
+++ b/packages/api/src/v1/super-agents/system-settings.test.ts
@@ -1,5 +1,9 @@
 import type { AppEnv } from '@api/types/hono';
 import { systemSettingsRouter } from '@api/v1/super-agents/system-settings';
+import {
+  SystemSettingsOptions,
+  TEXT_ROLES,
+} from '@shared/types/data/system-settings';
 import { Hono } from 'hono';
 import { testClient } from 'hono/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -32,15 +36,9 @@ describe('System Settings API', () => {
     judge_model_id: 'model-4444-5555-6666-777788889999',
     skill_arbiter_model_id: null,
     intent_compaction_model_id: null,
-    options: {
-      system_prompt_reflection: { timeout_ms: 120_000 },
-      evaluation_generation: { timeout_ms: 120_000 },
-      embedding: { timeout_ms: 30_000 },
-      judge: { timeout_ms: 60_000, max_tokens: 4_000 },
-      skill_arbiter: { timeout_ms: 15_000 },
+    options: SystemSettingsOptions.parse({
       intent_compaction: { timeout_ms: 15_000 },
-      developer_mode: false,
-    },
+    }),
     created_at: '2023-01-01T00:00:00Z',
     updated_at: '2023-01-01T00:00:00Z',
   };
@@ -247,6 +245,39 @@ describe('System Settings API', () => {
         json: { options: { judge: { max_tokens: 16_000 } } },
       });
       expect(ok.status).toBe(200);
+    });
+
+    it('should accept a reasoning effort on every text role, or null to clear it', async () => {
+      for (const role of TEXT_ROLES) {
+        for (const reasoning_effort of ['none', 'low', 'high', null]) {
+          mockUserDataStorageConnector.updateSystemSettings.mockResolvedValue({
+            ...mockSettings,
+            options: {
+              ...mockSettings.options,
+              [role]: { ...mockSettings.options[role], reasoning_effort },
+            },
+          });
+          const res = await client.index.$patch({
+            json: { options: { [role]: { reasoning_effort } } } as never,
+          });
+          expect(res.status).toBe(200);
+        }
+      }
+    });
+
+    it('should return 400 for a reasoning effort it cannot honour', async () => {
+      for (const json of [
+        // Not one of the enum's values.
+        { options: { judge: { reasoning_effort: 'ultra' } } },
+        // Embedding has no effort: one forward pass, nothing to think about.
+        { options: { embedding: { reasoning_effort: 'low' } } },
+      ]) {
+        const res = await client.index.$patch({ json: json as never });
+        expect(res.status).toBe(400);
+      }
+      expect(
+        mockUserDataStorageConnector.updateSystemSettings,
+      ).not.toHaveBeenCalled();
     });
 
     it('should return 400 for an unknown option (strict validation)', async () => {

--- a/packages/shared/src/types/api/routes/shared/thinking.ts
+++ b/packages/shared/src/types/api/routes/shared/thinking.ts
@@ -1,4 +1,9 @@
 export enum ReasoningEffort {
+  /**
+   * No reasoning at all. OpenAI's newer models take it, and Ollama's
+   * OpenAI-compatible endpoint maps it to turning thinking off.
+   */
+  NONE = 'none',
   MINIMAL = 'minimal',
   LOW = 'low',
   MEDIUM = 'medium',

--- a/packages/shared/src/types/data/system-settings.test.ts
+++ b/packages/shared/src/types/data/system-settings.test.ts
@@ -1,0 +1,181 @@
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
+import {
+  DEFAULT_JUDGE_MAX_TOKENS,
+  INTERNAL_ROLES,
+  mergeSystemSettingsOptions,
+  SystemSettingsOptions,
+  SystemSettingsOptionsUpdate,
+  TEXT_ROLES,
+} from '@shared/types/data/system-settings';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The settings that need no column of their own live in one JSON document,
+ * which puts the weight on this schema: its defaults are what a row written
+ * before a field existed reads as, and its merge is what a PATCH means.
+ */
+
+describe('SystemSettingsOptions', () => {
+  it('reads an empty document as every default', () => {
+    const options = SystemSettingsOptions.parse({});
+
+    expect(options.system_prompt_reflection.timeout_ms).toBe(120_000);
+    expect(options.evaluation_generation.timeout_ms).toBe(120_000);
+    expect(options.embedding.timeout_ms).toBe(30_000);
+    expect(options.judge.timeout_ms).toBe(60_000);
+    expect(options.judge.max_tokens).toBe(DEFAULT_JUDGE_MAX_TOKENS);
+    expect(options.skill_arbiter.timeout_ms).toBe(15_000);
+    expect(options.intent_compaction.timeout_ms).toBe(60_000);
+    expect(options.developer_mode).toBe(false);
+  });
+
+  it('starts every text role at the model’s own reasoning default', () => {
+    const options = SystemSettingsOptions.parse({});
+
+    for (const role of TEXT_ROLES) {
+      expect(options[role].reasoning_effort).toBeNull();
+    }
+  });
+
+  it('gives an effort to every role but embedding', () => {
+    // An embedding is one forward pass with nothing to think about, and its
+    // slot only accepts an embed model.
+    expect(TEXT_ROLES).toEqual(
+      INTERNAL_ROLES.filter((role) => role !== 'embedding'),
+    );
+    expect(SystemSettingsOptions.parse({}).embedding).toEqual({
+      timeout_ms: 30_000,
+    });
+  });
+
+  it('fills only what a partial document lacks', () => {
+    // This is what makes adding a setting a change to this schema alone: a
+    // row stored before the field existed reads as if it had been set.
+    const options = SystemSettingsOptions.parse({
+      judge: { timeout_ms: 90_000 },
+      developer_mode: true,
+    });
+
+    expect(options.judge).toEqual({
+      timeout_ms: 90_000,
+      max_tokens: DEFAULT_JUDGE_MAX_TOKENS,
+      reasoning_effort: null,
+    });
+    expect(options.developer_mode).toBe(true);
+    expect(options.skill_arbiter.timeout_ms).toBe(15_000);
+  });
+});
+
+describe('SystemSettingsOptionsUpdate', () => {
+  it('accepts a reasoning effort on any text role, and null to clear it', () => {
+    for (const role of TEXT_ROLES) {
+      expect(
+        SystemSettingsOptionsUpdate.safeParse({
+          [role]: { reasoning_effort: ReasoningEffort.NONE },
+        }).success,
+      ).toBe(true);
+      expect(
+        SystemSettingsOptionsUpdate.safeParse({
+          [role]: { reasoning_effort: null },
+        }).success,
+      ).toBe(true);
+    }
+  });
+
+  it('refuses an effort on the embedding role, which has none', () => {
+    expect(
+      SystemSettingsOptionsUpdate.safeParse({
+        embedding: { reasoning_effort: ReasoningEffort.LOW },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('refuses an effort outside the enum, and any unknown key', () => {
+    expect(
+      SystemSettingsOptionsUpdate.safeParse({
+        judge: { reasoning_effort: 'ultra' },
+      }).success,
+    ).toBe(false);
+    expect(
+      SystemSettingsOptionsUpdate.safeParse({ judge: { thinking: 'low' } })
+        .success,
+    ).toBe(false);
+    expect(
+      SystemSettingsOptionsUpdate.safeParse({ judge_timeout_ms: 60_000 })
+        .success,
+    ).toBe(false);
+  });
+
+  it('bounds the timeouts and the judge token budget', () => {
+    expect(
+      SystemSettingsOptionsUpdate.safeParse({ judge: { timeout_ms: 500 } })
+        .success,
+    ).toBe(false);
+    expect(
+      SystemSettingsOptionsUpdate.safeParse({ judge: { max_tokens: 10 } })
+        .success,
+    ).toBe(false);
+    expect(
+      SystemSettingsOptionsUpdate.safeParse({
+        judge: { timeout_ms: 90_000, max_tokens: 16_000 },
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe('mergeSystemSettingsOptions', () => {
+  const stored = SystemSettingsOptions.parse({});
+
+  it('leaves everything a patch does not name', () => {
+    const merged = mergeSystemSettingsOptions(stored, {
+      judge: { max_tokens: 16_000 },
+    });
+
+    expect(merged.judge.max_tokens).toBe(16_000);
+    // The judge's other fields, and every other role, are untouched.
+    expect(merged.judge.timeout_ms).toBe(60_000);
+    expect(merged.judge.reasoning_effort).toBeNull();
+    expect(merged.skill_arbiter).toEqual(stored.skill_arbiter);
+    expect(merged.developer_mode).toBe(false);
+  });
+
+  it('sets and clears a reasoning effort per role', () => {
+    const set = mergeSystemSettingsOptions(stored, {
+      judge: { reasoning_effort: ReasoningEffort.NONE },
+      system_prompt_reflection: { reasoning_effort: ReasoningEffort.HIGH },
+    });
+    expect(set.judge.reasoning_effort).toBe('none');
+    expect(set.system_prompt_reflection.reasoning_effort).toBe('high');
+    expect(set.skill_arbiter.reasoning_effort).toBeNull();
+
+    // Null is a value here -- back to the model's own default -- not an
+    // omission, which is why the merge cannot simply drop nullish fields.
+    const cleared = mergeSystemSettingsOptions(set, {
+      judge: { reasoning_effort: null },
+    });
+    expect(cleared.judge.reasoning_effort).toBeNull();
+    expect(cleared.system_prompt_reflection.reasoning_effort).toBe('high');
+  });
+
+  it('changes several fields of one role at once', () => {
+    const merged = mergeSystemSettingsOptions(stored, {
+      judge: {
+        timeout_ms: 90_000,
+        max_tokens: 16_000,
+        reasoning_effort: ReasoningEffort.LOW,
+      },
+      developer_mode: true,
+    });
+
+    expect(merged.judge).toEqual({
+      timeout_ms: 90_000,
+      max_tokens: 16_000,
+      reasoning_effort: 'low',
+    });
+    expect(merged.developer_mode).toBe(true);
+  });
+
+  it('is a no-op for an empty patch', () => {
+    expect(mergeSystemSettingsOptions(stored, {})).toEqual(stored);
+  });
+});

--- a/packages/shared/src/types/data/system-settings.ts
+++ b/packages/shared/src/types/data/system-settings.ts
@@ -1,3 +1,4 @@
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { z } from 'zod';
 
 /**
@@ -73,8 +74,31 @@ export const INTERNAL_ROLES = [
 ] as const;
 export type InternalRole = (typeof INTERNAL_ROLES)[number];
 
+/**
+ * The roles served by a text model, which is every role but embedding.
+ *
+ * Only these carry a reasoning effort: an embedding is one forward pass with
+ * nothing to think about, and its slot takes an embed model anyway.
+ */
+export const TEXT_ROLES = INTERNAL_ROLES.filter(
+  (role): role is Exclude<InternalRole, 'embedding'> => role !== 'embedding',
+);
+export type TextRole = (typeof TEXT_ROLES)[number];
+
 const timeout = (defaultMs: number) =>
   z.number().int().positive().default(defaultMs);
+
+/**
+ * How hard a reasoning model may think before it answers.
+ *
+ * Null sends nothing and leaves the model to its own default, which is where
+ * every role starts. It is per role because the roles ask for different work:
+ * the judge answers a score and a sentence and the arbiter names a skill,
+ * while reflection writes a system prompt and may be worth the thinking. A
+ * model that takes no such parameter is unaffected -- the gateway drops it
+ * from the request.
+ */
+const reasoningEffort = () => z.enum(ReasoningEffort).nullable().default(null);
 const timeoutUpdate = () =>
   z
     .number()
@@ -106,11 +130,15 @@ export const SystemSettingsOptions = z.object({
   system_prompt_reflection: z
     .object({
       timeout_ms: timeout(DEFAULT_SYSTEM_PROMPT_REFLECTION_TIMEOUT_MS),
+      reasoning_effort: reasoningEffort(),
     })
     .prefault({}),
   /** How long one attempt at generating a skill's evaluations may take. */
   evaluation_generation: z
-    .object({ timeout_ms: timeout(DEFAULT_EVALUATION_GENERATION_TIMEOUT_MS) })
+    .object({
+      timeout_ms: timeout(DEFAULT_EVALUATION_GENERATION_TIMEOUT_MS),
+      reasoning_effort: reasoningEffort(),
+    })
     .prefault({}),
   /**
    * How long one embedding call may take. On the request path -- routing
@@ -123,17 +151,28 @@ export const SystemSettingsOptions = z.object({
     .object({
       /** How long one judging attempt may take, task extraction included. */
       timeout_ms: timeout(DEFAULT_JUDGE_TIMEOUT_MS),
-      /** How many completion tokens one judging attempt may spend. */
+      /**
+       * How many completion tokens one judging attempt may spend. A thinking
+       * model spends these before it writes a word, and one that runs out
+       * answers nothing at all -- which is why this sits beside the effort.
+       */
       max_tokens: z.number().int().positive().default(DEFAULT_JUDGE_MAX_TOKENS),
+      reasoning_effort: reasoningEffort(),
     })
     .prefault({}),
   /** How long one arbiter attempt may take, in milliseconds. */
   skill_arbiter: z
-    .object({ timeout_ms: timeout(DEFAULT_SKILL_ARBITER_TIMEOUT_MS) })
+    .object({
+      timeout_ms: timeout(DEFAULT_SKILL_ARBITER_TIMEOUT_MS),
+      reasoning_effort: reasoningEffort(),
+    })
     .prefault({}),
   /** How long one compaction attempt may take, in milliseconds. */
   intent_compaction: z
-    .object({ timeout_ms: timeout(DEFAULT_INTENT_COMPACTION_TIMEOUT_MS) })
+    .object({
+      timeout_ms: timeout(DEFAULT_INTENT_COMPACTION_TIMEOUT_MS),
+      reasoning_effort: reasoningEffort(),
+    })
     .prefault({}),
   /** Shows the `super-agents` internal agent and its skills in the dashboard. */
   developer_mode: z.boolean().default(false),
@@ -167,16 +206,24 @@ export type SystemSettings = z.infer<typeof SystemSettings>;
  * one, so a caller sends only the fields it changes. Strict throughout, so a
  * misspelled field is refused rather than stored and ignored.
  */
+/** Null clears a reasoning effort: back to the model's own default. */
+const reasoningEffortUpdate = () =>
+  z.enum(ReasoningEffort).nullable().optional();
+
+/** A text role's patch: its timeout, its reasoning effort, or both. */
+const textRoleUpdate = () =>
+  z
+    .object({
+      timeout_ms: timeoutUpdate(),
+      reasoning_effort: reasoningEffortUpdate(),
+    })
+    .strict()
+    .optional();
+
 export const SystemSettingsOptionsUpdate = z
   .object({
-    system_prompt_reflection: z
-      .object({ timeout_ms: timeoutUpdate() })
-      .strict()
-      .optional(),
-    evaluation_generation: z
-      .object({ timeout_ms: timeoutUpdate() })
-      .strict()
-      .optional(),
+    system_prompt_reflection: textRoleUpdate(),
+    evaluation_generation: textRoleUpdate(),
     embedding: z.object({ timeout_ms: timeoutUpdate() }).strict().optional(),
     judge: z
       .object({
@@ -187,17 +234,12 @@ export const SystemSettingsOptionsUpdate = z
           .min(MIN_JUDGE_MAX_TOKENS)
           .max(MAX_JUDGE_MAX_TOKENS)
           .optional(),
+        reasoning_effort: reasoningEffortUpdate(),
       })
       .strict()
       .optional(),
-    skill_arbiter: z
-      .object({ timeout_ms: timeoutUpdate() })
-      .strict()
-      .optional(),
-    intent_compaction: z
-      .object({ timeout_ms: timeoutUpdate() })
-      .strict()
-      .optional(),
+    skill_arbiter: textRoleUpdate(),
+    intent_compaction: textRoleUpdate(),
     developer_mode: z.boolean().optional(),
   })
   .strict();

--- a/packages/web/src/components/settings/reasoning-effort-field.tsx
+++ b/packages/web/src/components/settings/reasoning-effort-field.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
+import { Label } from '@web/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@web/components/ui/select';
+import type { ReactElement } from 'react';
+import { useId } from 'react';
+
+/**
+ * The value standing for "send nothing and let the model decide".
+ *
+ * A Radix select item cannot carry an empty value, so the absence of a
+ * setting needs a name of its own on the way in and out of the control.
+ */
+export const MODEL_DEFAULT_EFFORT = 'model-default';
+
+export interface ReasoningEffortFieldProps {
+  /** The field's accessible name, e.g. `Judge Reasoning Effort`. */
+  label: string;
+  /** What thinking costs this role, and what it buys. */
+  description: string;
+  value: ReasoningEffort | null;
+  onChange: (value: ReasoningEffort | null) => void;
+  isLoading: boolean;
+}
+
+/**
+ * One role's reasoning effort, on the line beneath the model it applies to.
+ *
+ * Every text model gets one because the roles ask for different work: naming
+ * a skill or scoring a turn wants an answer, while writing a system prompt
+ * may be worth the thinking. A model that takes no such parameter is
+ * unaffected, so the control is safe to leave at the model default.
+ */
+export function ReasoningEffortField({
+  label,
+  description,
+  value,
+  onChange,
+  isLoading,
+}: ReasoningEffortFieldProps): ReactElement {
+  const id = useId();
+
+  return (
+    <div className="flex items-center gap-2">
+      <Label
+        htmlFor={id}
+        className="text-sm text-muted-foreground whitespace-nowrap"
+      >
+        Reasoning
+      </Label>
+      <Select
+        value={value ?? MODEL_DEFAULT_EFFORT}
+        onValueChange={(next) =>
+          onChange(
+            next === MODEL_DEFAULT_EFFORT ? null : (next as ReasoningEffort),
+          )
+        }
+        disabled={isLoading}
+      >
+        <SelectTrigger
+          id={id}
+          className="h-8 w-36"
+          aria-label={label}
+          title={description}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={MODEL_DEFAULT_EFFORT}>Model default</SelectItem>
+          {Object.values(ReasoningEffort).map((effort) => (
+            <SelectItem key={effort} value={effort}>
+              {effort}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/system-settings-view.test.tsx
+++ b/packages/web/src/components/settings/system-settings-view.test.tsx
@@ -1,6 +1,12 @@
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import type { SystemSettings } from '@shared/types/data/system-settings';
+import { SystemSettingsOptions } from '@shared/types/data/system-settings';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { SystemSettingsView } from '@web/components/settings/system-settings-view';
+import {
+  buildOptionsPatch,
+  type FormValues,
+  SystemSettingsView,
+} from '@web/components/settings/system-settings-view';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
@@ -22,15 +28,9 @@ const settings: SystemSettings = {
   judge_model_id: null,
   skill_arbiter_model_id: null,
   intent_compaction_model_id: null,
-  options: {
-    system_prompt_reflection: { timeout_ms: 120_000 },
-    evaluation_generation: { timeout_ms: 120_000 },
-    embedding: { timeout_ms: 30_000 },
-    judge: { timeout_ms: 60_000, max_tokens: 4_000 },
-    skill_arbiter: { timeout_ms: 15_000 },
+  options: SystemSettingsOptions.parse({
     intent_compaction: { timeout_ms: 15_000 },
-    developer_mode: false,
-  },
+  }),
   created_at: '2023-01-01T00:00:00Z',
   updated_at: '2023-01-01T00:00:00Z',
 };
@@ -240,5 +240,129 @@ describe('SystemSettingsView', () => {
       );
     });
     expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('gives every text model a reasoning effort, at the model default', () => {
+    render(<SystemSettingsView />);
+
+    for (const label of [
+      'Reflection Reasoning Effort',
+      'Evaluation Generation Reasoning Effort',
+      'Judge Reasoning Effort',
+      'Arbiter Reasoning Effort',
+      'Compaction Reasoning Effort',
+    ]) {
+      expect(screen.getByLabelText(label)).toHaveTextContent('Model default');
+    }
+  });
+
+  it('offers no reasoning effort for the embedding model', () => {
+    render(<SystemSettingsView />);
+
+    expect(screen.getByLabelText('Embedding Timeout')).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Embedding Reasoning Effort'),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('buildOptionsPatch', () => {
+  // What the form holds when nothing has been touched: the stored settings.
+  const untouched: FormValues = {
+    system_prompt_reflection_model_id: null,
+    evaluation_generation_model_id: null,
+    embedding_model_id: null,
+    judge_model_id: null,
+    skill_arbiter_model_id: null,
+    intent_compaction_model_id: null,
+    timeouts: {
+      system_prompt_reflection: 120,
+      evaluation_generation: 120,
+      embedding: 30,
+      judge: 60,
+      skill_arbiter: 15,
+      intent_compaction: 15,
+    },
+    reasoningEfforts: {
+      system_prompt_reflection: null,
+      evaluation_generation: null,
+      judge: null,
+      skill_arbiter: null,
+      intent_compaction: null,
+    },
+    judge_max_tokens: 4_000,
+    developer_mode: false,
+  };
+
+  it('sends nothing when nothing changed', () => {
+    expect(buildOptionsPatch(untouched, settings)).toEqual({});
+  });
+
+  it('sends a chosen reasoning effort for any role, and null to clear one', () => {
+    expect(
+      buildOptionsPatch(
+        {
+          ...untouched,
+          reasoningEfforts: {
+            ...untouched.reasoningEfforts,
+            skill_arbiter: ReasoningEffort.NONE,
+            system_prompt_reflection: ReasoningEffort.HIGH,
+          },
+        },
+        settings,
+      ),
+    ).toEqual({
+      skill_arbiter: { reasoning_effort: 'none' },
+      system_prompt_reflection: { reasoning_effort: 'high' },
+    });
+
+    const stored = {
+      ...settings,
+      options: {
+        ...settings.options,
+        judge: {
+          ...settings.options.judge,
+          reasoning_effort: ReasoningEffort.LOW,
+        },
+      },
+    };
+    expect(buildOptionsPatch(untouched, stored)).toEqual({
+      judge: { reasoning_effort: null },
+    });
+  });
+
+  it("folds every changed field of one role into that role's object", () => {
+    expect(
+      buildOptionsPatch(
+        {
+          ...untouched,
+          timeouts: { ...untouched.timeouts, judge: 90 },
+          judge_max_tokens: 16_000,
+          reasoningEfforts: {
+            ...untouched.reasoningEfforts,
+            judge: ReasoningEffort.LOW,
+          },
+          developer_mode: true,
+        },
+        settings,
+      ),
+    ).toEqual({
+      judge: {
+        timeout_ms: 90_000,
+        max_tokens: 16_000,
+        reasoning_effort: 'low',
+      },
+      developer_mode: true,
+    });
+  });
+
+  it('never sends an effort for the embedding role', () => {
+    // It has none to send: an embedding is one forward pass.
+    const patch = buildOptionsPatch(
+      { ...untouched, timeouts: { ...untouched.timeouts, embedding: 45 } },
+      settings,
+    );
+
+    expect(patch.embedding).toEqual({ timeout_ms: 45_000 });
   });
 });

--- a/packages/web/src/components/settings/system-settings-view.tsx
+++ b/packages/web/src/components/settings/system-settings-view.tsx
@@ -1,13 +1,17 @@
 'use client';
 
+import type { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { type AIProvider, PrettyAIProvider } from '@shared/types/constants';
 import {
   INTERNAL_ROLES,
   type InternalRole,
   MAX_JUDGE_MAX_TOKENS,
   MIN_JUDGE_MAX_TOKENS,
+  type SystemSettings,
   type SystemSettingsOptionsUpdate,
   type SystemSettingsUpdateParams,
+  TEXT_ROLES,
+  type TextRole,
 } from '@shared/types/data/system-settings';
 import {
   BoundedNumberField,
@@ -18,6 +22,7 @@ import {
   type ModelOption,
   ModelSelector,
 } from '@web/components/settings/model-selector';
+import { ReasoningEffortField } from '@web/components/settings/reasoning-effort-field';
 import {
   TimeoutField,
   timeoutProblem,
@@ -53,7 +58,7 @@ type ModelField =
   | 'skill_arbiter_model_id'
   | 'intent_compaction_model_id';
 
-interface FormValues extends Record<ModelField, string | null> {
+export interface FormValues extends Record<ModelField, string | null> {
   /**
    * Edited in seconds, keyed by the role whose `options.<role>.timeout_ms`
    * each one saves to, so adding a role adds a field here without touching
@@ -62,6 +67,11 @@ interface FormValues extends Record<ModelField, string | null> {
   timeouts: Record<InternalRole, number>;
   /** `options.judge.max_tokens`: completion tokens one judging call may spend. */
   judge_max_tokens: number;
+  /**
+   * `options.<role>.reasoning_effort`, keyed by role like the timeouts. Null
+   * leaves that role's model to its own default.
+   */
+  reasoningEfforts: Record<TextRole, ReasoningEffort | null>;
   developer_mode: boolean;
 }
 
@@ -72,14 +82,44 @@ const blankTimeouts = (): Record<InternalRole, number> =>
     number
   >;
 
+/** Every effort at the model's own default, before settings arrive. */
+const blankReasoningEfforts = (): Record<TextRole, ReasoningEffort | null> =>
+  Object.fromEntries(TEXT_ROLES.map((role) => [role, null])) as Record<
+    TextRole,
+    ReasoningEffort | null
+  >;
+
+/** What each role is called where a field has to name it. */
+const ROLE_LABELS: Record<InternalRole, string> = {
+  system_prompt_reflection: 'Reflection',
+  evaluation_generation: 'Evaluation Generation',
+  embedding: 'Embedding',
+  judge: 'Judge',
+  skill_arbiter: 'Arbiter',
+  intent_compaction: 'Compaction',
+};
+
 /** How each role's timeout reads in the dashboard. */
-const TIMEOUT_LABELS: Record<InternalRole, string> = {
-  system_prompt_reflection: 'Reflection Timeout',
-  evaluation_generation: 'Evaluation Generation Timeout',
-  embedding: 'Embedding Timeout',
-  judge: 'Judge Timeout',
-  skill_arbiter: 'Arbiter Timeout',
-  intent_compaction: 'Compaction Timeout',
+const TIMEOUT_LABELS = Object.fromEntries(
+  INTERNAL_ROLES.map((role) => [role, `${ROLE_LABELS[role]} Timeout`]),
+) as Record<InternalRole, string>;
+
+/** And its reasoning effort, where it has one. */
+const REASONING_LABELS = Object.fromEntries(
+  TEXT_ROLES.map((role) => [role, `${ROLE_LABELS[role]} Reasoning Effort`]),
+) as Record<TextRole, string>;
+
+const REASONING_DESCRIPTIONS: Record<TextRole, string> = {
+  system_prompt_reflection:
+    'How hard this model may think before writing a system prompt or naming a skill. Writing a prompt is the one internal call where thinking tends to pay for itself.',
+  evaluation_generation:
+    "How hard this model may think before writing a skill's evaluations. It runs in the background, so thinking costs time rather than a caller's wait.",
+  judge:
+    "How hard the judge may think before it answers. Its answer is a score and a sentence, so on a thinking model 'none' or 'low' keeps the token budget for the answer rather than the reasoning.",
+  skill_arbiter:
+    "The arbiter only has to name a skill or none, and a request waits for the answer, so 'none' or 'low' serves it best.",
+  intent_compaction:
+    'Compaction summarises a long system prompt, which is more transcription than deliberation. A request carrying an uncompacted prompt waits for it.',
 };
 
 const TIMEOUT_DESCRIPTIONS: Record<InternalRole, string> = {
@@ -96,6 +136,40 @@ const TIMEOUT_DESCRIPTIONS: Record<InternalRole, string> = {
   intent_compaction:
     'Seconds one compaction attempt may take; a timed-out attempt is retried once. These prompts run to thousands of tokens, so allow more than the arbiter gets — when compaction keeps timing out, every request carrying that prompt pays the wait and then routes on a truncated one.',
 };
+
+/**
+ * The options a save sends: only what differs from the stored settings, one
+ * object per role, so the server merges rather than overwrites. Exported for
+ * the tests, since the reasoning-effort select cannot be driven in jsdom.
+ */
+export function buildOptionsPatch(
+  formValues: FormValues,
+  settings: SystemSettings | null,
+): SystemSettingsOptionsUpdate {
+  const options: SystemSettingsOptionsUpdate = {};
+  for (const role of INTERNAL_ROLES) {
+    const ms = formValues.timeouts[role] * 1000;
+    if (ms !== settings?.options[role].timeout_ms) {
+      options[role] = { timeout_ms: ms };
+    }
+  }
+  if (formValues.judge_max_tokens !== settings?.options.judge.max_tokens) {
+    options.judge = {
+      ...options.judge,
+      max_tokens: formValues.judge_max_tokens,
+    };
+  }
+  for (const role of TEXT_ROLES) {
+    const effort = formValues.reasoningEfforts[role];
+    if (effort !== settings?.options[role].reasoning_effort) {
+      options[role] = { ...options[role], reasoning_effort: effort };
+    }
+  }
+  if (formValues.developer_mode !== settings?.options.developer_mode) {
+    options.developer_mode = formValues.developer_mode;
+  }
+  return options;
+}
 
 const JUDGE_MAX_TOKENS_LABEL = 'Judge Token Budget';
 const JUDGE_MAX_TOKENS_DESCRIPTION =
@@ -127,6 +201,7 @@ export function SystemSettingsView(): ReactElement {
     intent_compaction_model_id: null,
     timeouts: blankTimeouts(),
     judge_max_tokens: MIN_JUDGE_MAX_TOKENS,
+    reasoningEfforts: blankReasoningEfforts(),
     developer_mode: false,
   });
 
@@ -156,6 +231,12 @@ export function SystemSettingsView(): ReactElement {
           ]),
         ) as Record<InternalRole, number>,
         judge_max_tokens: settings.options.judge.max_tokens,
+        reasoningEfforts: Object.fromEntries(
+          TEXT_ROLES.map((role) => [
+            role,
+            settings.options[role].reasoning_effort,
+          ]),
+        ) as Record<TextRole, ReasoningEffort | null>,
         developer_mode: settings.options.developer_mode,
       });
       setIsDirty(false);
@@ -208,6 +289,17 @@ export function SystemSettingsView(): ReactElement {
 
   const handleJudgeMaxTokensChange = (tokens: number) => {
     setFormValues((prev) => ({ ...prev, judge_max_tokens: tokens }));
+    setIsDirty(true);
+  };
+
+  const handleReasoningEffortChange = (
+    role: TextRole,
+    effort: ReasoningEffort | null,
+  ) => {
+    setFormValues((prev) => ({
+      ...prev,
+      reasoningEfforts: { ...prev.reasoningEfforts, [role]: effort },
+    }));
     setIsDirty(true);
   };
 
@@ -313,22 +405,7 @@ export function SystemSettingsView(): ReactElement {
       }
       // The options patch carries only what changed; the server merges it
       // over what is stored.
-      const options: SystemSettingsOptionsUpdate = {};
-      for (const role of INTERNAL_ROLES) {
-        const ms = formValues.timeouts[role] * 1000;
-        if (ms !== settings?.options[role].timeout_ms) {
-          options[role] = { timeout_ms: ms };
-        }
-      }
-      if (formValues.judge_max_tokens !== settings?.options.judge.max_tokens) {
-        options.judge = {
-          ...options.judge,
-          max_tokens: formValues.judge_max_tokens,
-        };
-      }
-      if (formValues.developer_mode !== settings?.options.developer_mode) {
-        options.developer_mode = formValues.developer_mode;
-      }
+      const options = buildOptionsPatch(formValues, settings);
       if (Object.keys(options).length > 0) {
         updateParams.options = options;
       }
@@ -360,6 +437,17 @@ export function SystemSettingsView(): ReactElement {
 
   const isAnyLoading = isLoading || isLoadingModels;
   const hasNoModels = !isAnyLoading && models.length === 0;
+
+  /** One role's reasoning effort, beside its timeout. */
+  const reasoningControl = (role: TextRole): ReactElement => (
+    <ReasoningEffortField
+      label={REASONING_LABELS[role]}
+      description={REASONING_DESCRIPTIONS[role]}
+      value={formValues.reasoningEfforts[role]}
+      onChange={(effort) => handleReasoningEffortChange(role, effort)}
+      isLoading={isAnyLoading}
+    />
+  );
 
   /** One role's timeout, on the line beneath its model. */
   const timeoutControl = (role: InternalRole): ReactElement => (
@@ -424,7 +512,12 @@ export function SystemSettingsView(): ReactElement {
               }
               modelOptions={textModelOptions}
               isLoading={isAnyLoading}
-              controls={timeoutControl('system_prompt_reflection')}
+              controls={
+                <>
+                  {timeoutControl('system_prompt_reflection')}
+                  {reasoningControl('system_prompt_reflection')}
+                </>
+              }
             />
 
             <ModelSelector
@@ -437,7 +530,12 @@ export function SystemSettingsView(): ReactElement {
               }
               modelOptions={textModelOptions}
               isLoading={isAnyLoading}
-              controls={timeoutControl('evaluation_generation')}
+              controls={
+                <>
+                  {timeoutControl('evaluation_generation')}
+                  {reasoningControl('evaluation_generation')}
+                </>
+              }
             />
 
             <ModelSelector
@@ -474,6 +572,7 @@ export function SystemSettingsView(): ReactElement {
                     isLoading={isAnyLoading}
                     layout="inline"
                   />
+                  {reasoningControl('judge')}
                 </>
               }
             />
@@ -507,7 +606,12 @@ export function SystemSettingsView(): ReactElement {
               isLoading={isAnyLoading}
               required={false}
               emptyOption="Same as System Prompt Reflection"
-              controls={timeoutControl('skill_arbiter')}
+              controls={
+                <>
+                  {timeoutControl('skill_arbiter')}
+                  {reasoningControl('skill_arbiter')}
+                </>
+              }
             />
 
             <ModelSelector
@@ -522,7 +626,12 @@ export function SystemSettingsView(): ReactElement {
               isLoading={isAnyLoading}
               required={false}
               emptyOption="Same as System Prompt Reflection"
-              controls={timeoutControl('intent_compaction')}
+              controls={
+                <>
+                  {timeoutControl('intent_compaction')}
+                  {reasoningControl('intent_compaction')}
+                </>
+              }
             />
           </CardContent>
         </Card>

--- a/packages/web/src/hooks/use-settings-validation.test.tsx
+++ b/packages/web/src/hooks/use-settings-validation.test.tsx
@@ -1,3 +1,4 @@
+import { SystemSettingsOptions } from '@shared/types/data/system-settings';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useSettingsValidation } from '@web/hooks/use-settings-validation';
@@ -31,15 +32,9 @@ describe('useSettingsValidation', () => {
     judge_model_id: 'model-4444-5555-6666-777788889999',
     skill_arbiter_model_id: null,
     intent_compaction_model_id: null,
-    options: {
-      system_prompt_reflection: { timeout_ms: 120_000 },
-      evaluation_generation: { timeout_ms: 120_000 },
-      embedding: { timeout_ms: 30_000 },
-      judge: { timeout_ms: 60_000, max_tokens: 4_000 },
-      skill_arbiter: { timeout_ms: 15_000 },
+    options: SystemSettingsOptions.parse({
       intent_compaction: { timeout_ms: 15_000 },
-      developer_mode: false,
-    },
+    }),
     created_at: '2023-01-01T00:00:00Z',
     updated_at: '2023-01-01T00:00:00Z',
   };

--- a/packages/web/src/providers/system-settings.test.tsx
+++ b/packages/web/src/providers/system-settings.test.tsx
@@ -1,4 +1,5 @@
 import type { SystemSettings } from '@shared/types/data/system-settings';
+import { SystemSettingsOptions } from '@shared/types/data/system-settings';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import {
@@ -41,15 +42,9 @@ describe('SystemSettingsProvider', () => {
     judge_model_id: 'model-4444-5555-6666-777788889999',
     skill_arbiter_model_id: null,
     intent_compaction_model_id: null,
-    options: {
-      system_prompt_reflection: { timeout_ms: 120_000 },
-      evaluation_generation: { timeout_ms: 120_000 },
-      embedding: { timeout_ms: 30_000 },
-      judge: { timeout_ms: 60_000, max_tokens: 4_000 },
-      skill_arbiter: { timeout_ms: 15_000 },
+    options: SystemSettingsOptions.parse({
       intent_compaction: { timeout_ms: 15_000 },
-      developer_mode: false,
-    },
+    }),
     created_at: '2023-01-01T00:00:00Z',
     updated_at: '2023-01-01T00:00:00Z',
   };


### PR DESCRIPTION
## Problem

Turning thinking off fixed a judge that spent its whole completion budget reasoning and stopped on `length` with an empty answer. But the switch belongs to every internal model, not just the judge, and a single evaluation may reasonably disagree with whatever the global setting says.

## Solution

**A reasoning effort per role.** `reasoning_effort` sits beside the timeout on each role served by a text model: reflection, evaluation generation, judge, arbiter, and compaction. Embedding does not get one, being a single forward pass with nothing to think about. `resolveSystemSettingsModel` returns a role's effort alongside its model and timeout, and all six internal callers send it. Null sends nothing and leaves the model at its own default.

The roles are set independently because they ask for different work: writing a system prompt can be worth the thinking, while naming a skill or scoring a turn is an answer a caller is waiting for. The settings page shows a "Reasoning" select on each of the five text-model rows, with per-role help text.

None of this needed a migration, which is the point of the options column added in #273.

**Ollama forwards it.** Its OpenAI-compatible endpoint maps the parameter onto thinking, `none` included, so the provider config passes it through and the shared `ReasoningEffort` enum gains `none`. The gateway already drops the parameter for models that reject it.

**Per-evaluation overrides.** `max_tokens` and `reasoning_effort` return as optional parameters on all six judge-backed evaluation methods (`connectors/evaluations/judge-overrides.ts`) and win over the global settings, in the scoring call and in task extraction alike. Both are optional with no default, which is load-bearing: absent means inherit, so an evaluation with no opinion keeps following the settings as they change.

**A length stop is no longer retried.** That failure is deterministic. The identical request under the identical budget exhausts it the same way, so three attempts only tripled the cost of finding out. It reports as a new `budget_exhausted` fallback whose message names the two settings that fix it.

## Test notes

`pnpm typecheck`, `pnpm check` (the one warning predates this branch), `pnpm test`: 187 files, 2974 tests passing, up from 2936.

New suites:

- `packages/shared/src/types/data/system-settings.test.ts`: defaults, partial documents, per-role efforts, merge semantics including null-clears-a-value, and update validation.
- `packages/api/src/connectors/evaluations/judge-overrides.test.ts`: absent means inherit, values pass through, schemas reject what they cannot honour.

Extended:

- Resolver: each role resolves its own effort, embedding resolves none, the judge carries budget and effort together.
- Judge: an evaluation's parameters win over the settings, the settings apply when it states neither, one from each, and a length stop is not retried.
- Arbiter and compaction: the effort reaches the request, and nothing is sent when it is unset.
- Route: every text role accepts an effort or null, embedding and out-of-enum values are refused.
- Settings form: per-role patch building, all five selects render, the embedding row has none.

The settings fixtures across ten test files now build from `SystemSettingsOptions.parse({})` instead of hand-written literals, so the next field added to the document cannot break them.

`pnpm verify:worker` was not run locally; the changes are schema and request-body handling with no Node-only imports.

## Note for this deployment

On `glm-5.3-flash:cloud`, setting the judge's reasoning effort to `none` is what stops the wasted calls. The token budget currently raised to 32,000 can likely come back down afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiMwStASMbRZMK7LvrBx98
