### PR TITLE
fix(api): refuse to mint a session when no password is configured

### DIFF
--- a/packages/api/src/v1/super-agents/auth-enforcement.test.ts
+++ b/packages/api/src/v1/super-agents/auth-enforcement.test.ts
@@ -116,3 +116,54 @@ describe('Auth enforcement on super-agents routes', () => {
     });
   });
 });
+
+/**
+ * The gateway configuration: BEARER_TOKEN guards the API and the dashboard
+ * password is left unset, which AGENTS.md documents as optional.
+ *
+ * `/auth/*` is exempt from the middleware and the middleware trusts the JWT
+ * cookie ahead of the bearer token, so a login endpoint that issued a session
+ * without a password to check would let anyone who can reach the port walk
+ * past BEARER_TOKEN entirely.
+ */
+describe('ACCESS_PASSWORD unset while BEARER_TOKEN guards the API', () => {
+  const gatewayApp = createAuthenticatedApp(superAgentsRouter, {
+    basePath: BASE,
+    bindings: { ACCESS_PASSWORD: undefined },
+  });
+
+  it('still refuses an unauthenticated request', async () => {
+    const response = await gatewayApp.request(`${BASE}/agents`);
+    expect(response.status).toBe(401);
+  });
+
+  it('refuses to mint a session from an arbitrary password', async () => {
+    const response = await gatewayApp.request(`${BASE}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'not-the-bearer-token' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('leaves the bearer token as the only way in', async () => {
+    const login = await gatewayApp.request(`${BASE}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'not-the-bearer-token' }),
+    });
+    const minted = login.headers.get('set-cookie')?.split(';')[0];
+
+    const withMintedCookie = await gatewayApp.request(`${BASE}/agents`, {
+      headers: minted ? { Cookie: minted } : {},
+    });
+    expect(withMintedCookie.status).toBe(401);
+
+    const withBearer = await gatewayApp.request(`${BASE}/agents`, {
+      headers: createBearerHeader(),
+    });
+    expect(withBearer.status).not.toBe(401);
+  });
+});

