### PR TITLE
Make a log readable, and say where its system prompt came from

### DIFF
--- a/e2e/contract/optimizer.spec.ts
+++ b/e2e/contract/optimizer.spec.ts
@@ -13,7 +13,7 @@ import {
   STUB_URL,
   stubRequests,
 } from '../fixtures/gateway';
-import { getLogs } from '../fixtures/logs';
+import { getLogs, getLogsByArm, type LoggedRequest } from '../fixtures/logs';
 import {
   getArms,
   getClusters,
@@ -200,6 +200,64 @@ test.describe('optimization loop', () => {
         return logged?.original_system_prompt;
       })
       .toBe('You are a restaurant concierge.');
+  });
+
+  test('records the configuration that served the request, and filters by it', async ({
+    request,
+  }) => {
+    /**
+     * The log row keeps `cluster_id`, which names the partition but not
+     * which of its configurations was pulled, and the prompt that reached
+     * the provider is that configuration's template already rendered -- so
+     * the arm cannot be recovered afterwards. It is recorded on the log
+     * instead, and `arm_id` filters on it: `json_extract` on SQLite, a
+     * `metadata->served_configuration->>id` path on PostgREST. Two
+     * hand-written translations of one filter, so both are checked.
+     */
+    const userMessage = 'which configuration answered this';
+    const response = await request.post(CHAT_COMPLETIONS_PATH, {
+      headers: {
+        'sa-config': optimizedConfig(
+          configured.agentName,
+          configured.skillName,
+        ),
+      },
+      data: chatBody(userMessage),
+    });
+    expect(response.status()).toBe(200);
+
+    const loggedRequest = async (): Promise<LoggedRequest | undefined> =>
+      (await getLogs(request, configured.skillId)).find((log) =>
+        log.ai_provider_request_log?.request_body.messages?.some(
+          (message) => message.content === userMessage,
+        ),
+      );
+
+    await expect
+      .poll(async () => (await loggedRequest())?.metadata.served_configuration)
+      .toBeDefined();
+
+    const logged = await loggedRequest();
+    const served = logged?.metadata.served_configuration as {
+      id: string;
+      name: string;
+    };
+    const arms = await getArms(request, configured.skillId);
+    const pulled = arms.find((arm) => arm.id === served.id);
+    expect(
+      pulled,
+      'the log names a configuration this skill does not have',
+    ).toBeDefined();
+    expect(served.name).toBe(pulled?.name);
+
+    const byArm = await getLogsByArm(request, served.id);
+    expect(byArm.map((log) => log.id)).toContain(logged?.id);
+
+    const byOtherArm = await getLogsByArm(
+      request,
+      '00000000-0000-4000-8000-000000000000',
+    );
+    expect(byOtherArm).toEqual([]);
   });
 
   test('embeds the request through the embedding skill', async ({

--- a/e2e/fixtures/logs.ts
+++ b/e2e/fixtures/logs.ts
@@ -34,3 +34,19 @@ export const getLogs = async (
   });
   return response.json() as Promise<LoggedRequest[]>;
 };
+
+/**
+ * The logs a configuration served. There is no `arm_id` column: both
+ * connectors reach into `metadata.served_configuration`, SQLite with
+ * `json_extract` and PostgREST with a `->>` path, which is why this is
+ * exercised on both backends.
+ */
+export const getLogsByArm = async (
+  request: APIRequestContext,
+  armId: string,
+): Promise<LoggedRequest[]> => {
+  const response = await request.get(LOGS_PATH, {
+    params: { arm_id: armId },
+  });
+  return response.json() as Promise<LoggedRequest[]>;
+};

--- a/e2e/fixtures/optimizer.ts
+++ b/e2e/fixtures/optimizer.ts
@@ -149,6 +149,7 @@ export const setUpOptimizedSkill = async (
 export interface Arm {
   id: string;
   cluster_id: string;
+  name: string;
   params: { system_prompt: string | null };
 }
 

--- a/packages/api/src/connectors/libsql/connector.test.ts
+++ b/packages/api/src/connectors/libsql/connector.test.ts
@@ -811,6 +811,29 @@ describe('logs', () => {
     expect(fetchedBare.original_system_prompt).toBeNull();
   });
 
+  it('filters by the configuration that served the request', async () => {
+    const { c } = await freshDatabase();
+    const agent = await seedAgent(c);
+    const skill = await seedSkill(c, agent.id);
+    const armId = '11111111-1111-4111-8111-111111111111';
+
+    // No `arm_id` column: the arm is matched inside the metadata, where the
+    // gateway records it.
+    const served = await logs.createLog(c, {
+      ...logParams(agent.id, skill.id),
+      metadata: { served_configuration: { id: armId, name: '7' } },
+    } as Parameters<typeof logs.createLog>[1]);
+    await logs.createLog(c, logParams(agent.id, skill.id));
+
+    const matched = await logs.getLogs(c, { arm_id: armId });
+    expect(matched.map((l) => l.id)).toEqual([served.id]);
+
+    const other = await logs.getLogs(c, {
+      arm_id: '22222222-2222-4222-8222-222222222222',
+    });
+    expect(other).toEqual([]);
+  });
+
   it('orders newest first and honours the time range', async () => {
     const { c } = await freshDatabase();
     const agent = await seedAgent(c);

--- a/packages/api/src/connectors/libsql/logs.ts
+++ b/packages/api/src/connectors/libsql/logs.ts
@@ -36,7 +36,15 @@ export const libsqlLogsStorageConnector: LogsStorageConnector = {
     eq('agent_id', queryParams.agent_id);
     eq('skill_id', queryParams.skill_id);
     eq('cluster_id', queryParams.cluster_id);
-    eq('arm_id', queryParams.arm_id);
+    // The arm is not a column. The row keeps `cluster_id`, which names the
+    // partition but not which of its configurations was pulled, so the
+    // gateway records that on the log as `metadata.served_configuration`.
+    if (queryParams.arm_id !== undefined) {
+      conditions.push(
+        "json_extract(metadata, '$.served_configuration.id') = ?",
+      );
+      args.push(queryParams.arm_id);
+    }
     eq('app_id', queryParams.app_id);
     eq('trace_id', queryParams.trace_id);
     eq('id', queryParams.id);

--- a/packages/api/src/connectors/supabase/supabase.ts
+++ b/packages/api/src/connectors/supabase/supabase.ts
@@ -1408,7 +1408,10 @@ export const supabaseLogsStorageConnector: LogsStorageConnector = {
       postgRESTQuery.cluster_id = `eq.${queryParams.cluster_id}`;
     }
     if (queryParams.arm_id) {
-      postgRESTQuery.arm_id = `eq.${queryParams.arm_id}`;
+      // As in the libSQL connector: the arm is not a column, it is recorded
+      // on the log as `metadata.served_configuration`.
+      postgRESTQuery['metadata->served_configuration->>id'] =
+        `eq.${queryParams.arm_id}`;
     }
     if (queryParams.app_id) {
       postgRESTQuery.app_id = `eq.${queryParams.app_id}`;

--- a/packages/api/src/middlewares/logs.test.ts
+++ b/packages/api/src/middlewares/logs.test.ts
@@ -11,7 +11,7 @@ import type { SkillRoutingDecision } from '@api/utils/super-agents/skill-routing
 import { FunctionName } from '@shared/types/api/request';
 import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
 import type { SuperAgentsConfig } from '@shared/types/api/request/headers';
-import type { Agent, Skill } from '@shared/types/data';
+import type { Agent, Skill, SkillOptimizationArm } from '@shared/types/data';
 import type { AIProviderRequestLog } from '@shared/types/data/log';
 import { HttpMethod } from '@shared/types/http';
 import { Hono } from 'hono';
@@ -48,6 +48,13 @@ const decision: SkillRoutingDecision = {
   candidates: 2,
 };
 
+/** The configuration the optimizer pulled to serve the request. */
+const pulledArm = {
+  id: 'arm-1',
+  cluster_id: 'cluster-1',
+  name: '7',
+} as SkillOptimizationArm;
+
 /** What the provider was actually sent, arm prompt and all. */
 const aiProviderLog = {
   provider: 'openai',
@@ -72,6 +79,7 @@ const aiProviderLog = {
 describe('logsMiddleware', () => {
   let requestData: SuperAgentsRequestData;
   let logsConnector: { createLog: ReturnType<typeof vi.fn> };
+  let userData: UserDataStorageConnector;
   let app: Hono<AppEnv>;
 
   beforeEach(() => {
@@ -93,7 +101,7 @@ describe('logsMiddleware', () => {
         .fn()
         .mockImplementation(async (_c, params) => ({ ...params, id: 'log-1' })),
     };
-    const userData = {
+    userData = {
       incrementSkillTotalRequests: vi.fn(),
       getSkillOptimizationEvaluations: vi.fn().mockResolvedValue([]),
     } as unknown as UserDataStorageConnector;
@@ -152,6 +160,39 @@ describe('logsMiddleware', () => {
 
     const log = await storedLog();
     expect(log.metadata).toEqual({ skill_routing: decision });
+  });
+
+  it('records which configuration served the request', async () => {
+    app = new Hono<AppEnv>()
+      .use('*', async (c, next) => {
+        c.set('sa_request_data', requestData);
+        c.set('user_data_storage_connector', userData);
+        await next();
+      })
+      .use(
+        '*',
+        logsMiddleware(
+          createFactory<AppEnv>(),
+          () => logsConnector as unknown as LogsStorageConnector,
+        ),
+      )
+      .post('/v1/chat/completions', (c) => {
+        c.set('sa_config', saConfig);
+        c.set('agent', agent);
+        c.set('skill', skill);
+        c.set('ai_provider_log', aiProviderLog);
+        c.set('pulled_arm', pulledArm);
+        return c.json({ ok: true });
+      });
+
+    await app.request('/v1/chat/completions', { method: 'POST' });
+
+    const log = await storedLog();
+    // The row keeps the partition; the arm only survives in the metadata.
+    expect(log.cluster_id).toBe('cluster-1');
+    expect(log.metadata).toEqual({
+      served_configuration: { id: 'arm-1', name: '7' },
+    });
   });
 
   it('leaves the metadata empty when the caller named the skill', async () => {

--- a/packages/api/src/middlewares/logs.ts
+++ b/packages/api/src/middlewares/logs.ts
@@ -25,6 +25,7 @@ import {
   type SuperAgentsConfig,
 } from '@shared/types/api/request/headers';
 import type {
+  ServedConfiguration,
   SkillOptimizationArm,
   SkillOptimizationEvaluationResult,
 } from '@shared/types/data';
@@ -453,8 +454,22 @@ async function processLogs({
     status: status,
     method: method,
     model: (aiProviderLog.request_body.model as string | undefined) || '',
-    // How the skill was chosen, when the caller named only the agent.
-    metadata: skillRouting ? { skill_routing: skillRouting } : {},
+    metadata: {
+      // How the skill was chosen, when the caller named only the agent.
+      ...(skillRouting ? { skill_routing: skillRouting } : {}),
+      // Which of the partition's configurations served the request. The row
+      // keeps `cluster_id`, which names the partition but not the arm, and
+      // the prompt that reached the provider is the arm's template rendered,
+      // so it cannot be matched back to one afterwards.
+      ...(pulledArm
+        ? {
+            served_configuration: {
+              id: pulledArm.id,
+              name: pulledArm.name,
+            } satisfies ServedConfiguration,
+          }
+        : {}),
+    },
     hook_logs: hookLogs,
     function_name: functionName,
     ai_provider_request_log: aiProviderLog,

--- a/packages/shared/src/types/data/log.ts
+++ b/packages/shared/src/types/data/log.ts
@@ -161,6 +161,8 @@ export const LogsQueryParams = z.object({
   agent_id: z.uuid().optional(),
   skill_id: z.uuid().optional(),
   cluster_id: z.uuid().optional(),
+  /** Matched against `metadata.served_configuration`, since the row keeps
+   * the partition an arm belongs to but not the arm itself. */
   arm_id: z.uuid().optional(),
   app_id: z.uuid().optional(),
   /** The trace -- for a client that names its session, the session. */

--- a/packages/shared/src/types/data/skill-optimization-arm.ts
+++ b/packages/shared/src/types/data/skill-optimization-arm.ts
@@ -107,3 +107,19 @@ export const SkillOptimizationArmUpdateParams = z
 export type SkillOptimizationArmUpdateParams = z.infer<
   typeof SkillOptimizationArmUpdateParams
 >;
+
+/**
+ * The configuration whose system prompt and parameters served a request,
+ * recorded on the log as `metadata.served_configuration`: the log row keeps
+ * the partition it belongs to, but not which of that partition's
+ * configurations was pulled.
+ *
+ * The name is stored beside the id so a log reads without loading the arms
+ * it was written against, and so it still names the configuration if that
+ * arm is later deleted with its partition.
+ */
+export const ServedConfiguration = z.object({
+  id: z.uuid(),
+  name: z.string(),
+});
+export type ServedConfiguration = z.infer<typeof ServedConfiguration>;

--- a/packages/web/src/components/agents/skills/logs/chat-completions-api-viewer.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/chat-completions-api-viewer.test.tsx
@@ -16,12 +16,14 @@ vi.mock('next-themes', () => ({
 interface GenericViewerProps {
   children: React.ReactNode;
   defaultValue: string;
+  variant?: string;
 }
 
-// Mock GenericViewer component
+// Mock GenericViewer component. `variant` is surfaced because it is what
+// gives the agent's own answer its background.
 vi.mock('@web/components/agents/skills/logs/components/generic-viewer', () => ({
-  GenericViewer: ({ children, defaultValue }: GenericViewerProps) => (
-    <div data-testid="generic-viewer">
+  GenericViewer: ({ children, defaultValue, variant }: GenericViewerProps) => (
+    <div data-testid="generic-viewer" data-variant={variant}>
       {children}
       <div data-testid="viewer-content">{defaultValue}</div>
     </div>
@@ -261,5 +263,56 @@ describe('ChatCompletionsAPIViewer - Tool Calls', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('calculate')).toBeInTheDocument();
     expect(screen.getByText('call_help')).toBeInTheDocument();
+  });
+
+  it("marks the answer and its tool calls as this turn's response", () => {
+    const requestBody: ChatCompletionRequestBody = {
+      model: 'gpt-4',
+      messages: [
+        { role: ChatCompletionMessageRole.USER, content: 'what is 1 + 1' },
+      ],
+    };
+    const responseBody: ChatCompletionResponseBody = {
+      id: 'chatcmpl-1',
+      object: 'chat.completion',
+      created: 1,
+      model: 'gpt-4',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: ChatCompletionMessageRole.ASSISTANT,
+            content: 'Two.',
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'calculate', arguments: '{}' },
+              },
+            ],
+          },
+          finish_reason: ChatCompletionFinishReason.TOOL_CALLS,
+        },
+      ],
+    };
+
+    const { container } = render(
+      <ChatCompletionsAPIViewer
+        logId="test-log"
+        saRequestBody={requestBody}
+        saResponseBody={responseBody}
+      />,
+    );
+
+    // What the agent said in this turn, told apart from the conversation
+    // that was sent to it by a background of its own.
+    expect(screen.getByTestId('generic-viewer')).toHaveAttribute(
+      'data-variant',
+      'response',
+    );
+    expect(
+      container.querySelector('[class*="bg-emerald"]'),
+      'the tool call the agent just made is part of its answer',
+    ).not.toBeNull();
   });
 });

--- a/packages/web/src/components/agents/skills/logs/components/completion-viewer/chat-completions-api.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/completion-viewer/chat-completions-api.tsx
@@ -6,12 +6,9 @@ import type {
 } from '@shared/types/api/routes/chat-completions-api';
 import { PrettyChatCompletionMessageRole } from '@shared/types/api/routes/shared/messages';
 import type { RawSchema } from '@shared/types/api/routes/shared/tools';
+import { FunctionCallCard } from '@web/components/agents/skills/logs/components/function-call-card';
 import { GenericViewer } from '@web/components/agents/skills/logs/components/generic-viewer';
-import { Badge } from '@web/components/ui/badge';
-import { Button } from '@web/components/ui/button';
-import { Separator } from '@web/components/ui/separator';
 import { isArray } from 'lodash';
-import { CopyIcon, Wrench } from 'lucide-react';
 
 export function ChatCompletionsAPIViewer({
   logId,
@@ -62,7 +59,7 @@ export function ChatCompletionsAPIViewer({
             //pass
           }}
           rawSchema={rawSchema as RawSchema}
-          className="border-green-500"
+          variant="response"
         >
           <div className="text-sm font-normal text-right">
             {PrettyChatCompletionMessageRole[message.role]}
@@ -70,55 +67,15 @@ export function ChatCompletionsAPIViewer({
         </GenericViewer>
       )}
       {hasToolCalls &&
-        message.tool_calls?.map((tc) => {
-          const args =
-            typeof tc.function.arguments === 'string'
-              ? tc.function.arguments
-              : JSON.stringify(tc.function.arguments, null, 2);
-
-          return (
-            <div
-              key={tc.id}
-              className="flex flex-col h-fit w-full gap-2 border rounded-lg overflow-hidden shrink-0 bg-card"
-            >
-              <div className="flex flex-col items-center border-b">
-                <div className="flex flex-row gap-2 w-full justify-between items-center h-10 px-2">
-                  <div className="text-sm font-normal">Assistant</div>
-                  <Separator orientation="vertical" />
-                  <div className="flex flex-row gap-2 w-full justify-between items-center">
-                    <div className="text-sm font-normal">Function Call</div>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={(): void => {
-                        navigator.clipboard.writeText(args);
-                      }}
-                    >
-                      <CopyIcon size={16} />
-                    </Button>
-                  </div>
-                </div>
-              </div>
-              <div className="p-4">
-                <div className="flex items-center gap-2 mb-3">
-                  <Wrench className="h-4 w-4 text-blue-600" />
-                  <Badge variant="secondary" className="font-mono text-xs">
-                    {tc.function.name}
-                  </Badge>
-                  <Badge variant="outline" className="font-mono text-xs">
-                    {tc.id}
-                  </Badge>
-                </div>
-                <div className="text-xs text-muted-foreground mb-2">
-                  Arguments:
-                </div>
-                <pre className="text-xs font-mono overflow-x-auto whitespace-pre-wrap">
-                  {args}
-                </pre>
-              </div>
-            </div>
-          );
-        })}
+        message.tool_calls?.map((tc) => (
+          <FunctionCallCard
+            key={tc.id}
+            name={tc.function.name}
+            callId={tc.id}
+            args={tc.function.arguments}
+            variant="response"
+          />
+        ))}
     </div>
   );
 }

--- a/packages/web/src/components/agents/skills/logs/components/completion-viewer/completion-viewer.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/completion-viewer/completion-viewer.test.tsx
@@ -1,0 +1,162 @@
+import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
+import { FunctionName } from '@shared/types/api/request/function-name';
+import type { ErrorResponseBody } from '@shared/types/api/response';
+import type { CompletionResponseBody } from '@shared/types/api/routes/completions-api';
+import type { LogResponseBodyError } from '@shared/types/data';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-themes', () => ({
+  useTheme: vi.fn(() => ({ resolvedTheme: 'light' })),
+}));
+
+interface GenericViewerProps {
+  children: React.ReactNode;
+  defaultValue: string;
+  variant?: string;
+}
+
+// `variant` is surfaced because it is what gives the agent's own answer its
+// background, whatever shape that answer arrived in.
+vi.mock('@web/components/agents/skills/logs/components/generic-viewer', () => ({
+  GenericViewer: ({ children, defaultValue, variant }: GenericViewerProps) => (
+    <div data-testid="generic-viewer" data-variant={variant}>
+      {children}
+      <div data-testid="viewer-content">{defaultValue}</div>
+    </div>
+  ),
+}));
+
+import { CompletionViewer } from '@web/components/agents/skills/logs/components/completion-viewer/completion-viewer';
+import { CompletionsAPIViewer } from '@web/components/agents/skills/logs/components/completion-viewer/completions-api';
+import { ErrorResponseViewer } from '@web/components/agents/skills/logs/components/completion-viewer/error-response-viewer';
+import { LogResponseBodyErrorViewer } from '@web/components/agents/skills/logs/components/completion-viewer/log-response-body-error';
+
+const asRequestData = (
+  functionName: FunctionName,
+  responseBody: unknown,
+): SuperAgentsRequestData =>
+  ({
+    functionName,
+    requestBody: { model: 'gpt-4' },
+    responseBody,
+  }) as unknown as SuperAgentsRequestData;
+
+describe('CompletionsAPIViewer', () => {
+  it('marks a text completion as the response', () => {
+    render(
+      <CompletionsAPIViewer
+        logId="test-log"
+        saResponseBody={
+          { choices: [{ text: 'Two.' }] } as CompletionResponseBody
+        }
+      />,
+    );
+
+    expect(screen.getByTestId('viewer-content')).toHaveTextContent('Two.');
+    expect(screen.getByTestId('generic-viewer')).toHaveAttribute(
+      'data-variant',
+      'response',
+    );
+  });
+});
+
+describe('ErrorResponseViewer', () => {
+  it('marks what came back instead of an answer as the response', () => {
+    render(
+      <ErrorResponseViewer
+        logId="test-log"
+        response={{ error: { message: 'rate limited' } } as ErrorResponseBody}
+      />,
+    );
+
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByTestId('viewer-content')).toHaveTextContent(
+      'rate limited',
+    );
+    expect(screen.getByTestId('generic-viewer')).toHaveAttribute(
+      'data-variant',
+      'response',
+    );
+  });
+});
+
+describe('LogResponseBodyErrorViewer', () => {
+  it('shows the recorded failure and the body it came with', () => {
+    render(
+      <LogResponseBodyErrorViewer
+        logId="test-log"
+        response={
+          {
+            message: 'the provider refused',
+            response: '{"error":"nope"}',
+          } as LogResponseBodyError
+        }
+      />,
+    );
+
+    expect(screen.getByTestId('viewer-content')).toHaveTextContent(
+      'the provider refused',
+    );
+    expect(screen.getByTestId('viewer-content')).toHaveTextContent(
+      '{"error":"nope"}',
+    );
+    expect(screen.getByTestId('generic-viewer')).toHaveAttribute(
+      'data-variant',
+      'response',
+    );
+  });
+});
+
+describe('CompletionViewer', () => {
+  it('says so when the request never got an answer', () => {
+    render(
+      <CompletionViewer
+        logId="test-log"
+        saRequestData={asRequestData(FunctionName.CHAT_COMPLETE, null)}
+      />,
+    );
+
+    expect(screen.getByText('No response body found.')).toBeInTheDocument();
+  });
+
+  it('reads a text completion through its own viewer', () => {
+    render(
+      <CompletionViewer
+        logId="test-log"
+        saRequestData={asRequestData(FunctionName.COMPLETE, {
+          choices: [{ text: 'Two.' }],
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId('viewer-content')).toHaveTextContent('Two.');
+  });
+
+  it('shows a generated image rather than a body', () => {
+    render(
+      <CompletionViewer
+        logId="test-log"
+        saRequestData={asRequestData(FunctionName.GENERATE_IMAGE, {
+          data: [{ url: 'https://example.test/cat.png' }],
+        })}
+      />,
+    );
+
+    expect(screen.getByAltText('Generated content')).toHaveAttribute(
+      'src',
+      'https://example.test/cat.png',
+    );
+  });
+
+  it('falls back for a function with no exchange to render', () => {
+    render(
+      <CompletionViewer
+        logId="test-log"
+        saRequestData={asRequestData(FunctionName.MODERATE, { results: [] })}
+      />,
+    );
+
+    expect(screen.getByText('Moderation')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/agents/skills/logs/components/completion-viewer/completions-api.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/completion-viewer/completions-api.tsx
@@ -27,7 +27,7 @@ export function CompletionsAPIViewer({
         onSelect={(): void => {
           //pass
         }}
-        className="border-green-500"
+        variant="response"
       >
         <div className="text-sm font-normal text-right">
           {PrettyChatCompletionMessageRole[ChatCompletionMessageRole.ASSISTANT]}

--- a/packages/web/src/components/agents/skills/logs/components/completion-viewer/error-response-viewer.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/completion-viewer/error-response-viewer.tsx
@@ -23,7 +23,7 @@ export function ErrorResponseViewer({
         onSelect={(): void => {
           //pass
         }}
-        className="border-green-500"
+        variant="response"
       >
         <div className="text-sm font-normal text-right">Error</div>
       </GenericViewer>

--- a/packages/web/src/components/agents/skills/logs/components/completion-viewer/log-response-body-error.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/completion-viewer/log-response-body-error.tsx
@@ -23,7 +23,7 @@ export function LogResponseBodyErrorViewer({
         onSelect={(): void => {
           //pass
         }}
-        className="border-green-500"
+        variant="response"
       >
         <div className="text-sm font-normal text-right">Error</div>
       </GenericViewer>

--- a/packages/web/src/components/agents/skills/logs/components/completion-viewer/responses-api.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/completion-viewer/responses-api.tsx
@@ -10,11 +10,8 @@ import {
   PrettyChatCompletionMessageRole,
 } from '@shared/types/api/routes/shared/messages';
 import type { RawSchema } from '@shared/types/api/routes/shared/tools';
+import { FunctionCallCard } from '@web/components/agents/skills/logs/components/function-call-card';
 import { GenericViewer } from '@web/components/agents/skills/logs/components/generic-viewer';
-import { Badge } from '@web/components/ui/badge';
-import { Button } from '@web/components/ui/button';
-import { Separator } from '@web/components/ui/separator';
-import { CopyIcon, Wrench } from 'lucide-react';
 import { useMemo } from 'react';
 
 export function ResponsesAPIViewer({
@@ -96,7 +93,7 @@ export function ResponsesAPIViewer({
             //pass
           }}
           rawSchema={rawSchema as RawSchema | undefined}
-          className="border-green-500"
+          variant="response"
         >
           <div className="text-sm font-normal">
             {
@@ -112,55 +109,15 @@ export function ResponsesAPIViewer({
           </div>
         </GenericViewer>
       )}
-      {functionCalls.map((fc) => {
-        const args =
-          typeof fc.arguments === 'string'
-            ? fc.arguments
-            : JSON.stringify(fc.arguments, null, 2);
-
-        return (
-          <div
-            key={fc.call_id}
-            className="flex flex-col h-fit w-full gap-2 border rounded-lg overflow-hidden shrink-0 bg-card"
-          >
-            <div className="flex flex-col items-center border-b">
-              <div className="flex flex-row gap-2 w-full justify-between items-center h-10 px-2">
-                <div className="text-sm font-normal">Assistant</div>
-                <Separator orientation="vertical" />
-                <div className="flex flex-row gap-2 w-full justify-between items-center">
-                  <div className="text-sm font-normal">Function Call</div>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={(): void => {
-                      navigator.clipboard.writeText(args);
-                    }}
-                  >
-                    <CopyIcon size={16} />
-                  </Button>
-                </div>
-              </div>
-            </div>
-            <div className="p-4">
-              <div className="flex items-center gap-2 mb-3">
-                <Wrench className="h-4 w-4 text-blue-600" />
-                <Badge variant="secondary" className="font-mono text-xs">
-                  {fc.name}
-                </Badge>
-                <Badge variant="outline" className="font-mono text-xs">
-                  {fc.call_id}
-                </Badge>
-              </div>
-              <div className="text-xs text-muted-foreground mb-2">
-                Arguments:
-              </div>
-              <pre className="text-xs font-mono overflow-x-auto whitespace-pre-wrap">
-                {args}
-              </pre>
-            </div>
-          </div>
-        );
-      })}
+      {functionCalls.map((fc) => (
+        <FunctionCallCard
+          key={fc.call_id}
+          name={fc.name}
+          callId={fc.call_id}
+          args={fc.arguments}
+          variant="response"
+        />
+      ))}
     </div>
   );
 }

--- a/packages/web/src/components/agents/skills/logs/components/function-call-card.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/function-call-card.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FunctionCallCard } from '@web/components/agents/skills/logs/components/function-call-card';
+import { describe, expect, it } from 'vitest';
+
+describe('FunctionCallCard', () => {
+  it('names the call, its id and the arguments as sent', () => {
+    render(
+      <FunctionCallCard
+        name="get_weather"
+        callId="call_123"
+        args='{"location": "San Francisco"}'
+      />,
+    );
+
+    expect(screen.getByText('Assistant')).toBeInTheDocument();
+    expect(screen.getByText('Function Call')).toBeInTheDocument();
+    expect(screen.getByText('get_weather')).toBeInTheDocument();
+    expect(screen.getByText('call_123')).toBeInTheDocument();
+    expect(
+      screen.getByText((content) => content.includes('San Francisco')),
+    ).toBeInTheDocument();
+  });
+
+  it('formats arguments that arrived as an object', () => {
+    render(
+      <FunctionCallCard
+        name="get_weather"
+        callId="call_123"
+        args={{ location: 'San Francisco' }}
+      />,
+    );
+
+    expect(
+      screen.getByText((content) =>
+        content.includes('"location": "San Francisco"'),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('collapses to the call it made', () => {
+    render(<FunctionCallCard name="get_weather" callId="call_123" args="{}" />);
+
+    fireEvent.click(screen.getByRole('button', { expanded: true }));
+
+    expect(screen.queryByText('call_123')).not.toBeInTheDocument();
+    expect(
+      screen.getByText((content) => content.startsWith('get_weather')),
+    ).toBeInTheDocument();
+  });
+
+  it('tints a call the agent has just made', () => {
+    const { container, rerender } = render(
+      <FunctionCallCard name="get_weather" callId="call_1" args="{}" />,
+    );
+    // Replayed from an earlier turn: part of the request, not this answer.
+    expect(container.firstElementChild?.className).not.toContain('emerald');
+
+    rerender(
+      <FunctionCallCard
+        name="get_weather"
+        callId="call_1"
+        args="{}"
+        variant="response"
+      />,
+    );
+
+    expect(container.firstElementChild?.className).toContain('bg-emerald');
+  });
+});

--- a/packages/web/src/components/agents/skills/logs/components/function-call-card.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/function-call-card.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import {
+  MessageCard,
+  previewOf,
+} from '@web/components/agents/skills/logs/components/message-card';
+import { Badge } from '@web/components/ui/badge';
+import { Wrench } from 'lucide-react';
+
+/**
+ * A tool call, whether it is one the agent just made -- `variant="response"`
+ * -- or one replayed from an earlier turn of the conversation.
+ */
+export function FunctionCallCard({
+  name,
+  callId,
+  args,
+  variant = 'default',
+}: {
+  name: string;
+  callId: string;
+  args: unknown;
+  variant?: 'default' | 'response';
+}): React.ReactElement {
+  const formattedArgs =
+    typeof args === 'string' ? args : JSON.stringify(args, null, 2);
+
+  return (
+    <MessageCard
+      label={<div className="text-sm font-normal">Assistant</div>}
+      kind="Function Call"
+      copyValue={formattedArgs}
+      variant={variant}
+      preview={`${name} ${previewOf(formattedArgs)}`}
+    >
+      <div className="p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Wrench className="h-4 w-4 text-blue-600" />
+          <Badge variant="secondary" className="font-mono text-xs">
+            {name}
+          </Badge>
+          <Badge variant="outline" className="font-mono text-xs">
+            {callId}
+          </Badge>
+        </div>
+        <div className="text-xs text-muted-foreground mb-2">Arguments:</div>
+        <pre className="text-xs font-mono overflow-x-auto whitespace-pre-wrap">
+          {formattedArgs}
+        </pre>
+      </div>
+    </MessageCard>
+  );
+}

--- a/packages/web/src/components/agents/skills/logs/components/generic-viewer.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/generic-viewer.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-themes', () => ({
+  useTheme: vi.fn(() => ({ resolvedTheme: 'light' })),
+}));
+
+// The editors are lazy, heavy, and not what these tests are about: what
+// matters is which one a language picks and what value it is handed.
+vi.mock(
+  '@web/components/agents/skills/logs/components/text-viewer.lazy',
+  () => ({
+    LazyTextViewer: ({ content }: { content: string }) => (
+      <div data-testid="text-viewer">{content}</div>
+    ),
+  }),
+);
+vi.mock('@web/components/monaco-editor', () => ({
+  MonacoEditor: ({ value }: { value: string }) => (
+    <div data-testid="monaco">{value}</div>
+  ),
+}));
+
+import { GenericViewer } from '@web/components/agents/skills/logs/components/generic-viewer';
+
+const viewer = (
+  props: Partial<React.ComponentProps<typeof GenericViewer>> = {},
+) => (
+  <GenericViewer
+    path="log-1-system"
+    language="text"
+    defaultValue="You are a concierge."
+    readOnly={true}
+    {...props}
+  >
+    <div>System</div>
+  </GenericViewer>
+);
+
+describe('GenericViewer', () => {
+  it('reads text through the text viewer', () => {
+    render(viewer());
+
+    expect(screen.getByText('System')).toBeInTheDocument();
+    expect(screen.getByText('Text')).toBeInTheDocument();
+    expect(screen.getByTestId('text-viewer')).toHaveTextContent(
+      'You are a concierge.',
+    );
+  });
+
+  it('reads a structured answer through the editor', () => {
+    render(viewer({ language: 'json', defaultValue: '{"score":0.9}' }));
+
+    expect(screen.getByText('JSON')).toBeInTheDocument();
+    expect(screen.getByTestId('monaco')).toHaveTextContent('{"score":0.9}');
+    expect(screen.queryByTestId('text-viewer')).not.toBeInTheDocument();
+  });
+
+  it('collapses to a preview of the prompt', () => {
+    render(viewer());
+
+    fireEvent.click(screen.getByRole('button', { expanded: true }));
+
+    expect(screen.queryByTestId('text-viewer')).not.toBeInTheDocument();
+    // The role label stays, so a collapsed card is still identifiable.
+    expect(screen.getByText('System')).toBeInTheDocument();
+    expect(screen.getByText('You are a concierge.')).toBeInTheDocument();
+  });
+
+  it('starts collapsed when asked, as the original system prompt does', () => {
+    render(viewer({ defaultCollapsed: true }));
+
+    expect(screen.queryByTestId('text-viewer')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+
+    expect(screen.getByTestId('text-viewer')).toBeInTheDocument();
+  });
+
+  it("tints the agent's answer", () => {
+    const { container, rerender } = render(viewer());
+    expect(container.firstElementChild?.className).not.toContain('emerald');
+
+    rerender(viewer({ variant: 'response' }));
+
+    expect(container.firstElementChild?.className).toContain('bg-emerald');
+  });
+
+  it('copies what is on screen', () => {
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(viewer());
+    const [, copy] = screen.getAllByRole('button');
+    fireEvent.click(copy);
+
+    expect(writeText).toHaveBeenCalledWith('You are a concierge.');
+  });
+
+  it('reports a schema it could not compile, and hides it when collapsed', () => {
+    render(
+      viewer({
+        language: 'json',
+        defaultValue: '{}',
+        rawSchema: { type: 'not-a-type' } as never,
+      }),
+    );
+
+    const complaint = screen.getByText(/^schema is invalid: /);
+    expect(complaint).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { expanded: true }));
+
+    expect(complaint).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/agents/skills/logs/components/generic-viewer.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/generic-viewer.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import type { RawSchema } from '@shared/types/api/routes/shared/tools';
+import {
+  MessageCard,
+  previewOf,
+} from '@web/components/agents/skills/logs/components/message-card';
 import { LazyTextViewer } from '@web/components/agents/skills/logs/components/text-viewer.lazy';
 import { MonacoEditor } from '@web/components/monaco-editor';
 import { Button } from '@web/components/ui/button';
-import { Separator } from '@web/components/ui/separator';
 import { cn } from '@web/utils/ui/utils';
 import Ajv, { type ValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
-import { AlertTriangleIcon, CopyIcon, SaveIcon } from 'lucide-react';
+import { AlertTriangleIcon, SaveIcon } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { type ReactNode, useEffect, useState } from 'react';
 
@@ -29,6 +32,9 @@ export interface DataCardProps {
   onSelect?: (selectedText: string) => void;
   wordWrap?: boolean;
   className?: string;
+  /** `response` tints the card as the agent's own answer to this turn. */
+  variant?: 'default' | 'response';
+  defaultCollapsed?: boolean;
 }
 export function GenericViewer({
   path,
@@ -41,6 +47,8 @@ export function GenericViewer({
   onSelect,
   wordWrap = true,
   className,
+  variant,
+  defaultCollapsed,
 }: DataCardProps): React.ReactElement {
   const { resolvedTheme } = useTheme();
   const [isValid, setIsValid] = useState(true);
@@ -135,38 +143,23 @@ export function GenericViewer({
   }
 
   return (
-    <div
-      className={cn(
-        'flex flex-col h-fit w-full gap-2 border rounded-lg overflow-hidden shrink-0 bg-card',
-        className,
-      )}
-    >
-      <div className="flex flex-col items-center border-b">
-        <div className="flex flex-row gap-2 w-full justify-between items-center h-10 px-2">
-          {children}
-          <Separator orientation="vertical" />
-          <div className="flex flex-row gap-2 w-full justify-between items-center">
-            <div className="text-sm font-normal">
-              {PrettyLanguage[language] || language}
-            </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={(): void => {
-                navigator.clipboard.writeText(value);
-              }}
-            >
-              <CopyIcon size={16} />
-            </Button>
-          </div>
-        </div>
-        {schemaError && (
+    <MessageCard
+      label={children}
+      kind={PrettyLanguage[language] || language}
+      copyValue={value}
+      variant={variant}
+      defaultCollapsed={defaultCollapsed}
+      preview={previewOf(value)}
+      className={className}
+      headerExtra={
+        schemaError && (
           <div className="w-full text-orange-500 text-xs text-left flex flex-row items-center gap-2">
             <AlertTriangleIcon size={16} />
             {schemaError}
           </div>
-        )}
-      </div>
+        )
+      }
+    >
       {language === 'text' ? (
         <LazyTextViewer
           readOnly={readOnly}
@@ -203,6 +196,6 @@ export function GenericViewer({
           )}
         </div>
       )}
-    </div>
+    </MessageCard>
   );
 }

--- a/packages/web/src/components/agents/skills/logs/components/message-card.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/message-card.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  MessageCard,
+  previewOf,
+} from '@web/components/agents/skills/logs/components/message-card';
+import { describe, expect, it, vi } from 'vitest';
+
+const body = <div>the body</div>;
+
+describe('previewOf', () => {
+  it('collapses a multi-line body onto one line', () => {
+    expect(previewOf('You are a\n\n  helpful   assistant.\n')).toBe(
+      'You are a helpful assistant.',
+    );
+  });
+
+  it('cuts a prompt far too long to stand in a header', () => {
+    expect(previewOf('x'.repeat(5000))).toHaveLength(200);
+  });
+});
+
+describe('MessageCard', () => {
+  it('shows the label, the kind and the body', () => {
+    render(
+      <MessageCard label={<span>System</span>} kind="Text">
+        {body}
+      </MessageCard>,
+    );
+
+    expect(screen.getByText('System')).toBeInTheDocument();
+    expect(screen.getByText('Text')).toBeInTheDocument();
+    expect(screen.getByText('the body')).toBeInTheDocument();
+  });
+
+  it('collapses the body away, leaving a preview of it', () => {
+    render(
+      <MessageCard label={<span>System</span>} preview="You are a concierge.">
+        {body}
+      </MessageCard>,
+    );
+
+    // Expanded, the preview would only repeat what is already on screen.
+    expect(screen.queryByText('You are a concierge.')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { expanded: true }));
+
+    expect(screen.queryByText('the body')).not.toBeInTheDocument();
+    expect(screen.getByText('You are a concierge.')).toBeInTheDocument();
+  });
+
+  it('opens a card that started collapsed', () => {
+    render(
+      <MessageCard label={<span>Original system prompt</span>} defaultCollapsed>
+        {body}
+      </MessageCard>,
+    );
+
+    expect(screen.queryByText('the body')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+
+    expect(screen.getByText('the body')).toBeInTheDocument();
+  });
+
+  it('copies the body without collapsing the card', () => {
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <MessageCard label={<span>System</span>} copyValue="the whole prompt">
+        {body}
+      </MessageCard>,
+    );
+
+    // The copy button is the one that is not the collapse toggle.
+    const [, copy] = screen.getAllByRole('button');
+    fireEvent.click(copy);
+
+    expect(writeText).toHaveBeenCalledWith('the whole prompt');
+    expect(screen.getByText('the body')).toBeInTheDocument();
+  });
+
+  it('offers no copy button when there is nothing to copy', () => {
+    render(<MessageCard label={<span>System</span>}>{body}</MessageCard>);
+
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  it("tints the agent's own answer apart from the messages sent to it", () => {
+    const { container, rerender } = render(
+      <MessageCard label={<span>Assistant</span>}>{body}</MessageCard>,
+    );
+    const plain = container.firstElementChild;
+    expect(plain).toHaveClass('bg-card');
+    expect(plain?.className).not.toContain('emerald');
+
+    rerender(
+      <MessageCard label={<span>Assistant</span>} variant="response">
+        {body}
+      </MessageCard>,
+    );
+
+    expect(container.firstElementChild?.className).toContain('bg-emerald');
+  });
+
+  it('keeps the header extra with the header, and hides it when collapsed', () => {
+    render(
+      <MessageCard
+        label={<span>Assistant</span>}
+        headerExtra={<span>schema is not valid</span>}
+      >
+        {body}
+      </MessageCard>,
+    );
+    expect(screen.getByText('schema is not valid')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { expanded: true }));
+
+    expect(screen.queryByText('schema is not valid')).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/agents/skills/logs/components/message-card.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/message-card.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { Button } from '@web/components/ui/button';
+import { Separator } from '@web/components/ui/separator';
+import { cn } from '@web/utils/ui/utils';
+import { ChevronDown, ChevronRight, CopyIcon } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
+
+/** How much of the body the header shows in place of it while collapsed. */
+const PREVIEW_LENGTH = 200;
+
+/** A one-line stand-in for a body that may be thousands of characters long. */
+export function previewOf(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().slice(0, PREVIEW_LENGTH);
+}
+
+export interface MessageCardProps {
+  /** Left-hand header label: who the turn belongs to. */
+  label?: ReactNode;
+  /** Right-hand header label: what the body is -- `Text`, `Function Call`. */
+  kind?: ReactNode;
+  /** Copied verbatim by the header button; without it there is no button. */
+  copyValue?: string;
+  /**
+   * `response` tints the card, which is how the agent's own answer is told
+   * apart from the messages that were sent to it.
+   */
+  variant?: 'default' | 'response';
+  defaultCollapsed?: boolean;
+  /** Shown in the header in place of the body while collapsed. */
+  preview?: string;
+  /** Rendered under the header row, inside the header's border. */
+  headerExtra?: ReactNode;
+  className?: string;
+  children?: ReactNode;
+}
+
+/**
+ * The shell every message in the log view shares: a header naming the turn,
+ * and a body that collapses away, since a system prompt is otherwise several
+ * screens of scrolling between the reader and the conversation.
+ */
+export function MessageCard({
+  label,
+  kind,
+  copyValue,
+  variant = 'default',
+  defaultCollapsed = false,
+  preview,
+  headerExtra,
+  className,
+  children,
+}: MessageCardProps): React.ReactElement {
+  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+  const isResponse = variant === 'response';
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col h-fit w-full gap-2 border rounded-lg overflow-hidden shrink-0 bg-card',
+        isResponse &&
+          'border-emerald-500/50 bg-emerald-500/5 dark:bg-emerald-400/10',
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          'flex flex-col items-center border-b',
+          isResponse &&
+            'border-emerald-500/30 bg-emerald-500/10 dark:bg-emerald-400/10',
+          isCollapsed && 'border-b-0',
+        )}
+      >
+        <div className="flex flex-row gap-2 w-full justify-between items-center h-10 px-2">
+          <button
+            type="button"
+            aria-expanded={!isCollapsed}
+            onClick={(): void => setIsCollapsed((collapsed) => !collapsed)}
+            className="flex flex-row gap-2 flex-1 min-w-0 items-center h-full text-left cursor-pointer"
+          >
+            {isCollapsed ? (
+              <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+            )}
+            {label}
+            {kind && (
+              <>
+                <Separator orientation="vertical" />
+                <div className="text-sm font-normal shrink-0">{kind}</div>
+              </>
+            )}
+            {isCollapsed && preview && (
+              <span className="text-xs text-muted-foreground truncate">
+                {preview}
+              </span>
+            )}
+          </button>
+          {copyValue !== undefined && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={(): void => {
+                navigator.clipboard.writeText(copyValue);
+              }}
+            >
+              <CopyIcon size={16} />
+            </Button>
+          )}
+        </div>
+        {!isCollapsed && headerExtra}
+      </div>
+      {!isCollapsed && children}
+    </div>
+  );
+}

--- a/packages/web/src/components/agents/skills/logs/components/messages-view.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/messages-view.tsx
@@ -9,14 +9,18 @@ import type {
 import {
   type ChatCompletionMessage,
   ChatCompletionMessageRole,
+  ChatCompletionSystemMessageRoles,
   PrettyChatCompletionMessageRole,
 } from '@shared/types/api/routes/shared/messages';
+import { FunctionCallCard } from '@web/components/agents/skills/logs/components/function-call-card';
 import { GenericViewer } from '@web/components/agents/skills/logs/components/generic-viewer';
+import {
+  MessageCard,
+  previewOf,
+} from '@web/components/agents/skills/logs/components/message-card';
 import { Badge } from '@web/components/ui/badge';
-import { Button } from '@web/components/ui/button';
-import { Separator } from '@web/components/ui/separator';
-import { Code, CopyIcon, Wrench } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { Code } from 'lucide-react';
+import { type ReactNode, useEffect, useState } from 'react';
 
 function getMessageValue(
   input: string | string[] | number[] | number[][],
@@ -35,9 +39,12 @@ function getMessageValue(
 export function MessagesView({
   logId,
   saRequestData,
+  systemPromptBadge,
 }: {
   logId: string;
   saRequestData: SuperAgentsRequestData;
+  /** Says where the system prompt came from, beside its role label. */
+  systemPromptBadge?: ReactNode;
 }): React.ReactElement {
   const [messages, setMessages] = useState<ChatCompletionMessage[]>([]);
 
@@ -144,6 +151,16 @@ export function MessagesView({
       {messages.map((message, index) => {
         const key = `${logId}-${message.role}-${String(message.content).slice(0, 20)}-${index}`;
 
+        const roleLabel = (
+          <div className="flex flex-row items-center gap-2">
+            <div className="text-sm font-normal">
+              {PrettyChatCompletionMessageRole[message.role]}
+            </div>
+            {ChatCompletionSystemMessageRoles.includes(message.role) &&
+              systemPromptBadge}
+          </div>
+        );
+
         // Handle tool role messages specially
         if (
           message.role === ChatCompletionMessageRole.TOOL &&
@@ -155,28 +172,13 @@ export function MessagesView({
               : JSON.stringify(message.content, null, 2);
 
           return (
-            <div
+            <MessageCard
               key={key}
-              className="flex flex-col h-fit w-full gap-2 border rounded-lg overflow-hidden shrink-0 bg-card"
+              label={<div className="text-sm font-normal">Tool</div>}
+              kind="Response"
+              copyValue={toolContent}
+              preview={previewOf(toolContent)}
             >
-              <div className="flex flex-col items-center border-b">
-                <div className="flex flex-row gap-2 w-full justify-between items-center h-10 px-2">
-                  <div className="text-sm font-normal">Tool</div>
-                  <Separator orientation="vertical" />
-                  <div className="flex flex-row gap-2 w-full justify-between items-center">
-                    <div className="text-sm font-normal">Response</div>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={(): void => {
-                        navigator.clipboard.writeText(toolContent);
-                      }}
-                    >
-                      <CopyIcon size={16} />
-                    </Button>
-                  </div>
-                </div>
-              </div>
               <div className="p-4">
                 <div className="flex items-center gap-2 mb-3">
                   <Code className="h-4 w-4 text-green-600" />
@@ -188,7 +190,7 @@ export function MessagesView({
                   {toolContent}
                 </div>
               </div>
-            </div>
+            </MessageCard>
           );
         }
 
@@ -213,65 +215,17 @@ export function MessagesView({
                     //pass
                   }}
                 >
-                  <div className="text-sm font-normal">
-                    {PrettyChatCompletionMessageRole[message.role]}
-                  </div>
+                  {roleLabel}
                 </GenericViewer>
               )}
-              {message.tool_calls.map((tc) => {
-                const args =
-                  typeof tc.function.arguments === 'string'
-                    ? tc.function.arguments
-                    : JSON.stringify(tc.function.arguments, null, 2);
-
-                return (
-                  <div
-                    key={`${key}-tc-${tc.id}`}
-                    className="flex flex-col h-fit w-full gap-2 border rounded-lg overflow-hidden shrink-0 bg-card"
-                  >
-                    <div className="flex flex-col items-center border-b">
-                      <div className="flex flex-row gap-2 w-full justify-between items-center h-10 px-2">
-                        <div className="text-sm font-normal">Assistant</div>
-                        <Separator orientation="vertical" />
-                        <div className="flex flex-row gap-2 w-full justify-between items-center">
-                          <div className="text-sm font-normal">
-                            Function Call
-                          </div>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={(): void => {
-                              navigator.clipboard.writeText(args);
-                            }}
-                          >
-                            <CopyIcon size={16} />
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                    <div className="p-4">
-                      <div className="flex items-center gap-2 mb-3">
-                        <Wrench className="h-4 w-4 text-blue-600" />
-                        <Badge
-                          variant="secondary"
-                          className="font-mono text-xs"
-                        >
-                          {tc.function.name}
-                        </Badge>
-                        <Badge variant="outline" className="font-mono text-xs">
-                          {tc.id}
-                        </Badge>
-                      </div>
-                      <div className="text-xs text-muted-foreground mb-2">
-                        Arguments:
-                      </div>
-                      <pre className="text-xs font-mono overflow-x-auto whitespace-pre-wrap">
-                        {args}
-                      </pre>
-                    </div>
-                  </div>
-                );
-              })}
+              {message.tool_calls.map((tc) => (
+                <FunctionCallCard
+                  key={`${key}-tc-${tc.id}`}
+                  name={tc.function.name}
+                  callId={tc.id}
+                  args={tc.function.arguments}
+                />
+              ))}
             </div>
           );
         }
@@ -291,9 +245,7 @@ export function MessagesView({
               //pass
             }}
           >
-            <div className="text-sm font-normal">
-              {PrettyChatCompletionMessageRole[message.role]}
-            </div>
+            {roleLabel}
           </GenericViewer>
         );
       })}

--- a/packages/web/src/components/agents/skills/logs/log-details-view.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-details-view.tsx
@@ -19,6 +19,7 @@ import { PageHeader } from '@web/components/ui/page-header';
 import { Separator } from '@web/components/ui/separator';
 import { Skeleton } from '@web/components/ui/skeleton';
 import { useLogSession } from '@web/hooks/use-log-session';
+import { usePinnedToBottom } from '@web/hooks/use-pinned-to-bottom';
 import { useSmartBack } from '@web/hooks/use-smart-back';
 import { useAgents } from '@web/providers/agents';
 import { useLogs } from '@web/providers/logs';
@@ -31,6 +32,10 @@ import {
   describeSkillRouting,
   readSkillRouting,
 } from '@web/utils/skill-routing';
+import {
+  describeSystemPromptOrigin,
+  readServedConfiguration,
+} from '@web/utils/system-prompt-origin';
 import { formatLogTimestamp } from '@web/utils/time';
 import {
   AlertTriangle,
@@ -129,6 +134,10 @@ export function LogDetailsView(): ReactElement {
     }
   }, [logSkillId, setSkillId, setClustersSkillId, setEvalSkillId]);
 
+  // A log opens on the agent's answer rather than on the top of a system
+  // prompt that is several screens long.
+  const conversation = usePinnedToBottom(selectedLog?.id);
+
   // Set log ID for evaluation runs provider
   useEffect(() => {
     if (selectedLog) {
@@ -226,6 +235,18 @@ export function LogDetailsView(): ReactElement {
     if (!original || !saRequestData) return null;
     return original === extractSystemPrompt(saRequestData) ? null : original;
   }, [selectedLog?.original_system_prompt, saRequestData]);
+
+  // Where the prompt that reached the provider came from: the configuration
+  // the optimizer pulled, or the client, when the skill substituted nothing.
+  const systemPromptOrigin = useMemo(() => {
+    if (!selectedLog) return null;
+    return describeSystemPromptOrigin({
+      partition: clusterName,
+      configuration: readServedConfiguration(selectedLog.metadata),
+      clientPrompt: selectedLog.original_system_prompt,
+      sentPrompt: saRequestData ? extractSystemPrompt(saRequestData) : null,
+    });
+  }, [selectedLog, clusterName, saRequestData]);
 
   // Use the weighted average score from the database view (logs_with_eval_scores)
   // This ensures consistency with the list view and handles orphaned evaluation runs correctly
@@ -405,7 +426,7 @@ export function LogDetailsView(): ReactElement {
               {clusterName && (
                 <>
                   <HeaderSeparator />
-                  <HeaderItem label="Cluster:">
+                  <HeaderItem label="Partition:">
                     <Badge
                       variant="outline"
                       className={`${HEADER_BADGE} font-mono`}
@@ -614,51 +635,71 @@ export function LogDetailsView(): ReactElement {
                 onSelect={openLog}
               />
             )}
-            <div className="inset-0 flex flex-col flex-1 w-full min-w-0 p-4 gap-4 overflow-hidden overflow-y-auto">
-              {selectedLog && originalSystemPrompt && (
-                <GenericViewer
-                  path={`${selectedLog.id}-original-system-prompt`}
-                  language={'text'}
-                  defaultValue={originalSystemPrompt}
-                  readOnly={true}
-                  onSave={async (): Promise<void> => {
-                    //pass
-                  }}
-                  onSelect={(): void => {
-                    //pass
-                  }}
-                >
-                  <div className="flex flex-row items-center gap-2">
-                    <div className="text-sm font-normal">
-                      Original system prompt
+            <div
+              ref={conversation.ref}
+              className="inset-0 flex flex-1 w-full min-w-0 p-4 overflow-hidden overflow-y-auto"
+            >
+              <div
+                ref={conversation.contentRef}
+                className="flex flex-col w-full min-w-0 gap-4 h-fit"
+              >
+                {selectedLog && originalSystemPrompt && (
+                  <GenericViewer
+                    path={`${selectedLog.id}-original-system-prompt`}
+                    language={'text'}
+                    defaultValue={originalSystemPrompt}
+                    readOnly={true}
+                    defaultCollapsed={true}
+                    onSave={async (): Promise<void> => {
+                      //pass
+                    }}
+                    onSelect={(): void => {
+                      //pass
+                    }}
+                  >
+                    <div className="flex flex-row items-center gap-2">
+                      <div className="text-sm font-normal">
+                        Original system prompt
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className="text-xs text-muted-foreground"
+                      >
+                        as sent by the client
+                      </Badge>
                     </div>
-                    <Badge
-                      variant="outline"
-                      className="text-xs text-muted-foreground"
-                    >
-                      as sent by the client
-                    </Badge>
-                  </div>
-                </GenericViewer>
-              )}
-              {selectedLog && saRequestData && (
-                <MessagesView
-                  logId={selectedLog.id}
-                  saRequestData={saRequestData}
-                />
-              )}
-              {selectedLog &&
-                saRequestData &&
-                selectedLog.ai_provider_request_log?.response_body &&
-                ('choices' in
-                  selectedLog.ai_provider_request_log.response_body ||
-                  'output' in
-                    selectedLog.ai_provider_request_log.response_body) && (
-                  <CompletionViewer
+                  </GenericViewer>
+                )}
+                {selectedLog && saRequestData && (
+                  <MessagesView
                     logId={selectedLog.id}
                     saRequestData={saRequestData}
+                    systemPromptBadge={
+                      systemPromptOrigin && (
+                        <Badge
+                          variant="outline"
+                          className="text-xs text-muted-foreground"
+                          title={systemPromptOrigin.title}
+                        >
+                          {systemPromptOrigin.label}
+                        </Badge>
+                      )
+                    }
                   />
                 )}
+                {selectedLog &&
+                  saRequestData &&
+                  selectedLog.ai_provider_request_log?.response_body &&
+                  ('choices' in
+                    selectedLog.ai_provider_request_log.response_body ||
+                    'output' in
+                      selectedLog.ai_provider_request_log.response_body) && (
+                    <CompletionViewer
+                      logId={selectedLog.id}
+                      saRequestData={saRequestData}
+                    />
+                  )}
+              </div>
             </div>
           </CardContent>
         </Card>

--- a/packages/web/src/components/agents/skills/logs/messages-view.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/messages-view.test.tsx
@@ -456,4 +456,79 @@ describe('MessagesView - Responses API Conversion', () => {
       expect(screen.getByText('A beautiful sunset')).toBeInTheDocument();
     });
   });
+
+  describe('system prompt badge', () => {
+    const chatRequest = (
+      messages: { role: string; content: string }[],
+    ): SuperAgentsRequestData =>
+      ({
+        functionName: FunctionName.CHAT_COMPLETE,
+        requestBody: { model: 'gpt-4', messages },
+        responseSchema: z.object({}),
+        requestSchema: z.object({}),
+      }) as unknown as SuperAgentsRequestData;
+
+    it('says where the system prompt came from, beside its role', () => {
+      render(
+        <MessagesView
+          logId="test-log"
+          saRequestData={chatRequest([
+            { role: 'system', content: 'You are a concierge.' },
+            { role: 'user', content: 'book a table' },
+          ])}
+          systemPromptBadge={<span>partition 2 · configuration 7</span>}
+        />,
+      );
+
+      const badge = screen.getByText('partition 2 · configuration 7');
+      expect(badge).toBeInTheDocument();
+      // Beside `System`, not beside the user's turn.
+      expect(badge.parentElement).toHaveTextContent('System');
+    });
+
+    it('marks a developer message, which is a system prompt by another name', () => {
+      render(
+        <MessagesView
+          logId="test-log"
+          saRequestData={chatRequest([
+            { role: 'developer', content: 'You are a concierge.' },
+          ])}
+          systemPromptBadge={<span>as sent by the client</span>}
+        />,
+      );
+
+      expect(
+        screen.getByText('as sent by the client').parentElement,
+      ).toHaveTextContent('Developer');
+    });
+
+    it('leaves the other roles unmarked', () => {
+      render(
+        <MessagesView
+          logId="test-log"
+          saRequestData={chatRequest([
+            { role: 'user', content: 'book a table' },
+            { role: 'assistant', content: 'Done.' },
+          ])}
+          systemPromptBadge={<span>partition 2</span>}
+        />,
+      );
+
+      expect(screen.queryByText('partition 2')).not.toBeInTheDocument();
+    });
+
+    it('renders the messages unchanged when there is nothing to say', () => {
+      render(
+        <MessagesView
+          logId="test-log"
+          saRequestData={chatRequest([
+            { role: 'system', content: 'You are a concierge.' },
+          ])}
+        />,
+      );
+
+      expect(screen.getByText('System')).toBeInTheDocument();
+      expect(screen.getByText('You are a concierge.')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/web/src/components/agents/skills/logs/responses-api-viewer.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/responses-api-viewer.test.tsx
@@ -17,12 +17,14 @@ vi.mock('next-themes', () => ({
 interface GenericViewerProps {
   children: React.ReactNode;
   defaultValue: string;
+  variant?: string;
 }
 
-// Mock GenericViewer component
+// Mock GenericViewer component. `variant` is surfaced because it is what
+// gives the agent's own answer its background.
 vi.mock('@web/components/agents/skills/logs/components/generic-viewer', () => ({
-  GenericViewer: ({ children, defaultValue }: GenericViewerProps) => (
-    <div data-testid="generic-viewer">
+  GenericViewer: ({ children, defaultValue, variant }: GenericViewerProps) => (
+    <div data-testid="generic-viewer" data-variant={variant}>
       {children}
       <div data-testid="viewer-content">{defaultValue}</div>
     </div>
@@ -646,6 +648,48 @@ describe('ResponsesAPIViewer - Function Call Rendering', () => {
       expect(
         screen.getByText((content) => content.includes('nested')),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('the answer this turn produced', () => {
+    it('marks the message and its function calls as the response', () => {
+      const responseBody: Partial<ResponsesResponseBody> = {
+        id: 'resp_123',
+        object: 'response',
+        created_at: 1234567890,
+        model: 'gpt-4',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: ChatCompletionMessageRole.ASSISTANT,
+            content: [{ type: 'text', text: 'Two.', annotations: [] }],
+          },
+          {
+            type: 'function_call',
+            name: 'calculate',
+            call_id: 'call_1',
+            arguments: '{}',
+          } as ResponsesAPIFunctionCall,
+        ],
+      };
+
+      const { container } = render(
+        <ResponsesAPIViewer
+          logId="test-log"
+          saRequestBody={{ model: 'gpt-4' } as ResponsesRequestBody}
+          saResponseBody={responseBody as ResponsesResponseBody}
+        />,
+      );
+
+      expect(screen.getByTestId('generic-viewer')).toHaveAttribute(
+        'data-variant',
+        'response',
+      );
+      expect(
+        container.querySelector('[class*="bg-emerald"]'),
+        'the function call the agent just made is part of its answer',
+      ).not.toBeNull();
     });
   });
 });

--- a/packages/web/src/hooks/use-pinned-to-bottom.test.tsx
+++ b/packages/web/src/hooks/use-pinned-to-bottom.test.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { usePinnedToBottom } from '@web/hooks/use-pinned-to-bottom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * jsdom implements neither scrolling nor layout: `scrollHeight` is always 0
+ * and assigning `scrollTop` does nothing. Both are replaced on the prototype
+ * so a test can say how tall the content is and see where the pane was sent.
+ */
+let contentHeight = 0;
+let scrolledTo: number[] = [];
+let originalScrollTop: PropertyDescriptor | undefined;
+let originalScrollHeight: PropertyDescriptor | undefined;
+
+/** The ResizeObservers alive right now, so a test can grow the content. */
+let observers: ResizeObserverCallback[] = [];
+const OriginalResizeObserver = global.ResizeObserver;
+
+function grow(to: number): void {
+  contentHeight = to;
+  for (const observe of observers) {
+    observe([], {} as ResizeObserver);
+  }
+}
+
+beforeEach(() => {
+  contentHeight = 1000;
+  scrolledTo = [];
+  observers = [];
+
+  originalScrollTop = Object.getOwnPropertyDescriptor(
+    Element.prototype,
+    'scrollTop',
+  );
+  originalScrollHeight = Object.getOwnPropertyDescriptor(
+    Element.prototype,
+    'scrollHeight',
+  );
+  Object.defineProperty(Element.prototype, 'scrollTop', {
+    configurable: true,
+    get: () => scrolledTo[scrolledTo.length - 1] ?? 0,
+    set: (value: number) => {
+      scrolledTo.push(value);
+    },
+  });
+  Object.defineProperty(Element.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => contentHeight,
+  });
+
+  global.ResizeObserver = class {
+    constructor(private readonly callback: ResizeObserverCallback) {
+      observers.push(callback);
+    }
+    observe(): void {
+      // Which element is watched does not matter here; `grow` fires them all.
+    }
+    unobserve(): void {
+      // Only `disconnect` is used, on the effect's cleanup.
+    }
+    disconnect(): void {
+      observers = observers.filter((one) => one !== this.callback);
+    }
+  } as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  if (originalScrollTop) {
+    Object.defineProperty(Element.prototype, 'scrollTop', originalScrollTop);
+  }
+  if (originalScrollHeight) {
+    Object.defineProperty(
+      Element.prototype,
+      'scrollHeight',
+      originalScrollHeight,
+    );
+  }
+  global.ResizeObserver = OriginalResizeObserver;
+});
+
+function Pane({
+  logId,
+  mounted = true,
+}: {
+  logId?: string;
+  mounted?: boolean;
+}): React.ReactElement {
+  const pinned = usePinnedToBottom(logId);
+  if (!mounted) return <div>loading</div>;
+  return (
+    <div data-testid="pane" ref={pinned.ref}>
+      <div data-testid="content" ref={pinned.contentRef} />
+    </div>
+  );
+}
+
+describe('usePinnedToBottom', () => {
+  it('sends the pane to the bottom when it mounts', () => {
+    render(<Pane logId="log-1" />);
+    expect(scrolledTo).toEqual([1000]);
+  });
+
+  it('follows the content as it grows', () => {
+    render(<Pane logId="log-1" />);
+
+    // The card bodies mount lazily, well after the pane's first paint.
+    grow(4000);
+    grow(9000);
+
+    expect(scrolledTo).toEqual([1000, 4000, 9000]);
+  });
+
+  it('pins a pane that mounts after the log is known', () => {
+    // The log arrives before the pane does -- the view is still showing its
+    // loading skeleton. Against a ref the effect would run once here, find
+    // nothing, and never pin.
+    const { rerender } = render(<Pane logId="log-1" mounted={false} />);
+    expect(scrolledTo).toEqual([]);
+
+    rerender(<Pane logId="log-1" mounted={true} />);
+    expect(scrolledTo).toEqual([1000]);
+  });
+
+  it.each([
+    'wheel',
+    'touchMove',
+    'pointerDown',
+    'keyDown',
+  ] as const)('lets go once the reader takes over with %s', (interaction) => {
+    render(<Pane logId="log-1" />);
+    fireEvent[interaction](screen.getByTestId('pane'));
+
+    grow(4000);
+
+    expect(scrolledTo).toEqual([1000]);
+  });
+
+  it('re-arms when another log is opened', () => {
+    const { rerender } = render(<Pane logId="log-1" />);
+    fireEvent.wheel(screen.getByTestId('pane'));
+    grow(4000);
+    expect(scrolledTo).toEqual([1000]);
+
+    rerender(<Pane logId="log-2" />);
+
+    expect(scrolledTo).toEqual([1000, 4000]);
+    grow(6000);
+    expect(scrolledTo).toEqual([1000, 4000, 6000]);
+  });
+
+  it('does nothing until there is a log to open', () => {
+    render(<Pane logId={undefined} />);
+    grow(4000);
+    expect(scrolledTo).toEqual([]);
+  });
+
+  it('stops watching the content once the pane is gone', () => {
+    const { unmount } = render(<Pane logId="log-1" />);
+    unmount();
+
+    grow(4000);
+
+    expect(scrolledTo).toEqual([1000]);
+  });
+});

--- a/packages/web/src/hooks/use-pinned-to-bottom.ts
+++ b/packages/web/src/hooks/use-pinned-to-bottom.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/** What the reader does when they take the scroll over themselves. */
+const RELEASING_EVENTS = ['wheel', 'touchmove', 'pointerdown', 'keydown'];
+
+export interface PinnedToBottom {
+  /** Attach to the scrolling element. */
+  ref: (node: HTMLElement | null) => void;
+  /** Attach to the element inside it that the content makes as tall as it is. */
+  contentRef: (node: HTMLElement | null) => void;
+}
+
+/**
+ * Holds a scrolling pane at its bottom until the reader scrolls it
+ * themselves, and re-arms whenever `key` changes.
+ *
+ * The content element is watched rather than the pane, because the content is
+ * what grows: the pane's own box never changes, while the bodies inside it
+ * mount lazily and arrive long after the first paint.
+ *
+ * Both elements are held as state rather than in refs. The pane is unmounted
+ * while its content loads, so the effect has to run again once it comes back
+ * -- against a ref it would run once, find null, and never retry.
+ */
+export function usePinnedToBottom(key: string | undefined): PinnedToBottom {
+  const [pane, setPane] = useState<HTMLElement | null>(null);
+  const [content, setContent] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!key || !pane || !content) return;
+
+    let following = true;
+    const pin = (): void => {
+      if (following) {
+        pane.scrollTop = pane.scrollHeight;
+      }
+    };
+    const release = (): void => {
+      following = false;
+    };
+
+    pin();
+    const observer = new ResizeObserver(pin);
+    observer.observe(content);
+    for (const event of RELEASING_EVENTS) {
+      pane.addEventListener(event, release, { passive: true });
+    }
+
+    return (): void => {
+      observer.disconnect();
+      for (const event of RELEASING_EVENTS) {
+        pane.removeEventListener(event, release);
+      }
+    };
+  }, [key, pane, content]);
+
+  return { ref: setPane, contentRef: setContent };
+}

--- a/packages/web/src/utils/system-prompt-origin.test.ts
+++ b/packages/web/src/utils/system-prompt-origin.test.ts
@@ -1,0 +1,91 @@
+import {
+  describeSystemPromptOrigin,
+  readServedConfiguration,
+} from '@web/utils/system-prompt-origin';
+import { describe, expect, it } from 'vitest';
+
+describe('readServedConfiguration', () => {
+  it('reads the configuration a log was served by', () => {
+    expect(
+      readServedConfiguration({
+        served_configuration: {
+          id: '11111111-1111-4111-8111-111111111111',
+          name: '7',
+        },
+      }),
+    ).toEqual({ id: '11111111-1111-4111-8111-111111111111', name: '7' });
+  });
+
+  it('returns null for a log written before it was recorded', () => {
+    expect(readServedConfiguration({ skill_routing: {} })).toBeNull();
+    expect(readServedConfiguration(null)).toBeNull();
+  });
+});
+
+describe('describeSystemPromptOrigin', () => {
+  const configuration = {
+    id: '11111111-1111-4111-8111-111111111111',
+    name: '7',
+  };
+
+  const unoptimized = { partition: null, configuration: null };
+
+  it('names the partition and the configuration that served the request', () => {
+    expect(
+      describeSystemPromptOrigin({
+        partition: '2',
+        configuration,
+        clientPrompt: 'You are the caller.',
+        sentPrompt: 'You are the arm.',
+      })?.label,
+    ).toBe('partition 2 · configuration 7');
+  });
+
+  it('falls back to the partition when the configuration was not recorded', () => {
+    expect(
+      describeSystemPromptOrigin({
+        partition: '2',
+        configuration: null,
+        clientPrompt: 'You are the caller.',
+        sentPrompt: 'You are the arm.',
+      })?.label,
+    ).toBe('partition 2');
+  });
+
+  it('says so when the provider saw the prompt the client sent', () => {
+    expect(
+      describeSystemPromptOrigin({
+        ...unoptimized,
+        clientPrompt: 'You are the caller.',
+        sentPrompt: 'You are the caller.',
+      })?.label,
+    ).toBe('as sent by the client');
+  });
+
+  it('says so when the gateway appended its own instructions', () => {
+    expect(
+      describeSystemPromptOrigin({
+        ...unoptimized,
+        clientPrompt: 'You are the caller.',
+        sentPrompt: 'You are the caller.\n\nRespond with JSON alone.',
+      })?.label,
+    ).toBe('client prompt + gateway instructions');
+  });
+
+  it("says nothing when the prompt is neither the client's nor a partition's", () => {
+    expect(
+      describeSystemPromptOrigin({
+        ...unoptimized,
+        clientPrompt: 'You are the caller.',
+        sentPrompt: 'Something else entirely.',
+      }),
+    ).toBeNull();
+    expect(
+      describeSystemPromptOrigin({
+        ...unoptimized,
+        clientPrompt: null,
+        sentPrompt: 'You are the caller.',
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/web/src/utils/system-prompt-origin.ts
+++ b/packages/web/src/utils/system-prompt-origin.ts
@@ -1,0 +1,67 @@
+import { ServedConfiguration } from '@shared/types/data/skill-optimization-arm';
+
+/** The configuration a log was served by, if the optimizer pulled one. */
+export function readServedConfiguration(
+  metadata: Record<string, unknown> | null | undefined,
+): ServedConfiguration | null {
+  const parsed = ServedConfiguration.safeParse(metadata?.served_configuration);
+  return parsed.success ? parsed.data : null;
+}
+
+export interface SystemPromptOrigin {
+  label: string;
+  title: string;
+}
+
+/**
+ * Where the system prompt that reached the provider came from, in the words
+ * the rest of the dashboard uses: an optimized skill substitutes the prompt
+ * of the configuration it pulled, and every other skill forwards what the
+ * client sent, sometimes with instructions appended.
+ *
+ * `configuration` is absent on logs written before it was recorded, and on
+ * requests the optimizer did not serve; `partition` is what the log row
+ * itself keeps.
+ */
+export function describeSystemPromptOrigin({
+  partition,
+  configuration,
+  clientPrompt,
+  sentPrompt,
+}: {
+  partition: string | null;
+  configuration: ServedConfiguration | null;
+  /** The system prompt the client sent, as received. */
+  clientPrompt: string | null;
+  /** The system prompt that reached the provider. */
+  sentPrompt: string | null;
+}): SystemPromptOrigin | null {
+  if (partition && configuration) {
+    return {
+      label: `partition ${partition} · configuration ${configuration.name}`,
+      title: `The optimizer served this request with configuration ${configuration.name} of partition ${partition}, whose system prompt replaced the one the client sent`,
+    };
+  }
+  if (partition) {
+    return {
+      label: `partition ${partition}`,
+      title: `The optimizer served this request from partition ${partition}; which configuration it pulled was not recorded`,
+    };
+  }
+  if (!clientPrompt || !sentPrompt) return null;
+  if (sentPrompt === clientPrompt) {
+    return {
+      label: 'as sent by the client',
+      title:
+        'This skill substituted no prompt, so the provider saw what the client sent',
+    };
+  }
+  if (sentPrompt.startsWith(clientPrompt)) {
+    return {
+      label: 'client prompt + gateway instructions',
+      title:
+        "The client's prompt, with instructions the gateway appended -- the response schema in prose, for a provider that does not enforce response_format itself",
+    };
+  }
+  return null;
+}


### PR DESCRIPTION
## Problem

Reading a log meant scrolling. The agent's own answer looked like every other message, so the one thing you opened the log for was the hardest thing to find. Every message was fully expanded, so a system prompt of several screens sat between you and the conversation. And the view opened at the top, on that prompt.

There was also no way to tell where the system prompt that reached the provider came from — whether an optimized skill had substituted one, and if so which.

## Solution

**The agent's answer has a background of its own** — the text it produced and the tool calls it made in the same turn. Calls replayed from earlier turns stay plain: those were sent *to* the agent.

**Every message collapses.** Each card's header is a toggle; collapsed, it shows a one-line preview so it stays identifiable, and its body unmounts. The original system prompt starts collapsed.

**A log opens on the answer**, held at the bottom while the lazily-mounted card bodies arrive and grow the pane, released the moment you scroll.

**The system prompt says where it came from**, in the dashboard's own words:

- `partition 2 · configuration 7` — the optimizer substituted that configuration's prompt
- `partition 2` — served by the optimizer, but the configuration predates this recording
- `as sent by the client` — the skill substituted nothing
- `client prompt + gateway instructions` — the client's prompt plus the response schema in prose, which is what the internal skills show

The log header's `Cluster:` becomes `Partition:` to match; the rest of the dashboard already says partition.

### Recording the configuration

It had to be recorded to be shown. The row keeps `cluster_id` — the partition, not the arm — and the prompt that reached the provider is that arm's template *already rendered*, so it can't be matched back afterwards: template variables are substituted before sending, reflection rewrites an arm's params in place, and arms in a fresh partition are all seeded from the same prompt. The gateway now writes `metadata.served_configuration` (`{id, name}`), so this is a fact about new logs; older ones fall back to `partition N`.

### A latent bug found on the way

`LogsQueryParams.arm_id` built a filter on an `arm_id` column that exists in neither backend's `logs` table. No caller passes it, so it never fired; one that did would have hit a SQLite error or a PostgREST 400 — and since the observability route answers a storage error with an empty list, it would have looked like a log-less deployment rather than a fault. It now matches the configuration where it lives: `json_extract` on SQLite, `metadata->served_configuration->>id` on PostgREST.

### Cleanup

The card shell every message had copy-pasted is now one component (`MessageCard`), and so is the tool-call card three files were rendering identically (`FunctionCallCard`). The scroll behaviour is a hook (`usePinnedToBottom`) rather than 35 lines inside a 700-line component that needs eight providers to render.

## Testing

`pnpm typecheck`, `pnpm check`, 3129 unit tests (203 files), and the full 102-test contract suite on **both** backends — libSQL and Postgres/PostgREST.

43 new unit tests:

- `usePinnedToBottom` (10) — pins on mount, follows the growing content, releases on wheel/touch/pointer/key, re-arms on the next log, and pins a pane that mounts *after* the log is known, which is a bug this caught during development
- `MessageCard` (9), `FunctionCallCard` (4), `GenericViewer` (7) — collapse, preview, copy, the response tint, schema errors. `GenericViewer` had been mocked away by every suite that touched it
- `CompletionViewer` and the three plain response viewers (7) — previously untested files
- The API records `served_configuration`; the libSQL connector filters on it against a real database; `e2e/contract/optimizer.spec.ts` drives the whole path over HTTP on both backends

Verified in the running dashboard, including a real request that came through mid-development and rendered `System [partition 2 · configuration 1]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXJ8mvP4UBRdCq4wG7M2fW

