### PR TITLE
test: cover the settings document on both backends, and the reasoning effort end to end

### DIFF
--- a/e2e/contract/system-settings.spec.ts
+++ b/e2e/contract/system-settings.spec.ts
@@ -1,0 +1,228 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * The settings document both storage backends have to agree about.
+ *
+ * Everything that needs no column of its own -- the timeout beside each
+ * model, the judge's token budget, each text role's reasoning effort,
+ * developer mode -- lives in one `options` column: JSONB in Postgres, TEXT
+ * parsed on read in SQLite. That makes this the newest hand-written
+ * conversion in `connectors/libsql/rows.ts`, and the one with the most
+ * behaviour riding on it, because a PATCH is *merged* over what is stored
+ * rather than replacing it. A backend that dropped a key, replaced the
+ * document, or mapped JSON `null` onto a missing value would satisfy its own
+ * tests and diverge only here.
+ *
+ * The settings row is a singleton the whole deployment shares, so every test
+ * restores what it found. Only `options` is touched: the model ids belong to
+ * whatever else is running.
+ */
+
+const SETTINGS_PATH = '/v1/super-agents/system-settings';
+
+interface Options {
+  system_prompt_reflection: { timeout_ms: number; reasoning_effort: unknown };
+  evaluation_generation: { timeout_ms: number; reasoning_effort: unknown };
+  embedding: { timeout_ms: number };
+  judge: {
+    timeout_ms: number;
+    max_tokens: number;
+    reasoning_effort: unknown;
+  };
+  skill_arbiter: { timeout_ms: number; reasoning_effort: unknown };
+  intent_compaction: { timeout_ms: number; reasoning_effort: unknown };
+  developer_mode: boolean;
+}
+
+const getOptions = async (request: {
+  get: (path: string) => Promise<{ status: () => number; json: () => unknown }>;
+}): Promise<Options> => {
+  const response = await request.get(SETTINGS_PATH);
+  expect(response.status()).toBe(200);
+  return ((await response.json()) as { options: Options }).options;
+};
+
+// One at a time: these share the singleton row.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('system settings options contract', () => {
+  test('answers the whole document, with every default filled in', async ({
+    request,
+  }) => {
+    // A row stored before a field existed reads as that field's default, and
+    // the API is what has to say so -- on either backend.
+    const options = await getOptions(request);
+
+    expect(options.judge).toMatchObject({
+      timeout_ms: expect.any(Number),
+      max_tokens: expect.any(Number),
+    });
+    expect(options.judge).toHaveProperty('reasoning_effort');
+    for (const role of [
+      'system_prompt_reflection',
+      'evaluation_generation',
+      'embedding',
+      'judge',
+      'skill_arbiter',
+      'intent_compaction',
+    ] as const) {
+      expect(options[role].timeout_ms).toBeGreaterThan(0);
+    }
+    expect(typeof options.developer_mode).toBe('boolean');
+    // The embedding role has no effort to answer with: one forward pass.
+    expect(options.embedding).not.toHaveProperty('reasoning_effort');
+  });
+
+  test('merges a patch over the stored document rather than replacing it', async ({
+    request,
+  }) => {
+    const before = await getOptions(request);
+
+    try {
+      const first = await request.patch(SETTINGS_PATH, {
+        data: { options: { judge: { timeout_ms: 90_000 } } },
+      });
+      expect(first.status()).toBe(200);
+
+      // A second patch naming only the budget must not lose the timeout the
+      // first one set, nor any role it never mentioned.
+      const second = await request.patch(SETTINGS_PATH, {
+        data: { options: { judge: { max_tokens: 16_000 } } },
+      });
+      expect(second.status()).toBe(200);
+      const merged = ((await second.json()) as { options: Options }).options;
+
+      expect(merged.judge.timeout_ms).toBe(90_000);
+      expect(merged.judge.max_tokens).toBe(16_000);
+      expect(merged.skill_arbiter).toEqual(before.skill_arbiter);
+      expect(merged.embedding).toEqual(before.embedding);
+      expect(merged.developer_mode).toBe(before.developer_mode);
+
+      // Re-read: a connector could answer with the object it just built
+      // rather than the one the database now holds.
+      expect(await getOptions(request)).toEqual(merged);
+    } finally {
+      await request.patch(SETTINGS_PATH, {
+        data: {
+          options: {
+            judge: {
+              timeout_ms: before.judge.timeout_ms,
+              max_tokens: before.judge.max_tokens,
+            },
+          },
+        },
+      });
+    }
+  });
+
+  test('preserves a null reasoning effort instead of dropping the key', async ({
+    request,
+  }) => {
+    /**
+     * Null is a value here -- back to the model's own default -- not an
+     * absence. Postgres stores JSON null inside the JSONB document; SQLite
+     * stores the same text and parses it back. A backend that dropped the key
+     * would still satisfy the schema, because the field has a default, and
+     * the setting would silently fail to clear.
+     */
+    const before = await getOptions(request);
+
+    try {
+      const set = await request.patch(SETTINGS_PATH, {
+        data: { options: { judge: { reasoning_effort: 'low' } } },
+      });
+      expect(set.status()).toBe(200);
+      expect(
+        ((await set.json()) as { options: Options }).options.judge
+          .reasoning_effort,
+      ).toBe('low');
+
+      const cleared = await request.patch(SETTINGS_PATH, {
+        data: { options: { judge: { reasoning_effort: null } } },
+      });
+      expect(cleared.status()).toBe(200);
+      const options = ((await cleared.json()) as { options: Options }).options;
+
+      expect(options.judge).toHaveProperty('reasoning_effort');
+      expect(options.judge.reasoning_effort).toBeNull();
+      // Clearing one field leaves the rest of the role alone.
+      expect(options.judge.max_tokens).toBe(before.judge.max_tokens);
+
+      expect((await getOptions(request)).judge.reasoning_effort).toBeNull();
+    } finally {
+      await request.patch(SETTINGS_PATH, {
+        data: {
+          options: {
+            judge: { reasoning_effort: before.judge.reasoning_effort },
+          },
+        },
+      });
+    }
+  });
+
+  test('keeps each role’s reasoning effort independent', async ({
+    request,
+  }) => {
+    const before = await getOptions(request);
+
+    try {
+      const response = await request.patch(SETTINGS_PATH, {
+        data: {
+          options: {
+            skill_arbiter: { reasoning_effort: 'none' },
+            system_prompt_reflection: { reasoning_effort: 'high' },
+          },
+        },
+      });
+      expect(response.status()).toBe(200);
+      const options = ((await response.json()) as { options: Options }).options;
+
+      expect(options.skill_arbiter.reasoning_effort).toBe('none');
+      expect(options.system_prompt_reflection.reasoning_effort).toBe('high');
+      // The roles are separate settings, not one shared value.
+      expect(options.judge.reasoning_effort).toEqual(
+        before.judge.reasoning_effort,
+      );
+      expect(options.intent_compaction.reasoning_effort).toEqual(
+        before.intent_compaction.reasoning_effort,
+      );
+    } finally {
+      await request.patch(SETTINGS_PATH, {
+        data: {
+          options: {
+            skill_arbiter: {
+              reasoning_effort: before.skill_arbiter.reasoning_effort,
+            },
+            system_prompt_reflection: {
+              reasoning_effort:
+                before.system_prompt_reflection.reasoning_effort,
+            },
+          },
+        },
+      });
+    }
+  });
+
+  test('refuses a value it could not honour, leaving the row untouched', async ({
+    request,
+  }) => {
+    const before = await getOptions(request);
+
+    for (const options of [
+      { judge: { reasoning_effort: 'ultra' } },
+      // Embedding has no effort to set.
+      { embedding: { reasoning_effort: 'low' } },
+      { judge: { timeout_ms: 0 } },
+      { judge: { max_tokens: 1 } },
+      // The old flat column names, which are options now.
+      { unknown_role: { timeout_ms: 1_000 } },
+    ]) {
+      const response = await request.patch(SETTINGS_PATH, {
+        data: { options },
+      });
+      expect(response.status(), JSON.stringify(options)).toBe(400);
+    }
+
+    expect(await getOptions(request)).toEqual(before);
+  });
+});

--- a/packages/api/src/handlers/handler-utils.test.ts
+++ b/packages/api/src/handlers/handler-utils.test.ts
@@ -400,6 +400,93 @@ describe('tryPost Error Handling', () => {
       }
       warn.mockRestore();
     });
+
+    /**
+     * The reasoning effort a role's settings choose is only useful if it
+     * survives the gateway. Two halves to that, and both are load-bearing:
+     * a provider with no capability table is assumed to accept everything,
+     * which is the only reason the setting reaches a self-hosted model at
+     * all; and a model whose table rejects the parameter must lose it, since
+     * OpenAI answers an unsupported `reasoning_effort` with a 400 for the
+     * whole request rather than ignoring the field.
+     */
+    it('forwards reasoning_effort to a provider with no capability table', async () => {
+      // Ollama registers none, and its OpenAI-compatible endpoint maps the
+      // parameter onto thinking -- `none` is how thinking is turned off.
+      mockSuperAgentsTarget.configuration.ai_provider = AIProvider.OLLAMA;
+      mockSuperAgentsTarget.configuration.model = 'glm-5.3-flash:cloud';
+      (providerConfigs as Record<string, AIProviderConfig | undefined>)[
+        AIProvider.OLLAMA
+      ] = {
+        api: {
+          getBaseURL: vi.fn().mockResolvedValue('http://localhost:11434'),
+          getEndpoint: vi.fn().mockReturnValue('/v1/chat/completions'),
+          headers: vi.fn().mockResolvedValue({}),
+        },
+      } as unknown as AIProviderConfig;
+      vi.mocked(inputHookHandler).mockResolvedValue({
+        errorResponse: undefined,
+        transformedSuperAgentsBody: undefined,
+      });
+      vi.mocked(transformToProviderRequest).mockImplementation(() => {
+        throw new Error('stop here');
+      });
+      mockSuperAgentsRequestData.requestBody = {
+        model: 'glm-5.3-flash:cloud',
+        messages: [{ role: ChatCompletionMessageRole.USER, content: 'Hello' }],
+        reasoning_effort: 'none',
+      } as never;
+
+      await tryPost(
+        mockContext,
+        mockSuperAgentsConfig,
+        mockSuperAgentsTarget,
+        mockSuperAgentsRequestData,
+        0,
+      );
+
+      const sent = vi.mocked(transformToProviderRequest).mock.calls[0][2]
+        .requestBody as Record<string, unknown>;
+      expect(sent.reasoning_effort).toBe('none');
+    });
+
+    it.each([
+      ['gpt-5.1', true],
+      // GPT-4o takes no reasoning_effort, and says so with a 400.
+      ['gpt-4o', false],
+    ])('forwards reasoning_effort to %s: %s', async (model, forwarded) => {
+      reachTheTransform();
+      registerProviderCapabilities(openAIModelCapabilities);
+      mockSuperAgentsTarget.configuration.model = model;
+      mockSuperAgentsRequestData.requestBody = {
+        model,
+        messages: [{ role: ChatCompletionMessageRole.USER, content: 'Hello' }],
+        reasoning_effort: 'low',
+      } as never;
+      const warn = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+      await tryPost(
+        mockContext,
+        mockSuperAgentsConfig,
+        mockSuperAgentsTarget,
+        mockSuperAgentsRequestData,
+        0,
+      );
+
+      const sent = vi.mocked(transformToProviderRequest).mock.calls[0][2]
+        .requestBody as Record<string, unknown>;
+      if (forwarded) {
+        expect(sent.reasoning_effort).toBe('low');
+      } else {
+        expect(sent).not.toHaveProperty('reasoning_effort');
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining('Dropped reasoning_effort'),
+        );
+      }
+      warn.mockRestore();
+    });
   });
 
   describe('the JSON instructions added for `response_format`', () => {

--- a/packages/api/src/optimization/utils/describe-skill.test.ts
+++ b/packages/api/src/optimization/utils/describe-skill.test.ts
@@ -10,6 +10,7 @@ import {
 import { createMockContext } from '@api/test-utils/mock-context';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { AIProvider } from '@shared/types/constants';
 import type { Agent, Skill } from '@shared/types/data';
 import { SkillEventType } from '@shared/types/data/skill-event';
@@ -128,6 +129,32 @@ describe('describeSkillForRequest', () => {
     };
     expect(request.messages[1].content).toContain('book_table');
     expect(request.messages[1].content).toContain('translate');
+  });
+
+  it("sends the naming call's reasoning effort", async () => {
+    // Naming happens on the request path, so the setting is what keeps the
+    // model from thinking its way past the caller's patience.
+    vi.mocked(resolveSystemSettingsModel).mockResolvedValue({
+      model: 'gpt-5-mini',
+      provider: AIProvider.OPENAI,
+      apiKey: 'sk-test',
+      reasoningEffort: ReasoningEffort.NONE,
+    });
+    modelSays({ name: 'concierge', description: 'Books tables.' });
+
+    await describeSkillForRequest(c, connector, agent, intent, []);
+
+    expect(mockParse.mock.calls[0][0]).toMatchObject({
+      reasoning_effort: 'none',
+    });
+  });
+
+  it('sends none when the role leaves the model to its default', async () => {
+    modelSays({ name: 'concierge', description: 'Books tables.' });
+
+    await describeSkillForRequest(c, connector, agent, intent, []);
+
+    expect(mockParse.mock.calls[0][0]).not.toHaveProperty('reasoning_effort');
   });
 
   it('names the skill from the request when no model is configured', async () => {

--- a/packages/api/src/optimization/utils/evaluations.test.ts
+++ b/packages/api/src/optimization/utils/evaluations.test.ts
@@ -4,6 +4,8 @@ import type {
   EvaluationMethodConnector,
   UserDataStorageConnector,
 } from '@api/types/connector';
+import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { AIProvider } from '@shared/types/constants';
 import type { Skill } from '@shared/types/data';
 import { EvaluationMethodName } from '@shared/types/evaluations';
@@ -109,6 +111,51 @@ describe('generateEvaluationCreateParams', () => {
     expect(mockParse.mock.calls[0][0]).toMatchObject({
       prompt_cache_options: { mode: 'explicit' },
     });
+  });
+
+  it("sends the evaluation-generation role's reasoning effort", async () => {
+    vi.mocked(resolveSystemSettingsModel).mockResolvedValueOnce({
+      model: 'glm-5.3-flash:cloud',
+      provider: AIProvider.OLLAMA,
+      apiKey: '',
+      customHost: 'http://localhost:11434',
+      reasoningEffort: ReasoningEffort.LOW,
+    });
+    mockParse.mockResolvedValue(parsedAs({ task: 'Review the diff' }));
+
+    await generateEvaluationCreateParams(
+      mockContext,
+      skill,
+      connectorFor(
+        EvaluationMethodName.TASK_COMPLETION,
+        z.object({ task: z.string() }),
+      ),
+      EvaluationMethodName.TASK_COMPLETION,
+      'an agent that maintains a website',
+      storageConnector,
+    );
+
+    expect(mockParse.mock.calls[0][0]).toMatchObject({
+      reasoning_effort: 'low',
+    });
+  });
+
+  it('sends none when the role leaves the model to its default', async () => {
+    mockParse.mockResolvedValue(parsedAs({ task: 'Review the diff' }));
+
+    await generateEvaluationCreateParams(
+      mockContext,
+      skill,
+      connectorFor(
+        EvaluationMethodName.TASK_COMPLETION,
+        z.object({ task: z.string() }),
+      ),
+      EvaluationMethodName.TASK_COMPLETION,
+      'an agent that maintains a website',
+      storageConnector,
+    );
+
+    expect(mockParse.mock.calls[0][0]).not.toHaveProperty('reasoning_effort');
   });
 
   it('does not call the model for a method with no AI parameters', async () => {

--- a/packages/api/src/optimization/utils/system-prompt.test.ts
+++ b/packages/api/src/optimization/utils/system-prompt.test.ts
@@ -1,6 +1,8 @@
 import { generateSeedSystemPromptWithContext } from '@api/optimization/utils/system-prompt';
 import { createMockContext } from '@api/test-utils/mock-context';
 import type { UserDataStorageConnector } from '@api/types/connector';
+import { resolveSystemSettingsModel } from '@api/utils/evaluation-model-resolver';
+import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { AIProvider } from '@shared/types/constants';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -74,5 +76,42 @@ describe('generateSeedSystemPromptWithContext', () => {
     );
 
     expect(askedWith()).not.toContain("developer's own system prompt");
+  });
+
+  it("sends the reflection role's reasoning effort", async () => {
+    // Writing a prompt is the internal call where thinking tends to pay for
+    // itself, so this role's setting has to reach the request. It travels
+    // separately from the model here -- the client is built in one function
+    // and the request in another -- which is where it would go missing.
+    vi.mocked(resolveSystemSettingsModel).mockResolvedValueOnce({
+      model: 'gpt-5-mini',
+      provider: AIProvider.OPENAI,
+      apiKey: 'sk-test',
+      reasoningEffort: ReasoningEffort.HIGH,
+    });
+
+    await generateSeedSystemPromptWithContext(
+      c,
+      'An agent for restaurants.',
+      'Books tables.',
+      [],
+      connector,
+    );
+
+    expect(mockParse.mock.calls[0][0]).toMatchObject({
+      reasoning_effort: 'high',
+    });
+  });
+
+  it('sends none when the role leaves the model to its default', async () => {
+    await generateSeedSystemPromptWithContext(
+      c,
+      'An agent for restaurants.',
+      'Books tables.',
+      [],
+      connector,
+    );
+
+    expect(mockParse.mock.calls[0][0]).not.toHaveProperty('reasoning_effort');
   });
 });


### PR DESCRIPTION
Tests only, no behavior change. Covers gaps in #273 and #274, both now merged.

Three gaps in what #273 and #274 shipped.

## 1. The settings document had no contract spec

`e2e/contract/` is the check that the hand-written libSQL conversions match Postgres, and `options` is the newest of them with the most riding on it: a PATCH is *merged* over what is stored rather than replacing it. A backend that dropped a key, replaced the whole document, or mapped JSON `null` onto a missing value would satisfy its own unit tests and diverge only here.

`e2e/contract/system-settings.spec.ts` covers, on both backends:

- the read answers the whole document with every default filled in, and embedding carries no reasoning effort
- a second patch naming only the token budget does not lose the timeout the first one set, nor any role it never mentioned, and a re-read agrees with what the write answered
- `null` clears a reasoning effort and stays null rather than the key going missing
- the roles stay independent of one another
- a refused value leaves the row untouched

The settings row is a singleton the whole run shares, so every test restores what it found and touches only `options`, never the model ids.

## 2. Three of the six internal callers were untested

The arbiter and compaction had forwarding tests; system prompt reflection, evaluation generation, and skill naming did not. Reflection needed it most: its effort travels separately from the model, resolved in one function and sent from another, which is exactly where it would go missing. Each now has a test that the effort reaches the request and that nothing is sent when the role is left at the model default.

## 3. Nothing asserted the parameter survives the gateway

The feature rests on `validateParameter` treating a provider with no capability table as accepting everything, which is the only reason the setting reaches a self-hosted model at all. The other half matters as much: a model whose table rejects `reasoning_effort` has to lose it, because OpenAI answers an unsupported one with a 400 for the whole request rather than ignoring the field. Both are now pinned in `handler-utils.test.ts` against the real OpenAI table: forwarded to Ollama and to gpt-5.1, dropped with a warning for gpt-4o.

## Test notes

- `pnpm typecheck`, `pnpm check` (the one warning predates these branches), `pnpm test`: 188 files, 2991 tests passing, up from 2974.
- The new contract spec was run against **both** backends: `contract:libsql` and `contract:supabase` via podman compose, 5 passing on each.
- Full e2e suite green, 66 passing, which also confirms the settings mutations do not disturb the optimizer spec running in parallel.

## Still open, deliberately

The Supabase connector's `updateSystemSettings` merge has no unit test of its own; the new contract spec now exercises that path end to end on Postgres, which covers the risk that mattered. Separately, an agent that overrides the arbiter model with its own `skill_arbiter_model_id` silently loses the system reasoning effort, while the timeout in that same position does fall back. That is a behavior fix rather than a test, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiMwStASMbRZMK7LvrBx98
