### PR TITLE
fix(api): keep the system reasoning effort for an agent's own arbiter model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,9 +202,12 @@ skill starts as a pass-through. `max_auto_created_skills` caps this per agent.
 The arbiter's model and per-attempt timeout are system settings
 (`skill_arbiter_model_id`, the reflection model when unset, and
 `options.skill_arbiter.timeout_ms`), which an agent overrides with its own
-`skill_arbiter_model_id` and `skill_arbiter_timeout_ms` columns; the arbiter
-is asked under the skill-creation lease, so the lease stretches by twice the
-timeout to cover it.
+`skill_arbiter_model_id` and `skill_arbiter_timeout_ms` columns; an agent that
+names its own model still arbitrates under the system's
+`options.skill_arbiter.reasoning_effort`, since it overrides which model
+answers rather than how hard it may think. The arbiter is asked under the
+skill-creation lease, so the lease stretches by twice the timeout to cover
+it.
 Creating happens under the agent's `skill_creation_leases` row
 (`withSkillCreationLease`), after a second look at the skills, so concurrent
 first requests produce one skill rather than one each. Intent embeddings are

--- a/packages/api/src/utils/super-agents/skill-arbiter.test.ts
+++ b/packages/api/src/utils/super-agents/skill-arbiter.test.ts
@@ -148,6 +148,60 @@ describe('arbitrateSkillForRequest', () => {
     expect(mockParse.mock.calls[0][0]).toMatchObject({ model: 'agent-model' });
   });
 
+  it("keeps the system's reasoning effort for an agent's own model", async () => {
+    // An agent overrides *which* model arbitrates, not how hard it may think.
+    // A model resolved by id carries no settings of its own, so the effort has
+    // to be handed to it -- as the timeout in the same position always was.
+    vi.mocked(resolveModelById).mockResolvedValue({
+      model: 'agent-model',
+      provider: AIProvider.OPENAI,
+      apiKey: 'key',
+    });
+    mockParse.mockResolvedValue(answer(null));
+
+    await arbitrateSkillForRequest(
+      createMockContext(),
+      connector,
+      { ...agent, skill_arbiter_model_id: 'agent-arbiter-model' },
+      skills,
+      intent,
+      {
+        ...settings,
+        options: SystemSettingsOptions.parse({
+          skill_arbiter: {
+            timeout_ms: 42_000,
+            reasoning_effort: ReasoningEffort.NONE,
+          },
+        }),
+      } as SystemSettings,
+    );
+
+    expect(mockParse.mock.calls[0][0]).toMatchObject({
+      model: 'agent-model',
+      reasoning_effort: 'none',
+    });
+  });
+
+  it("sends none for an agent's own model when the system sets none", async () => {
+    vi.mocked(resolveModelById).mockResolvedValue({
+      model: 'agent-model',
+      provider: AIProvider.OPENAI,
+      apiKey: 'key',
+    });
+    mockParse.mockResolvedValue(answer(null));
+
+    await arbitrateSkillForRequest(
+      createMockContext(),
+      connector,
+      { ...agent, skill_arbiter_model_id: 'agent-arbiter-model' },
+      skills,
+      intent,
+      settings,
+    );
+
+    expect(mockParse.mock.calls[0][0]).not.toHaveProperty('reasoning_effort');
+  });
+
   it('sends the arbiter reasoning effort the settings chose', async () => {
     // A request waits for this answer, so the setting exists to keep the
     // model from thinking its way past the timeout.

--- a/packages/api/src/utils/super-agents/skill-arbiter.ts
+++ b/packages/api/src/utils/super-agents/skill-arbiter.ts
@@ -2,6 +2,7 @@ import { getApiUrl, SA_SKILL_REQUEST_PARAMS } from '@api/constants';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import {
+  type ResolvedModelConfig,
   resolveModelById,
   resolveSystemSettingsModel,
 } from '@api/utils/evaluation-model-resolver';
@@ -102,6 +103,36 @@ function arbiterUserMessage(
  * settings because it needs the timeout too: the arbiter is asked under the
  * skill-creation lease, which has to outlast it.
  */
+/**
+ * The agent's own arbiter model, under the system's bounds.
+ *
+ * An agent overrides *which* model arbitrates, not how hard it may think. A
+ * model resolved by id carries no settings of its own, so without this the
+ * system's reasoning effort silently stopped applying to any agent that named
+ * its own model -- while the timeout, resolved separately by
+ * `skillArbiterTimeoutMs`, has always fallen back to the system value. The
+ * two sit in the same position and now behave the same way.
+ */
+async function resolveAgentArbiterModel(
+  c: AppContext,
+  modelId: string,
+  connector: UserDataStorageConnector,
+  settings: SystemSettings,
+): Promise<ResolvedModelConfig | null> {
+  const resolved = await resolveModelById(
+    c,
+    modelId,
+    connector,
+    'MODEL_RESOLVER_SKILL_ARBITER',
+  );
+  return (
+    resolved && {
+      ...resolved,
+      reasoningEffort: settings.options.skill_arbiter.reasoning_effort,
+    }
+  );
+}
+
 export async function arbitrateSkillForRequest(
   c: AppContext,
   connector: UserDataStorageConnector,
@@ -112,11 +143,11 @@ export async function arbitrateSkillForRequest(
 ): Promise<SkillArbiterVerdict> {
   try {
     const modelConfig = agent.skill_arbiter_model_id
-      ? await resolveModelById(
+      ? await resolveAgentArbiterModel(
           c,
           agent.skill_arbiter_model_id,
           connector,
-          'MODEL_RESOLVER_SKILL_ARBITER',
+          settings,
         )
       : await resolveSystemSettingsModel(
           c,


### PR DESCRIPTION
## Problem

An agent can name its own arbiter model through `agents.skill_arbiter_model_id`. That model is resolved by id, and a model resolved by id carries no settings of its own, so the system's `options.skill_arbiter.reasoning_effort` silently stopped applying to any agent that named one.

The timeout sits in exactly the same position and does not behave that way: `skillArbiterTimeoutMs` falls back to `options.skill_arbiter.timeout_ms` whenever the agent sets no override of its own. Two settings on the same call, resolved a few lines apart, disagreed about what an agent-level model override means.

## Solution

A small helper resolves the agent's model and hands it the system's arbiter effort, so the two settings behave alike. An agent overriding the model is saying which model answers, not how hard it may think.

No schema change. There is still no per-agent effort column, and if one is ever wanted it can fall back through the same helper.

## Test notes

- `pnpm typecheck`, `pnpm check` (the one warning predates this branch), `pnpm test`: 188 files, 2993 tests passing.
- Two new cases in `skill-arbiter.test.ts`: an agent-named model arbitrating under a system effort of `none`, and nothing sent when the system leaves the model at its own default.
- The paragraph on the arbiter in AGENTS.md now states the fallback.

Found while reviewing test coverage for #274 and #276, and called out as still open in #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiMwStASMbRZMK7LvrBx98