--- a/packages/api/src/v1/super-agents/auth.test.ts
+++ b/packages/api/src/v1/super-agents/auth.test.ts
@@ -49,16 +49,29 @@ describe('Auth Router', () => {
   });
 
   describe('POST /login', () => {
-    it('accepts any password when ACCESS_PASSWORD is not set', async () => {
+    it('rejects login when ACCESS_PASSWORD is not set', async () => {
       const response = await app.request('/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ password: 'anything' }),
       });
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(400);
       const data = await response.json();
-      expect(data).toEqual({ message: 'Password verified' });
+      expect(data).toEqual({
+        error:
+          'Dashboard authentication is disabled because ACCESS_PASSWORD is not configured.',
+      });
+    });
+
+    it('sets no cookie when ACCESS_PASSWORD is not set', async () => {
+      const response = await app.request('/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: 'anything' }),
+      });
+
+      expect(response.headers.get('set-cookie')).toBeNull();
     });
 
     it('rejects wrong password when ACCESS_PASSWORD is set', async () => {

--- a/packages/api/src/v1/super-agents/auth/login.ts
+++ b/packages/api/src/v1/super-agents/auth/login.ts
@@ -18,7 +18,14 @@ const verifyPasswordSchema = z.object({
 export const loginRouter = new Hono<AppEnv>()
   /**
    * Handles the '/super-agents/auth/login' API request by verifying the user's password.
-   * If ACCESS_PASSWORD is not set, authentication is disabled and any request succeeds.
+   *
+   * With no ACCESS_PASSWORD there is nothing to verify, so this refuses rather
+   * than issuing a session. Minting one would be an authentication bypass: the
+   * auth middleware exempts `/auth/*` so that an unauthenticated visitor can
+   * reach the login form, and it trusts the cookie ahead of the bearer token.
+   * A deployment that sets only BEARER_TOKEN -- the gateway configuration,
+   * where the dashboard password is documented as optional -- would hand full
+   * access to anyone who posted an arbitrary password here.
    */
   .post(
     '/',
@@ -28,10 +35,16 @@ export const loginRouter = new Hono<AppEnv>()
       const accessPassword = getAccessPassword(c);
 
       if (!accessPassword) {
-        console.warn(
-          'ACCESS_PASSWORD is not set — dashboard authentication is disabled. Any login will be accepted.',
+        return c.json(
+          {
+            error:
+              'Dashboard authentication is disabled because ACCESS_PASSWORD is not configured.',
+          },
+          400,
         );
-      } else if (password !== accessPassword) {
+      }
+
+      if (password !== accessPassword) {
         return c.json({ error: 'Invalid password' }, 401);
       }
 


### PR DESCRIPTION
## Problem

With `ACCESS_PASSWORD` unset, `POST /v1/super-agents/auth/login` logged a warning that authentication was disabled and then **signed a JWT anyway**.

That is an authentication bypass wherever `BEARER_TOKEN` guards the API on its own — the gateway configuration, where AGENTS.md documents the dashboard password as optional.

Two things compose into the hole:

- `middlewares/auth.ts` exempts `/v1/super-agents/auth/*`, so an unauthenticated visitor can reach the login form.
- The same middleware checks the JWT cookie **before** the bearer token.

So anyone who could reach the port could post an arbitrary password, take the cookie, and walk past `BEARER_TOKEN` entirely. Confirmed by running it against the real router and middleware before writing the fix:

```
no credentials                              -> 401   (guard works)
POST /auth/login {"password":"not-the-..."} -> 200 + Set-Cookie
GET  /agents      with that cookie          -> 200   <- bearer token defeated
```

One mitigating note: all three packaged deployments set `NODE_ENV=production`, so `AUTH_JWT_SECRET` is mandatory there and the `'default-dev-jwt-secret'` fallback can't be used to forge a cookie directly. This endpoint was the only easy door, so closing it closes the deployment.

## Solution

Login answers `400` when there is nothing to verify against, leaving the bearer token as the only way in.

## This does not require anyone to set a password

Nothing changes for a deployment that runs without one:

- With neither variable set (`pnpm dev`, the default image), `middlewares/auth.ts` skips auth before any of this and everything stays open by design.
- The dashboard never posts here regardless — `/auth/status` reports `authRequired: false`, and the `/login` route redirects an arriving visitor straight to `/agents`, so the form is unreachable.

The existing `e2e/dashboard/agents.spec.ts` runs its whole suite against a no-password server and is unaffected.

## Tests

The existing enforcement suite only exercised the *password-set* case, which is why this survived. Added alongside it:

- `auth.test.ts` — the case that asserted `accepts any password when ACCESS_PASSWORD is not set` now asserts refusal, plus a companion pinning that no cookie is set.
- `auth-enforcement.test.ts` — a new suite for the shape that was vulnerable (`BEARER_TOKEN` set, `ACCESS_PASSWORD` unset): an unauthenticated request is still refused, login won't mint a session, and the bearer token is the only way in.

| Check | Result |
| --- | --- |
| `pnpm typecheck` | exit 0 |
| `pnpm test` | 3018 passed, 13 skipped, 190 files |
| `pnpm check` | clean for these files |

`pnpm check` reports one pre-existing warning (unused `StructuredOutputResponse` in `task-completion/service/task-and-outcome.ts`), untouched here.

## Relationship to #216

Reimplements #216, which had the right idea but was written in February against the pre-rename `packages/api/src/v1/reactive-agents/` path. It no longer merges — a real merge conflicts across `package.json`, `constants.ts`, `middlewares/auth.ts`, `types/hono.ts` and both auth files, despite GitHub still labelling it `CLEAN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjoXMFvzzfrgDiRYMxra8Z