### PR TITLE
feat(web): a reason beside the thumb, and judges told why

### DIFF
--- a/packages/api/src/connectors/evaluations/conversation-completeness/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/conversation-completeness/service/evaluate.ts
@@ -96,7 +96,7 @@ export async function evaluateConversationCompleteness(
   // A run triggered by thumbs up/down carries the human's verdict: the
   // judge re-derives what makes the response good or bad with it anchored.
   const verdictSection = options?.humanVerdict
-    ? ` ${humanVerdictNote(options.humanVerdict)}`
+    ? ` ${humanVerdictNote(options.humanVerdict, options.humanVerdictReason)}`
     : '';
 
   // Create a simple evaluation prompt that won't trigger template-based evaluation

--- a/packages/api/src/connectors/evaluations/knowledge-retention/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/knowledge-retention/service/evaluate.ts
@@ -85,7 +85,7 @@ export async function evaluateLog(
 
   // A feedback-triggered run carries the human's verdict as an anchor.
   const verdictSection = options?.humanVerdict
-    ? ` ${humanVerdictNote(options.humanVerdict)}`
+    ? ` ${humanVerdictNote(options.humanVerdict, options.humanVerdictReason)}`
     : '';
 
   const evaluationText = `Analyze the following conversation for knowledge retention quality. ${roleSection}CONVERSATION: ${input} ASSISTANT RESPONSE: ${output} Consider how well the assistant retains and recalls information provided by the user throughout the conversation, judged against what its role requires it to carry forward. Look for: Knowledge retention vs. knowledge attrition patterns, consistency in recalling previously mentioned information, ability to maintain context across multiple turns, and specific instances where information was retained or lost. For single-turn conversations, assess if the assistant would be able to retain the information for future reference.${verdictSection} Provide a score between 0 and 1 with detailed reasoning for your analysis.`;

--- a/packages/api/src/connectors/evaluations/task-completion/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/service/evaluate.ts
@@ -43,11 +43,13 @@ async function generateVerdict(
     outcome,
     inProgress,
     humanVerdict,
+    humanVerdictReason,
   }: {
     task: string;
     outcome: string;
     inProgress: boolean;
     humanVerdict?: 'good' | 'bad';
+    humanVerdictReason?: string;
   },
   llm_judge: LLMJudge,
 ): Promise<{ verdict: number; reason: string }> {
@@ -55,7 +57,9 @@ async function generateVerdict(
     task,
     outcome,
     inProgress,
-    humanVerdictNote: humanVerdict ? humanVerdictNote(humanVerdict) : undefined,
+    humanVerdictNote: humanVerdict
+      ? humanVerdictNote(humanVerdict, humanVerdictReason)
+      : undefined,
   });
   // Explicit prompts: the heuristic re-split of the joined text only kept
   // returning real scores because the template's JSON instruction happened
@@ -158,7 +162,13 @@ export async function evaluateLog(
 
     // Step 2: Generate verdict
     const { verdict, reason } = await generateVerdict(
-      { task, outcome, inProgress, humanVerdict: options?.humanVerdict },
+      {
+        task,
+        outcome,
+        inProgress,
+        humanVerdict: options?.humanVerdict,
+        humanVerdictReason: options?.humanVerdictReason,
+      },
       llmJudge,
     );
     const verdict_llm_output = JSON.stringify({ verdict, reason });

--- a/packages/api/src/connectors/evaluations/turn-relevancy/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/turn-relevancy/service/evaluate.ts
@@ -128,7 +128,7 @@ export async function evaluateLog(
     current_turn,
     assistant_role,
     human_verdict_note: options?.humanVerdict
-      ? humanVerdictNote(options.humanVerdict)
+      ? humanVerdictNote(options.humanVerdict, options.humanVerdictReason)
       : undefined,
     strict_mode: params.strict_mode || false,
     verbose_mode: params.verbose_mode ?? true,

--- a/packages/api/src/evaluations/human-verdict.test.ts
+++ b/packages/api/src/evaluations/human-verdict.test.ts
@@ -1,0 +1,38 @@
+import { humanVerdictNote } from '@api/evaluations/human-verdict';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The note is the whole of what a human verdict contributes to a judge's
+ * prompt, so what it does and does not say is the behaviour under test.
+ */
+describe('humanVerdictNote', () => {
+  it('anchors the judge to the verdict', () => {
+    expect(humanVerdictNote('good')).toContain('verified it as a GOOD output');
+    expect(humanVerdictNote('bad')).toContain('verified it as a BAD output');
+  });
+
+  it("quotes the reviewer's reason when they typed one", () => {
+    const note = humanVerdictNote('bad', 'It invented the citation.');
+
+    expect(note).toContain('"It invented the citation."');
+    // The reason is about the response as a whole, and each judge scores one
+    // dimension: a complaint from elsewhere must not be double-counted here.
+    expect(note).toContain('do not import its complaint into this score');
+  });
+
+  it('says nothing about a reason for a bare thumb', () => {
+    // Whitespace and the nullable column both mean "no reason given" -- an
+    // empty quotation would read to the judge as a reviewer with no answer.
+    for (const reason of [undefined, null, '   \n  ']) {
+      const note = humanVerdictNote('good', reason);
+      expect(note).not.toContain('in their own words');
+      expect(note).toBe(humanVerdictNote('good'));
+    }
+  });
+
+  it('trims the stored reason before quoting it', () => {
+    expect(humanVerdictNote('good', '  Nailed the tone.  ')).toContain(
+      '"Nailed the tone."',
+    );
+  });
+});

--- a/packages/api/src/evaluations/human-verdict.ts
+++ b/packages/api/src/evaluations/human-verdict.ts
@@ -6,8 +6,21 @@
  */
 export type HumanVerdict = 'good' | 'bad';
 
-export function humanVerdictNote(verdict: HumanVerdict): string {
-  return verdict === 'good'
-    ? 'IMPORTANT: A human has manually reviewed this exact response and verified it as a GOOD output. Treat that verdict as ground truth about the overall quality. Your job is to work out what makes it work on the dimension you are scoring and score accordingly; if your own analysis says it is bad, re-examine that analysis against the human verdict before answering -- you are likely misreading the task.'
-    : 'IMPORTANT: A human has manually reviewed this exact response and verified it as a BAD output. Treat that verdict as ground truth about the overall quality. Your job is to work out what makes it fall short on the dimension you are scoring and score accordingly; if your own analysis says it is good, re-examine that analysis against the human verdict before answering -- you are likely missing the flaw.';
+export function humanVerdictNote(
+  verdict: HumanVerdict,
+  reason?: string | null,
+): string {
+  const base =
+    verdict === 'good'
+      ? 'IMPORTANT: A human has manually reviewed this exact response and verified it as a GOOD output. Treat that verdict as ground truth about the overall quality. Your job is to work out what makes it work on the dimension you are scoring and score accordingly; if your own analysis says it is bad, re-examine that analysis against the human verdict before answering -- you are likely misreading the task.'
+      : 'IMPORTANT: A human has manually reviewed this exact response and verified it as a BAD output. Treat that verdict as ground truth about the overall quality. Your job is to work out what makes it fall short on the dimension you are scoring and score accordingly; if your own analysis says it is good, re-examine that analysis against the human verdict before answering -- you are likely missing the flaw.';
+
+  // The reviewer may also have said why. That is the most specific evidence
+  // in the prompt, but it is about the response as a whole: a complaint that
+  // belongs to another dimension must not be double-counted into this score.
+  const trimmed = reason?.trim();
+  if (!trimmed) {
+    return base;
+  }
+  return `${base} The reviewer gave this reason, in their own words: "${trimmed}". Treat it as ground truth as well, and read it before you score: where it bears on the dimension you are scoring, it is the explanation you were looking for and your reasoning should follow it; where it is about some other dimension, do not import its complaint into this score -- the overall verdict still stands either way.`;
 }

--- a/packages/api/src/types/connector.ts
+++ b/packages/api/src/types/connector.ts
@@ -422,9 +422,12 @@ export interface HooksConnector {
  * was triggered by thumbs up/down feedback on the log: the LLM judges fold
  * the verified verdict into their prompts and re-derive what makes the
  * response good or bad; connectors that compute rather than judge ignore it.
+ * `humanVerdictReason` is the note the reviewer typed alongside the thumb,
+ * when they typed one -- the only place in the prompt that says *why*.
  */
 export interface EvaluateLogOptions {
   humanVerdict?: 'good' | 'bad';
+  humanVerdictReason?: string;
 }
 
 export interface EvaluationMethodConnector {

--- a/packages/api/src/utils/super-agents/feedback-reevaluation.test.ts
+++ b/packages/api/src/utils/super-agents/feedback-reevaluation.test.ts
@@ -28,8 +28,8 @@ const log = {
   cluster_id: 'cluster-1',
 } as unknown as Log;
 
-const feedbackOf = (score: number): Feedback =>
-  ({ id: 'feedback-1', log_id: 'log-1', score }) as Feedback;
+const feedbackOf = (score: number, feedback?: string | null): Feedback =>
+  ({ id: 'feedback-1', log_id: 'log-1', score, feedback }) as Feedback;
 
 const evaluations = [{ id: 'eval-1', evaluation_method: 'task_completion' }];
 const newResults = [{ evaluation_id: 'eval-1', score: 0.2 }];
@@ -103,6 +103,29 @@ describe('reevaluateLogFromFeedback', () => {
 
     expect(vi.mocked(runEvaluationsForLog).mock.calls[0][5]).toEqual({
       humanVerdict: 'good',
+    });
+  });
+
+  it("carries the reviewer's typed reason to the judges", async () => {
+    await reevaluateLogFromFeedback(
+      context,
+      feedbackOf(0, 'It invented the citation.'),
+    );
+
+    expect(vi.mocked(runEvaluationsForLog).mock.calls[0][5]).toEqual({
+      humanVerdict: 'bad',
+      humanVerdictReason: 'It invented the citation.',
+    });
+  });
+
+  it('sends no reason when the thumb came without one', async () => {
+    // The column is nullable and both backends answer NULL for a bare
+    // thumb; the judges must see an absent reason, not the string "null".
+    await reevaluateLogFromFeedback(context, feedbackOf(0, null));
+
+    expect(vi.mocked(runEvaluationsForLog).mock.calls[0][5]).toEqual({
+      humanVerdict: 'bad',
+      humanVerdictReason: undefined,
     });
   });
 

--- a/packages/api/src/utils/super-agents/feedback-reevaluation.ts
+++ b/packages/api/src/utils/super-agents/feedback-reevaluation.ts
@@ -44,7 +44,7 @@ export async function reevaluateLogFromFeedback(
     evaluations,
     evaluationConnectorsMap,
     userDataConnector,
-    { humanVerdict },
+    { humanVerdict, humanVerdictReason: feedback.feedback ?? undefined },
   );
   if (results.length === 0) {
     error(

--- a/packages/web/src/components/agents/skills/logs/log-feedback.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-feedback.test.tsx
@@ -4,8 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * The thumbs on a log: one verdict per log, the other thumb replaces it,
- * the same thumb withdraws it. The server does the special part (re-running
- * the evaluations); what matters here is the score each press sends.
+ * and the thumb already holding the verdict re-opens its note to edit or
+ * withdraw. A thumb opens a composer instead of writing, so the optional
+ * reason rides along on the same write -- the server re-runs every judge on
+ * each one. What matters here is the score and reason each save sends.
  */
 
 const getFeedback = vi.fn();
@@ -41,12 +43,13 @@ describe('LogFeedback', () => {
     vi.clearAllMocks();
   });
 
-  it('sends a thumbs down as score 0', async () => {
+  it('sends a thumbs down as score 0 with no reason typed', async () => {
     getFeedback.mockResolvedValue([]);
     createFeedback.mockResolvedValue({ id: 'feedback-1', score: 0 });
 
     renderFeedback();
     fireEvent.click(screen.getByLabelText('Bad output'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(createFeedback).toHaveBeenCalledWith({
@@ -58,6 +61,54 @@ describe('LogFeedback', () => {
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Marked as a bad output' }),
     );
+  });
+
+  it('sends the typed reason alongside the verdict', async () => {
+    getFeedback.mockResolvedValue([]);
+    createFeedback.mockResolvedValue({
+      id: 'feedback-1',
+      score: 0,
+      feedback: 'It invented the citation.',
+    });
+
+    renderFeedback();
+    fireEvent.click(screen.getByLabelText('Bad output'));
+    fireEvent.change(await screen.findByLabelText('Reason for this verdict'), {
+      target: { value: '  It invented the citation.  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(createFeedback).toHaveBeenCalledWith({
+        log_id: 'log-1',
+        score: 0,
+        feedback: 'It invented the citation.',
+      });
+    });
+  });
+
+  it('opens the current verdict prefilled with its saved reason', async () => {
+    getFeedback.mockResolvedValue([
+      {
+        id: 'feedback-1',
+        log_id: 'log-1',
+        score: 1,
+        feedback: 'Nailed the tone.',
+      },
+    ]);
+    createFeedback.mockResolvedValue({ id: 'feedback-2', score: 1 });
+
+    renderFeedback();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Good output')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+    fireEvent.click(screen.getByLabelText('Good output'));
+
+    const textarea = await screen.findByLabelText('Reason for this verdict');
+    expect(textarea).toHaveValue('Nailed the tone.');
   });
 
   it('replaces the opposite verdict', async () => {
@@ -75,6 +126,7 @@ describe('LogFeedback', () => {
       );
     });
     fireEvent.click(screen.getByLabelText('Good output'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(createFeedback).toHaveBeenCalledWith({
@@ -85,7 +137,7 @@ describe('LogFeedback', () => {
     expect(deleteFeedback).toHaveBeenCalledWith('feedback-1');
   });
 
-  it('withdraws the verdict when the same thumb is pressed again', async () => {
+  it('withdraws the verdict from the composer', async () => {
     getFeedback.mockResolvedValue([
       { id: 'feedback-1', log_id: 'log-1', score: 1 },
     ]);
@@ -98,6 +150,7 @@ describe('LogFeedback', () => {
       );
     });
     fireEvent.click(screen.getByLabelText('Good output'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove' }));
 
     await waitFor(() => {
       expect(deleteFeedback).toHaveBeenCalledWith('feedback-1');

--- a/packages/web/src/components/agents/skills/logs/log-feedback.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-feedback.tsx
@@ -8,6 +8,12 @@ import {
 } from '@web/api/v1/super-agents/feedbacks';
 import { Button } from '@web/components/ui/button';
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@web/components/ui/popover';
+import { Textarea } from '@web/components/ui/textarea';
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -15,52 +21,75 @@ import {
 } from '@web/components/ui/tooltip';
 import { useToast } from '@web/hooks/use-toast';
 import { ThumbsDownIcon, ThumbsUpIcon } from 'lucide-react';
-import type { ReactElement } from 'react';
+import { type ReactElement, useState } from 'react';
+
+type Verdict = 'good' | 'bad';
 
 /**
  * Thumbs up / thumbs down on one log. This is an evaluation, but a special
  * one: the verdict is stored as feedback (score 1 or 0) and the server
  * re-runs every evaluation of the log with the judges told a human verified
  * the output as good or bad, so their scores and reasoning get re-anchored.
- * Pressing the same thumb again withdraws the feedback.
+ *
+ * A thumb opens a composer rather than writing straight away, because the
+ * reviewer may also type *why* -- the one piece of the judges' prompt that
+ * says what is actually wrong with the response instead of that something
+ * is. Collecting it before the write matters: each write re-runs every
+ * judge on the log, so saving the verdict and the reason separately would
+ * pay for two rounds of judging and throw the first one away.
+ *
+ * Choosing the thumb already carrying the verdict re-opens its note for
+ * editing, and offers to withdraw the feedback entirely.
  */
 export function LogFeedback({ logId }: { logId: string }): ReactElement {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const [composing, setComposing] = useState<Verdict | null>(null);
+  const [reason, setReason] = useState('');
 
   const { data: feedbackList = [] } = useQuery({
     queryKey: ['feedback', logId],
     queryFn: () => getFeedback({ log_id: logId }),
   });
   const existing = feedbackList[0];
-  const currentVerdict =
+  const currentVerdict: Verdict | null =
     existing === undefined ? null : existing.score >= 0.5 ? 'good' : 'bad';
 
   const mutation = useMutation({
-    mutationFn: async (verdict: 'good' | 'bad') => {
-      // One verdict per log: pressing the other thumb replaces it, pressing
-      // the same thumb withdraws it.
+    mutationFn: async ({
+      verdict,
+      note,
+    }: {
+      verdict: Verdict | null;
+      note: string;
+    }) => {
+      // One verdict per log: saving replaces whatever was there, and a null
+      // verdict withdraws it.
       for (const feedback of feedbackList) {
         await deleteFeedback(feedback.id);
       }
-      if (verdict === currentVerdict) {
+      if (verdict === null) {
         return null;
       }
+      const trimmed = note.trim();
       return await createFeedback({
         log_id: logId,
         score: verdict === 'good' ? 1 : 0,
+        ...(trimmed ? { feedback: trimmed } : {}),
       });
     },
     onSuccess: (created) => {
       queryClient.invalidateQueries({ queryKey: ['feedback', logId] });
+      setComposing(null);
       if (created) {
         toast({
           title:
             created.score >= 0.5
               ? 'Marked as a good output'
               : 'Marked as a bad output',
-          description:
-            'Re-running the evaluations with your verdict as context.',
+          description: created.feedback
+            ? 'Re-running the evaluations with your verdict and reason as context.'
+            : 'Re-running the evaluations with your verdict as context.',
         });
       }
     },
@@ -72,49 +101,127 @@ export function LogFeedback({ logId }: { logId: string }): ReactElement {
     },
   });
 
+  // Opening the composer for the verdict already stored starts from the note
+  // it was saved with, so editing a reason does not mean retyping it.
+  const openComposer = (verdict: Verdict): void => {
+    setReason(verdict === currentVerdict ? (existing?.feedback ?? '') : '');
+    setComposing(verdict);
+  };
+
+  const renderThumb = (verdict: Verdict): ReactElement => {
+    const isCurrent = currentVerdict === verdict;
+    const label = verdict === 'good' ? 'Good output' : 'Bad output';
+    const Icon = verdict === 'good' ? ThumbsUpIcon : ThumbsDownIcon;
+
+    return (
+      <Popover
+        open={composing === verdict}
+        onOpenChange={(open) => {
+          if (open) {
+            openComposer(verdict);
+          } else if (!mutation.isPending) {
+            setComposing(null);
+          }
+        }}
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                variant={
+                  isCurrent
+                    ? verdict === 'good'
+                      ? 'default'
+                      : 'destructive'
+                    : 'outline'
+                }
+                size="icon"
+                aria-label={label}
+                aria-pressed={isCurrent}
+                disabled={mutation.isPending}
+              >
+                <Icon className="h-4 w-4" />
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          {/* Nothing to explain once the composer is open, and a tooltip
+              hovering over it only covers what the reviewer is reading. */}
+          {composing !== verdict && (
+            <TooltipContent>
+              <p className="text-xs">
+                Verify as a {verdict} output, optionally saying why, and re-run
+                the evaluations with that context
+              </p>
+            </TooltipContent>
+          )}
+        </Tooltip>
+        <PopoverContent align="end" className="w-80">
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <p className="font-medium text-sm">
+                {verdict === 'good'
+                  ? 'Verify as a good output'
+                  : 'Verify as a bad output'}
+              </p>
+              <p className="text-muted-foreground text-xs">
+                The judges re-score this log with your verdict as ground truth.
+                A reason tells them what to look at.
+              </p>
+            </div>
+            {/* Radix traps focus into the popover and lands on the first
+                tabbable element, which is this textarea -- the composer
+                opens ready to type in without an autoFocus of its own. */}
+            <Textarea
+              aria-label="Reason for this verdict"
+              placeholder={
+                verdict === 'good'
+                  ? 'What makes this a good output? (optional)'
+                  : "What's wrong with this output? (optional)"
+              }
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              onKeyDown={(event) => {
+                // The composer is a textarea, so plain Enter has to stay a
+                // newline; the usual modifier submits.
+                if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  mutation.mutate({ verdict, note: reason });
+                }
+              }}
+              className="min-h-[80px] text-sm"
+            />
+            <div className="flex items-center justify-between gap-2">
+              {isCurrent ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={mutation.isPending}
+                  onClick={() => mutation.mutate({ verdict: null, note: '' })}
+                >
+                  Remove
+                </Button>
+              ) : (
+                <span />
+              )}
+              <Button
+                size="sm"
+                disabled={mutation.isPending}
+                onClick={() => mutation.mutate({ verdict, note: reason })}
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    );
+  };
+
   return (
     <TooltipProvider>
       <div className="flex items-center gap-1">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant={currentVerdict === 'good' ? 'default' : 'outline'}
-              size="icon"
-              aria-label="Good output"
-              aria-pressed={currentVerdict === 'good'}
-              disabled={mutation.isPending}
-              onClick={() => mutation.mutate('good')}
-            >
-              <ThumbsUpIcon className="h-4 w-4" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p className="text-xs">
-              Verify as a good output and re-run the evaluations with that
-              context
-            </p>
-          </TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant={currentVerdict === 'bad' ? 'destructive' : 'outline'}
-              size="icon"
-              aria-label="Bad output"
-              aria-pressed={currentVerdict === 'bad'}
-              disabled={mutation.isPending}
-              onClick={() => mutation.mutate('bad')}
-            >
-              <ThumbsDownIcon className="h-4 w-4" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p className="text-xs">
-              Verify as a bad output and re-run the evaluations with that
-              context
-            </p>
-          </TooltipContent>
-        </Tooltip>
+        {renderThumb('good')}
+        {renderThumb('bad')}
       </div>
     </TooltipProvider>
   );


### PR DESCRIPTION
## Problem

Thumbs up/down on a log already re-ran every evaluation with the human verdict folded into the judges' prompts. But the judges were only ever told *that* a response was good or bad — never why. The `feedbacks.feedback` column, the Zod schema and `createFeedback` in the client API had all carried a note since the beginning; nothing ever wrote one, and nothing read it.

## Solution

**Typing the reason.** A thumb now opens a composer instead of writing straight away: an optional reason, **Save**, and **Remove** when you are editing the verdict already stored. Cmd/Ctrl+Enter saves; plain Enter stays a newline. Re-opening the thumb that holds the current verdict prefills the note it was saved with, so editing a reason is not retyping it.

The reason is collected *before* the write rather than added afterwards. Every write to a feedback row deletes the log's evaluation runs and re-runs every judge on it, so a verdict-then-reason flow would pay for two rounds of judging and discard the first. The trade-off is that giving feedback is now two clicks rather than one — worth flagging, since it slows the bare-thumb path.

**Passing it to the evals.** All four judges reach the anchor text through `humanVerdictNote`, so widening that one function to take the reason — and threading `humanVerdictReason` through `EvaluateLogOptions` from `reevaluateLogFromFeedback` — covers task-completion, turn-relevancy, knowledge-retention and conversation-completeness at once.

The note tells the judge to weigh the reason first *where it bears on the dimension being scored*, and explicitly not to import it where it does not. That guard is load-bearing: the reason is about the response as a whole while each judge scores a single dimension, so without it a complaint about tone would drag down the knowledge-retention score too. A blank or NULL reason produces the original note unchanged, so a bare thumb never shows the judge an empty quotation.

No schema change on either backend — the column and its nullability were already right.

## Test notes

- `pnpm typecheck` clean, `pnpm check` clean (the one remaining warning is a pre-existing unused type in `task-and-outcome.ts`, untouched here), `pnpm test` **2982 passed / 188 files**.
- Rewrote the five `LogFeedback` cases around the composer: save with no reason, save with one trimmed, prefill on re-open, replace the opposite verdict, withdraw via Remove.
- Added two cases to `feedback-reevaluation.test.ts` — the reason reaching `runEvaluationsForLog`, and a NULL note staying absent rather than arriving as the string `"null"`.
- New `human-verdict.test.ts` covers the note composition: the verdict anchor, the quoted reason, the cross-dimension guard, and that `undefined`/`null`/whitespace all collapse to the bare note.

## Screenshots

Not included — the composer is a Radix popover on the log-details header; the component tests drive it open, type, save, prefill and withdraw in jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123qpTodJiTnam2JCUpQCmx