### PR TITLE
refactor(api): delete the judge's extraction mode

### DIFF
--- a/packages/api/src/connectors/evaluations/argument-correctness/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/argument-correctness/service/evaluate.ts
@@ -110,6 +110,8 @@ export async function evaluateLog(
 
   const judgeResult = await llmJudge.evaluate({
     text: `${systemPrompt}\n\n${userPrompt}`,
+    systemPrompt,
+    userPrompt,
   });
 
   let computed_score: number | null = null;

--- a/packages/api/src/connectors/evaluations/argument-correctness/templates/extraction-trace.ts
+++ b/packages/api/src/connectors/evaluations/argument-correctness/templates/extraction-trace.ts
@@ -29,7 +29,6 @@ For each tool call, decide if the arguments are correct and explain briefly.`;
   return {
     systemPrompt,
     userPrompt,
-    outputFormat: 'json',
   };
 }
 

--- a/packages/api/src/connectors/evaluations/argument-correctness/templates/extraction.ts
+++ b/packages/api/src/connectors/evaluations/argument-correctness/templates/extraction.ts
@@ -37,7 +37,6 @@ For each tool call, decide if the arguments are correct and explain briefly.`;
   return {
     systemPrompt,
     userPrompt,
-    outputFormat: 'json',
   };
 }
 

--- a/packages/api/src/connectors/evaluations/argument-correctness/templates/main.ts
+++ b/packages/api/src/connectors/evaluations/argument-correctness/templates/main.ts
@@ -38,6 +38,5 @@ Judge whether the arguments for each tool are correct given the input.`;
   return {
     systemPrompt,
     userPrompt,
-    outputFormat: 'json',
   } as const;
 }

--- a/packages/api/src/connectors/evaluations/argument-correctness/templates/verdict.ts
+++ b/packages/api/src/connectors/evaluations/argument-correctness/templates/verdict.ts
@@ -27,7 +27,6 @@ Provide an overall score and reasoning. The score may be computed as (# correct 
   return {
     systemPrompt,
     userPrompt,
-    outputFormat: 'json',
   };
 }
 

--- a/packages/api/src/connectors/evaluations/argument-correctness/types.ts
+++ b/packages/api/src/connectors/evaluations/argument-correctness/types.ts
@@ -29,7 +29,6 @@ export type ArgumentCorrectnessTemplateData = z.infer<
 export const ArgumentCorrectnessTemplateConfigSchema = z.object({
   systemPrompt: z.string(),
   userPrompt: z.string(),
-  outputFormat: z.literal('json'),
 });
 export type ArgumentCorrectnessTemplateConfig = z.infer<
   typeof ArgumentCorrectnessTemplateConfigSchema

--- a/packages/api/src/connectors/evaluations/knowledge-retention/evaluate-log.test.ts
+++ b/packages/api/src/connectors/evaluations/knowledge-retention/evaluate-log.test.ts
@@ -336,7 +336,7 @@ describe('Knowledge Retention - evaluateLog', () => {
 
   it('records the real score on a multi-message conversation, and shows the judge the role', async () => {
     // A conversation with two user messages renders with a blank line in it,
-    // and the old `outputFormat: 'json'` call had the judge re-split the
+    // and before the call passed explicit criteria the judge re-split the
     // text there: the "structured" result that came back scored a flat 1.0
     // no matter what the judge concluded. This is the title-generator log
     // that surfaced it -- judge said 0.25, the run recorded 1.0.

--- a/packages/api/src/connectors/evaluations/knowledge-retention/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/knowledge-retention/service/evaluate.ts
@@ -90,11 +90,11 @@ export async function evaluateLog(
 
   const evaluationText = `Analyze the following conversation for knowledge retention quality. ${roleSection}CONVERSATION: ${input} ASSISTANT RESPONSE: ${output} Consider how well the assistant retains and recalls information provided by the user throughout the conversation, judged against what its role requires it to carry forward. Look for: Knowledge retention vs. knowledge attrition patterns, consistency in recalling previously mentioned information, ability to maintain context across multiple turns, and specific instances where information was retained or lost. For single-turn conversations, assess if the assistant would be able to retain the information for future reference.${verdictSection} Provide a score between 0 and 1 with detailed reasoning for your analysis.`;
 
-  // Explicit criteria pin the scored judge path. The old `outputFormat:
-  // 'json'` call had the judge re-split this text at its first blank line --
-  // which lives inside the conversation once it has two messages -- and the
-  // "structured" result that came back scored 1.0 no matter what the judge
-  // actually answered.
+  // Explicit criteria pin the scored judge path. Without them the judge
+  // re-splits this text at its first blank line -- which lives inside the
+  // conversation once it has two messages -- and can read what comes back
+  // as an extraction, which scores 1.0 no matter what the judge actually
+  // answered.
   const result = await llmJudge.evaluate({
     text: evaluationText,
     evaluationCriteria: {

--- a/packages/api/src/connectors/evaluations/llm-judge.test.ts
+++ b/packages/api/src/connectors/evaluations/llm-judge.test.ts
@@ -1015,10 +1015,9 @@ describe('LLM Judge', () => {
     };
 
     it('uses explicit prompts verbatim and returns the real score', async () => {
-      // The template heuristics split on the first blank line and flip to a
-      // "structured" result whenever the text mentions a JSON object -- which
-      // reported score 1.0 no matter what the judge answered. Explicit
-      // prompts must bypass all of it.
+      // The judge used to split `text` on its first blank line and report a
+      // flat 1.0 whenever the leading fragment mentioned a JSON object.
+      // Explicit prompts reach the model untouched.
       judgeAnswer({ score: 0.3, reasoning: 'barely relevant' });
 
       const systemPrompt =
@@ -1042,27 +1041,27 @@ describe('LLM Judge', () => {
       );
     });
 
-    it('treats a call as an extraction only when declared structured', async () => {
-      judgeAnswer({ task: 'summarize', outcome: 'a summary' });
+    it('scores template-shaped text instead of reading it as an extraction', async () => {
+      // No explicit prompts and no criteria: this used to match the template
+      // heuristics, and the leading "as a JSON object" flipped it to an
+      // extraction scored a flat 1.0. There is no such path any more.
+      judgeAnswer({ score: 0.25, reasoning: 'lost the earlier context' });
 
       const result = await llmJudge.evaluate({
-        text: '',
-        systemPrompt: 'Extract the task and outcome.',
-        userPrompt: 'INPUT: hello OUTPUT: world',
-        structured: true,
+        text: 'You are an expert evaluator. Provide your evaluation as a JSON object.\n\nCONVERSATION: hi\n\nthere',
       });
 
-      expect(result.score).toBe(1.0);
-      expect(result.metadata).toEqual({
-        task: 'summarize',
-        outcome: 'a summary',
-      });
+      expect(result.score).toBe(0.25);
+      expect(result.metadata).toBeUndefined();
+      expect(mockParse.mock.calls[0][0].messages[0].content).toContain(
+        'You are a quality evaluator',
+      );
     });
 
-    it('lets explicit criteria win over the template heuristics', async () => {
+    it('scores text that looks like a template when criteria are given', async () => {
       // Conversation content can contain "You are", "evaluate" and blank
       // lines; a caller that provided criteria means the scored criteria
-      // judge, never a heuristic re-split of its text.
+      // judge.
       judgeAnswer({ score: 0.2, reasoning: 'mostly unmet' });
 
       const result = await llmJudge.evaluate({

--- a/packages/api/src/connectors/evaluations/llm-judge.test.ts
+++ b/packages/api/src/connectors/evaluations/llm-judge.test.ts
@@ -1,4 +1,4 @@
-import { createLLMJudge } from '@api/evaluations/llm-judge';
+import { createLLMJudge, withExtraCriteria } from '@api/evaluations/llm-judge';
 import { createMockContext } from '@api/test-utils/mock-context';
 import { ReasoningEffort } from '@shared/types/api/routes/shared/thinking';
 import { AIProvider } from '@shared/types/constants';
@@ -1073,6 +1073,21 @@ describe('LLM Judge', () => {
       const call = mockParse.mock.calls[0][0];
       expect(call.messages[0].content).toContain('You are a quality evaluator');
       expect(call.messages[0].content).toContain('Check every user intention');
+    });
+  });
+
+  describe('withExtraCriteria', () => {
+    it("appends a caller's description to the template's user prompt", () => {
+      expect(withExtraCriteria('Conversation:\nhi', 'Must cite a source')).toBe(
+        'Conversation:\nhi\n\nAdditional criteria:\nMust cite a source',
+      );
+    });
+
+    it('leaves the prompt alone when there is no description', () => {
+      expect(withExtraCriteria('Conversation:\nhi')).toBe('Conversation:\nhi');
+      expect(withExtraCriteria('Conversation:\nhi', '   ')).toBe(
+        'Conversation:\nhi',
+      );
     });
   });
 });

--- a/packages/api/src/connectors/evaluations/role-adherence/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/role-adherence/service/evaluate.ts
@@ -86,6 +86,8 @@ export async function evaluateLog(
 
   const judgeResult = await llmJudge.evaluate({
     text: `${tpl.systemPrompt}\n\n${tpl.userPrompt}`,
+    systemPrompt: tpl.systemPrompt,
+    userPrompt: tpl.userPrompt,
   });
 
   let final_score = judgeResult.score;

--- a/packages/api/src/connectors/evaluations/role-adherence/service/role-adherence-criteria.ts
+++ b/packages/api/src/connectors/evaluations/role-adherence/service/role-adherence-criteria.ts
@@ -2,7 +2,7 @@ import { getRoleAdherenceMainTemplate } from '@api/connectors/evaluations/role-a
 import type { RoleAdherenceMetadata } from '@api/connectors/evaluations/role-adherence/types';
 import { RoleAdherenceResultSchema } from '@api/connectors/evaluations/role-adherence/types';
 
-import { createLLMJudge } from '@api/evaluations/llm-judge';
+import { createLLMJudge, withExtraCriteria } from '@api/evaluations/llm-judge';
 import type {
   GenericEvaluationInput,
   GenericEvaluator,
@@ -66,11 +66,17 @@ async function evaluateRoleAdherenceWithJudge(
     include_reason: input.criteria?.include_reason ?? true,
   });
 
+  // The caller's description is extra criteria for this metric, not a
+  // replacement for it: appended to the template rather than handed to the
+  // generic criteria judge, which would drop the template altogether.
+  const userPrompt = withExtraCriteria(
+    tpl.userPrompt,
+    input.criteria?.description,
+  );
   const result = await llmJudge.evaluate({
-    text: `${tpl.systemPrompt}\n\n${tpl.userPrompt}`,
-    evaluationCriteria: input.criteria?.description
-      ? { criteria: [input.criteria.description] }
-      : undefined,
+    text: `${tpl.systemPrompt}\n\n${userPrompt}`,
+    systemPrompt: tpl.systemPrompt,
+    userPrompt,
   });
 
   return parseRoleAdherenceResult(result);
@@ -105,11 +111,14 @@ export function createRoleAdherenceEvaluator(
         include_reason: criteria?.include_reason ?? true,
       });
 
+      const userPrompt = withExtraCriteria(
+        tpl.userPrompt,
+        criteria?.description,
+      );
       const result = await llmJudge.evaluate({
-        text: `${tpl.systemPrompt}\n\n${tpl.userPrompt}`,
-        evaluationCriteria: criteria?.description
-          ? { criteria: [criteria.description] }
-          : undefined,
+        text: `${tpl.systemPrompt}\n\n${userPrompt}`,
+        systemPrompt: tpl.systemPrompt,
+        userPrompt,
       });
 
       const parsed = parseRoleAdherenceResult(result);

--- a/packages/api/src/connectors/evaluations/role-adherence/templates/main.ts
+++ b/packages/api/src/connectors/evaluations/role-adherence/templates/main.ts
@@ -60,7 +60,6 @@ ${jsonStructure}`;
   return {
     systemPrompt,
     userPrompt,
-    outputFormat: 'json',
   };
 }
 

--- a/packages/api/src/connectors/evaluations/role-adherence/types.ts
+++ b/packages/api/src/connectors/evaluations/role-adherence/types.ts
@@ -19,7 +19,6 @@ export type RoleAdherenceTemplateData = z.infer<
 export const RoleAdherenceTemplateConfigSchema = z.object({
   systemPrompt: z.string(),
   userPrompt: z.string(),
-  outputFormat: z.literal('json'),
 });
 
 export type RoleAdherenceTemplateConfig = z.infer<

--- a/packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/service/task-and-outcome.ts
@@ -13,8 +13,6 @@ const StructuredOutputResponse = z.object({
   outcome: z.string(),
 });
 
-type StructuredOutputResponse = z.infer<typeof StructuredOutputResponse>;
-
 // The outcome is scoped to the latest response on purpose: every earlier
 // turn of the conversation arrived as its own request, carries its own log,
 // and is scored by its own evaluation run -- often under a different arm.

--- a/packages/api/src/connectors/evaluations/task-completion/templates/extraction-trace.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/templates/extraction-trace.ts
@@ -30,7 +30,6 @@ Extract the TASK and OUTCOME from this trace.`;
   return {
     systemPrompt,
     userPrompt,
-    outputFormat: 'json',
   };
 }
 

--- a/packages/api/src/connectors/evaluations/task-completion/templates/extraction.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/templates/extraction.ts
@@ -76,7 +76,6 @@ Remember: Return ONLY a JSON object with "task" and "outcome" fields. No other f
   return {
     systemPrompt,
     userPrompt,
-    outputFormat: 'json',
   };
 }
 

--- a/packages/api/src/connectors/evaluations/task-completion/templates/main.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/templates/main.ts
@@ -81,7 +81,6 @@ Please evaluate how well the output fulfills the task requirements.`;
   return {
     systemPrompt,
     userPrompt,
-    outputFormat: 'json',
   };
 }
 

--- a/packages/api/src/connectors/evaluations/task-completion/templates/verdict.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/templates/verdict.ts
@@ -43,7 +43,6 @@ Please evaluate how well the outcome fulfills the task requirements and provide 
   return {
     systemPrompt,
     userPrompt,
-    outputFormat: 'json',
   };
 }
 

--- a/packages/api/src/connectors/evaluations/task-completion/types.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/types.ts
@@ -25,7 +25,6 @@ export type TaskCompletionTemplateData = z.infer<
 export const TaskCompletionTemplateConfig = z.object({
   systemPrompt: z.string(),
   userPrompt: z.string(),
-  outputFormat: z.literal('json'),
 });
 
 export type TaskCompletionTemplateConfig = z.infer<

--- a/packages/api/src/connectors/evaluations/turn-relevancy/evaluate-log.test.ts
+++ b/packages/api/src/connectors/evaluations/turn-relevancy/evaluate-log.test.ts
@@ -269,10 +269,10 @@ describe('Turn Relevancy - evaluateLog', () => {
       },
     };
 
-    // The judge concludes the turn is irrelevant. Under the old
-    // `outputFormat: 'json'` call this came back as a "structured" result
-    // scored a flat 1.0, with the judge's verdict buried in metadata --
-    // every successful turn-relevancy run scored 1.0.
+    // The judge concludes the turn is irrelevant. Before the call passed
+    // explicit prompts this came back as a "structured" result scored a
+    // flat 1.0, with the judge's verdict buried in metadata -- every
+    // successful turn-relevancy run scored 1.0.
     mockParse.mockResolvedValueOnce({
       choices: [
         {

--- a/packages/api/src/connectors/evaluations/turn-relevancy/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/turn-relevancy/service/evaluate.ts
@@ -135,10 +135,11 @@ export async function evaluateLog(
     include_reason: params.include_reason ?? true,
   });
 
-  // Explicit prompts, and no `outputFormat: 'json'`: that flag made the
-  // judge treat the reply as an extraction and report a flat 1.0 with the
-  // real score buried in metadata -- every successful turn-relevancy run
-  // scored 1.0 regardless of what the judge concluded.
+  // Explicit prompts, so the judge scores rather than extracts. Left to
+  // re-split `text` on its own the judge can read the reply as an
+  // extraction and report a flat 1.0 with the real score buried in
+  // metadata -- which is what made every successful turn-relevancy run
+  // score 1.0 regardless of what the judge concluded.
   const judgeResult = await llmJudge.evaluate({
     text: `${tpl.systemPrompt}\n\n${tpl.userPrompt}`,
     systemPrompt: tpl.systemPrompt,

--- a/packages/api/src/connectors/evaluations/turn-relevancy/service/turn-relevancy-criteria.ts
+++ b/packages/api/src/connectors/evaluations/turn-relevancy/service/turn-relevancy-criteria.ts
@@ -3,7 +3,7 @@ import {
   type TurnRelevancyMetadata,
   TurnRelevancyResultSchema,
 } from '@api/connectors/evaluations/turn-relevancy/types';
-import { createLLMJudge } from '@api/evaluations/llm-judge';
+import { createLLMJudge, withExtraCriteria } from '@api/evaluations/llm-judge';
 import type {
   GenericEvaluationInput,
   GenericEvaluator,
@@ -64,11 +64,17 @@ async function evaluateTurnRelevancyWithJudge(
     include_reason: input.criteria?.include_reason ?? true,
   });
 
+  // The caller's description is extra criteria for this metric, not a
+  // replacement for it: appended to the template rather than handed to the
+  // generic criteria judge, which would drop the template altogether.
+  const userPrompt = withExtraCriteria(
+    tpl.userPrompt,
+    input.criteria?.description,
+  );
   const result = await llmJudge.evaluate({
-    text: `${tpl.systemPrompt}\n\n${tpl.userPrompt}`,
-    evaluationCriteria: input.criteria?.description
-      ? { criteria: [input.criteria.description] }
-      : undefined,
+    text: `${tpl.systemPrompt}\n\n${userPrompt}`,
+    systemPrompt: tpl.systemPrompt,
+    userPrompt,
   });
 
   return parseTurnRelevancyResult(result);
@@ -104,11 +110,14 @@ export function createTurnRelevancyEvaluator(
         include_reason: criteria?.include_reason ?? true,
       });
 
+      const userPrompt = withExtraCriteria(
+        tpl.userPrompt,
+        criteria?.description,
+      );
       const result = await llmJudge.evaluate({
-        text: `${tpl.systemPrompt}\n\n${tpl.userPrompt}`,
-        evaluationCriteria: criteria?.description
-          ? { criteria: [criteria.description] }
-          : undefined,
+        text: `${tpl.systemPrompt}\n\n${userPrompt}`,
+        systemPrompt: tpl.systemPrompt,
+        userPrompt,
       });
 
       const parsed = parseTurnRelevancyResult(result);

--- a/packages/api/src/evaluations/llm-judge.ts
+++ b/packages/api/src/evaluations/llm-judge.ts
@@ -264,14 +264,6 @@ export function createLLMJudge(
       return criteriaBasedPrompt(input);
     }
 
-    // If outputFormat is explicitly specified (always 'json' now), use structured output
-    if (input.outputFormat === 'json') {
-      const { systemPrompt, userPrompt } = parseTemplatePrompt(input.text);
-      if (systemPrompt && userPrompt) {
-        return { systemPrompt, userPrompt, useStructuredOutput: true };
-      }
-    }
-
     // Template-based evaluation: More robust detection of pre-formatted prompts
     if (isTemplateBasedInput(input.text)) {
       const { systemPrompt, userPrompt } = parseTemplatePrompt(input.text);

--- a/packages/api/src/evaluations/llm-judge.ts
+++ b/packages/api/src/evaluations/llm-judge.ts
@@ -111,6 +111,21 @@ export function parseJudgeJson(content: string): unknown {
 }
 
 /**
+ * Fold a caller's extra criteria into a template's user prompt. A metric is
+ * described by its own template; a `description` supplied alongside narrows
+ * that judgement rather than replacing it, so it is appended instead of being
+ * handed to the criteria judge, which builds a generic prompt and drops the
+ * template entirely.
+ */
+export function withExtraCriteria(
+  userPrompt: string,
+  description?: string,
+): string {
+  const extra = description?.trim();
+  return extra ? `${userPrompt}\n\nAdditional criteria:\n${extra}` : userPrompt;
+}
+
+/**
  * Zod schema for evaluation results
  */
 const EvaluationResultSchema = z.object({

--- a/packages/api/src/evaluations/llm-judge.ts
+++ b/packages/api/src/evaluations/llm-judge.ts
@@ -111,63 +111,6 @@ export function parseJudgeJson(content: string): unknown {
 }
 
 /**
- * Check if input text appears to be a pre-formatted template prompt
- */
-function isTemplateBasedInput(text: string): boolean {
-  // Generic template detection criteria:
-  const templateIndicators = [
-    text.includes('You are an expert evaluator'),
-    text.includes('You are a quality evaluator'),
-    text.includes('Provide your evaluation as a JSON object'),
-    text.includes('Return your response as a JSON object'),
-    text.includes('You are') &&
-      text.includes('evaluate') &&
-      text.includes('\n\n'),
-  ];
-
-  // Must have at least one strong indicator AND contain double newlines (separator)
-  return (
-    templateIndicators.some((indicator) => indicator) && text.includes('\n\n')
-  );
-}
-
-/**
- * Parse a template-based prompt into system and user components
- */
-function parseTemplatePrompt(text: string): {
-  systemPrompt: string;
-  userPrompt: string;
-} {
-  // Split on first occurrence of double newline
-  const doubleLnIndex = text.indexOf('\n\n');
-  if (doubleLnIndex === -1) {
-    return { systemPrompt: '', userPrompt: text };
-  }
-
-  const systemPrompt = text.substring(0, doubleLnIndex).trim();
-  const userPrompt = text.substring(doubleLnIndex + 2).trim();
-
-  // Validate that we have meaningful content in both parts
-  if (systemPrompt.length < 10 || userPrompt.length < 10) {
-    return { systemPrompt: '', userPrompt: text };
-  }
-
-  return { systemPrompt, userPrompt };
-}
-
-/**
- * Check if the prompt expects structured JSON output
- */
-function expectsStructuredOutput(systemPrompt: string): boolean {
-  return (
-    systemPrompt.includes('JSON object') ||
-    systemPrompt.includes('JSON structure') ||
-    systemPrompt.includes('Return your response as') ||
-    systemPrompt.includes('as a JSON object')
-  );
-}
-
-/**
  * Zod schema for evaluation results
  */
 const EvaluationResultSchema = z.object({
@@ -244,43 +187,26 @@ export function createLLMJudge(
   function generateEvaluationPrompt(input: EvaluationInput): {
     systemPrompt: string;
     userPrompt: string;
-    useStructuredOutput: boolean;
   } {
-    // Explicit prompts are used verbatim -- no re-splitting. Only a call
-    // declared as an extraction gets the metadata-only result; a scoring
-    // call gets the score the judge actually answered.
+    // A caller that built its own prompts has them used verbatim. Everything
+    // else is scored by the criteria judge. The judge used to re-derive a
+    // system/user split from `text` instead, guessing at blank lines and
+    // prompt wording -- a template whose opening paragraph mentioned JSON
+    // was read as an extraction and scored a flat 1.0 whatever it answered.
     if (input.systemPrompt !== undefined && input.userPrompt !== undefined) {
       return {
         systemPrompt: input.systemPrompt,
         userPrompt: input.userPrompt,
-        useStructuredOutput: input.structured === true,
       };
-    }
-
-    // Explicit criteria mean the criteria-based judge. This must win over
-    // the template heuristics below: they match on phrases and blank lines,
-    // and conversation content can contain both.
-    if (input.evaluationCriteria) {
-      return criteriaBasedPrompt(input);
-    }
-
-    // Template-based evaluation: More robust detection of pre-formatted prompts
-    if (isTemplateBasedInput(input.text)) {
-      const { systemPrompt, userPrompt } = parseTemplatePrompt(input.text);
-      if (systemPrompt && userPrompt) {
-        const useStructuredOutput = expectsStructuredOutput(systemPrompt);
-        return { systemPrompt, userPrompt, useStructuredOutput };
-      }
     }
 
     return criteriaBasedPrompt(input);
   }
 
-  /** The generic criteria judge: scored output, no template heuristics. */
+  /** The generic criteria judge. */
   function criteriaBasedPrompt(input: EvaluationInput): {
     systemPrompt: string;
     userPrompt: string;
-    useStructuredOutput: boolean;
   } {
     const criteria =
       input.evaluationCriteria?.criteria || evaluationCriteria.general;
@@ -303,7 +229,7 @@ ${input.text}
 
 Provide a score between 0 and 1 with detailed reasoning for your evaluation.`;
 
-    return { systemPrompt, userPrompt, useStructuredOutput: false };
+    return { systemPrompt, userPrompt };
   }
 
   /**
@@ -400,16 +326,6 @@ Provide a score between 0 and 1 with detailed reasoning for your evaluation.`;
           throw new Error('No parsed response from AI provider');
         }
 
-        // For structured output (like task/outcome extraction), return as metadata
-        if (prompt.useStructuredOutput) {
-          return {
-            score: 1.0, // Default score for successful extraction
-            reasoning: 'Structured data extracted successfully',
-            metadata: parsed as Record<string, unknown>,
-          };
-        }
-
-        // For regular evaluation, validate and return
         return LLMJudgeResult.parse(parsed);
       } catch (err) {
         lastError = err;

--- a/packages/api/src/types/evaluations/llm-judge.ts
+++ b/packages/api/src/types/evaluations/llm-judge.ts
@@ -46,7 +46,6 @@ export type EvaluationCriteria = z.infer<typeof EvaluationCriteriaSchema>;
 export const EvaluationInputSchema = z.object({
   text: z.string(),
   evaluationCriteria: EvaluationCriteriaSchema.optional(),
-  outputFormat: z.literal('json').optional(),
   /**
    * Explicit prompts, used verbatim when both are set. Without them the
    * judge re-derives a system/user split from `text` heuristically, and a

--- a/packages/api/src/types/evaluations/llm-judge.ts
+++ b/packages/api/src/types/evaluations/llm-judge.ts
@@ -47,19 +47,12 @@ export const EvaluationInputSchema = z.object({
   text: z.string(),
   evaluationCriteria: EvaluationCriteriaSchema.optional(),
   /**
-   * Explicit prompts, used verbatim when both are set. Without them the
-   * judge re-derives a system/user split from `text` heuristically, and a
-   * conversation that happens to contain a blank line splits mid-content.
+   * Explicit prompts, used verbatim when both are set. Without them the call
+   * is scored by the criteria judge, which builds its own prompts around
+   * `text`. The judge never re-derives a split from `text` itself.
    */
   systemPrompt: z.string().optional(),
   userPrompt: z.string().optional(),
-  /**
-   * True only for extraction calls, where the judge's JSON *is* the result
-   * and there is no score to read: the result carries the parsed object as
-   * metadata. A scoring call must leave this unset -- a structured result
-   * reports score 1.0 regardless of what the judge thought.
-   */
-  structured: z.boolean().optional(),
 });
 
 export type EvaluationInput = z.infer<typeof EvaluationInputSchema>;


### PR DESCRIPTION
## Problem

`llmJudge.evaluate()` served two jobs — scoring a response, and extracting JSON from one. Extraction has no score to report, so it returned a placeholder `score: 1.0` with the model's real answer in `metadata`.

Which mode you got was **inferred from the prompt's wording**, not declared by the caller:

```ts
if (isTemplateBasedInput(input.text)) {                       // does text look like a template?
  const { systemPrompt } = parseTemplatePrompt(input.text);   // split on the FIRST blank line
  const useStructuredOutput = expectsStructuredOutput(systemPrompt);  // does it mention "JSON object"?
}
```

Callers build one string, `` `${tpl.systemPrompt}\n\n${tpl.userPrompt}` ``, and the judge took it apart again. When it guessed wrong the failure was silent and maximally wrong: not an error, not a zero, a **perfect** score. `strict_mode` (`score === 1.0 ? 1.0 : 0.0`) passed it too, and these scores feed prompt optimization.

It had already misfired twice, and a third case was live when this PR started:

- **knowledge-retention** — a conversation with two user messages renders with a blank line, so the judge re-split mid-conversation. The title-generator log in the test: judge said 0.25, the run recorded 1.0.
- **turn-relevancy** (main service path) — every successful run scored 1.0 regardless of the verdict.
- **turn-relevancy-criteria** — still live. Its template says `Return a JSON object` and its first blank line *is* the real boundary, so any conversation containing the word "evaluate" (the fifth template indicator) tipped the call into the extraction branch and scored a flat 1.0.

The first two were fixed by opting the caller out. The guess itself was left standing, and **role-adherence was one reworded sentence from being next** — its `Provide your evaluation as a JSON object` line sits twelve lines below where the split falls.

## Why delete rather than fix

Extraction has no users left:

- Nothing in the repo passes `structured: true` — the only occurrence was a test guarding the flag.
- Task/outcome extraction, the case the branch was written for (`// like task/outcome extraction`), now calls the provider directly in `task-completion/service/task-and-outcome.ts`.

So the mode is gone rather than made more reliable. A caller either supplies its own prompts or is scored by the criteria judge; there is no third path and no placeholder score.

## Changes

Four commits:

1. **`chore`** — drop the unreachable `outputFormat: 'json'` entry point. Templates still returned the field, but no service forwarded it, so `input.outputFormat` was never populated. Removing it from `EvaluationInputSchema` makes wiring it back a type error.
2. **`docs`** — reword four notes in turn-relevancy and knowledge-retention that explained the trap in terms of the removed flag.
3. **`refactor`** — delete `isTemplateBasedInput`, `parseTemplatePrompt`, `expectsStructuredOutput`, the `useStructuredOutput` plumbing, the `structured` field, and the `score: 1.0` block. `role-adherence` and `argument-correctness` passed only `text` and leaned on the re-split, so they now pass the prompts they already build.
4. **`fix`** — the four `*-criteria.ts` call sites. They passed both `text` and an `evaluationCriteria` built from an *optional* description, so with a description the criteria judge dropped the metric's template, and without one they fell into the heuristics (the live turn-relevancy 1.0 above). They now pass the template explicitly and treat the description as extra criteria appended to it. Also drops the unused `StructuredOutputResponse` alias, clearing the repo's only standing lint warning.

The `evaluationCriteria` special case in the dispatcher collapsed out as well — with the heuristic gone, both remaining paths lead to `criteriaBasedPrompt`.

## Behavior changes

Deliberate, and worth reviewing:

- **turn-relevancy-criteria** stops intermittently scoring 1.0. This is the live bug above.
- **The four criteria evaluators** now send their metric's template to the model. Previously a supplied `description` replaced the whole template with a generic prompt built from that single line; it is now appended under `Additional criteria:`, narrowing the metric instead of replacing it.

Every other caller is unaffected: `task-completion`, `knowledge-retention`, `conversation-completeness`, and the main `turn-relevancy` path already passed explicit prompts or criteria, and `role-adherence` / `argument-correctness` now pass the prompts they were already building.

## Test notes

- `pnpm typecheck` clean; `pnpm check` fully clean (the one pre-existing warning is gone).
- `pnpm test` — 3020 passed, 190 files.
- Dropped the `structured: true` test and added one in its place guarding the deleted path: template-shaped text, no explicit prompts, no criteria, asserting a real score, no metadata, and the criteria judge's system prompt. That exact input scored 1.0 under the old code, so it fails if the guess comes back.
- Added unit tests for `withExtraCriteria` (appends, trims, leaves the prompt alone when absent).

Net **175 deletions, 82 insertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZzjiYLXxABB3y7iRa4NQ
