### PR TITLE
fix(api): score latency on the provider's own time, not the whole request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -617,6 +617,19 @@ The system uses special auto-generated skills in the `super-agents` agent (defin
 - `embedding`: Text embedding generation
 - `describe-skill`: Name and description for a skill the gateway creates
 
+### Latency
+
+The log row's `start_time` and `end_time` span the whole request: choosing
+the skill, embedding it, the hooks, a reviewer. `ai_provider_request_log`
+carries a `start_time` and `end_time` of its own -- when the provider was
+asked, for the attempt that answered, and when its answer was in -- and the
+latency evaluation reads those: to `first_token_time`, stamped as the
+provider's first chunk arrives, when the request streamed, and to the whole
+answer otherwise. A held stream is unstreamed at the provider, so it is
+measured to its whole answer, and the review it then waits for is not
+counted. A log written before the gateway recorded the provider's timing is
+measured across the whole request instead.
+
 ## Development Workflow
 
 1. Run `pnpm dev` to start both web and API servers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,20 @@ Database management:
 - Seed data: `supabase/seed.sql`
 - Start/stop: `supabase start|stop`
 
+### The log row a request opens
+
+A gateway request is written to `logs` when it reaches its agent, before a
+skill is chosen, and completed by an upsert under the same id when it
+finishes (`markRequestStarted` in `middlewares/logs.ts`, called from the
+agent-and-skill middleware). Until routing has picked the skill the row's
+`skill_id` is null -- the column is nullable for exactly this -- and the
+middleware writes the row again once it has, so the skill's own logs pick it
+up. A request that fails before a provider answers, routing included, is
+closed as a failed row with its status and an `error`, which is how the
+failures that used to leave no trace are seen. The dashboard learns of both
+ends over the event stream (`log:request-started`, `log:request-settled`)
+and draws a running row until the completion lands.
+
 ## Coding Style & Naming Conventions
 
 - **Language**: TypeScript, React 19, Vite, TanStack Router

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -121,6 +121,7 @@ GET  /__control/requests?model=NAME   what the gateway sent
 POST /__control/fail                  {model, times, status}
 POST /__control/fence                 {model} -- structured output inside a markdown fence
 POST /__control/reply                 {model, content} -- answer with this; a list, in order
+POST /__control/delay                 {model, ms} -- answer that much later; 0 lifts it
 POST /__control/reset                 {model}
 ```
 

--- a/e2e/contract/log-lifecycle.spec.ts
+++ b/e2e/contract/log-lifecycle.spec.ts
@@ -4,6 +4,7 @@ import {
   CHAT_COMPLETIONS_PATH,
   chatBody,
   saConfig,
+  stubDelay,
   stubReset,
   uniqueModelName,
 } from '../fixtures/gateway';
@@ -85,6 +86,54 @@ test.describe('the log row a request opens', () => {
       expect(provider.start_time).toBeGreaterThanOrEqual(logs[0].start_time);
       expect(provider.end_time).toBeGreaterThanOrEqual(provider.start_time);
       expect(provider.end_time).toBeLessThanOrEqual(logs[0].end_time);
+    } finally {
+      await stubReset(request, model);
+    }
+  });
+
+  test('shows the request as running while the provider answers', async ({
+    request,
+  }) => {
+    const agent = await createAgent(request, uniqueAgentName('running'));
+    await createSkill(request, agent.id, 'running_skill');
+    const model = uniqueModelName('running');
+    // Long enough to be seen, short enough not to hold up the run.
+    await stubDelay(request, model, 3000);
+
+    const rows = async () =>
+      (await request
+        .get(`${LOGS_PATH}?agent_id=${agent.id}`)
+        .then((r) => r.json())) as {
+        status: number | null;
+        end_time: number | null;
+      }[];
+
+    try {
+      const pending = request.post(CHAT_COMPLETIONS_PATH, {
+        headers: {
+          'sa-config': saConfig(agent.name, 'running_skill', { model }),
+        },
+        data: chatBody('are you still there'),
+      });
+
+      // The row is open before the provider has answered: no status, no
+      // end. This is what the dashboard draws as a running request.
+      await expect
+        .poll(async () => (await rows()).map((row) => row.end_time), {
+          timeout: 2500,
+          message: 'the request was never shown as running',
+        })
+        .toEqual([null]);
+      expect((await rows())[0].status).toBeNull();
+
+      const response = await pending;
+      expect(response.status()).toBe(200);
+      await expect
+        .poll(async () => (await rows()).map((row) => row.end_time), {
+          timeout: 15_000,
+          message: 'the request never completed its row',
+        })
+        .toEqual([expect.any(Number)]);
     } finally {
       await stubReset(request, model);
     }

--- a/e2e/contract/log-lifecycle.spec.ts
+++ b/e2e/contract/log-lifecycle.spec.ts
@@ -182,11 +182,12 @@ test.describe('the log row a request opens', () => {
     }
   });
 
-  test('records a request that failed before a provider answered', async ({
+  test('records a request that named a skill that does not exist', async ({
     request,
   }) => {
-    // The gap this closes: naming a skill that does not exist used to be
-    // answered with a 404 and logged nowhere at all.
+    // Answered with a 404 before any skill resolved. The row is opened as
+    // soon as the agent is known, so this leaves a failed row on the agent
+    // with no skill -- where it used to leave nothing at all.
     const agent = await createAgent(request, uniqueAgentName('failed'));
     await createSkill(request, agent.id, 'real_skill');
     const model = uniqueModelName('failed');
@@ -200,14 +201,25 @@ test.describe('the log row a request opens', () => {
       });
       expect(response.status()).toBe(404);
 
-      // Nothing is recorded: the row is opened only once the skill resolves,
-      // and this request never got that far. Asserting it explicitly because
-      // it is the known edge of the feature, not an oversight.
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      const logs = await request
-        .get(`${LOGS_PATH}?agent_id=${agent.id}`)
-        .then((r) => r.json());
-      expect(logs).toHaveLength(0);
+      const rows = async () =>
+        (await request
+          .get(`${LOGS_PATH}?agent_id=${agent.id}`)
+          .then((r) => r.json())) as {
+          skill_id: string | null;
+          status: number | null;
+          end_time: number | null;
+          error: string | null;
+        }[];
+      await expect
+        .poll(async () => (await rows()).map((row) => row.status), {
+          timeout: 15_000,
+          message: 'the failed request left no trace',
+        })
+        .toEqual([404]);
+      const [log] = await rows();
+      expect(log.skill_id).toBeNull();
+      expect(log.end_time).not.toBeNull();
+      expect(log.error).toBe('Skill with name no_such_skill not found');
     } finally {
       await stubReset(request, model);
     }

--- a/e2e/contract/log-lifecycle.spec.ts
+++ b/e2e/contract/log-lifecycle.spec.ts
@@ -27,6 +27,14 @@ import { createSkill } from '../fixtures/skills';
 
 const LOGS_PATH = '/v1/super-agents/observability/logs';
 
+/** A completed row's timing, as the streamed test reads it. */
+interface StreamedRow {
+  start_time: number;
+  first_token_time: number;
+  end_time: number;
+  ai_provider_request_log: { start_time: number; end_time: number };
+}
+
 test.describe('the log row a request opens', () => {
   test('records a completed request once, not twice', async ({ request }) => {
     const agent = await createAgent(request, uniqueAgentName('inflight'));
@@ -68,6 +76,58 @@ test.describe('the log row a request opens', () => {
       expect(logs[0].duration).toBeGreaterThanOrEqual(0);
       expect(logs[0].error).toBeNull();
       expect(logs[0].ai_provider_request_log).not.toBeNull();
+
+      // The provider's own span sits inside the row's. The row counts the
+      // gateway's work around the call -- choosing the skill, embedding the
+      // request, the hooks -- and the latency evaluation reads the provider's
+      // span so that none of it counts against the model.
+      const provider = logs[0].ai_provider_request_log;
+      expect(provider.start_time).toBeGreaterThanOrEqual(logs[0].start_time);
+      expect(provider.end_time).toBeGreaterThanOrEqual(provider.start_time);
+      expect(provider.end_time).toBeLessThanOrEqual(logs[0].end_time);
+    } finally {
+      await stubReset(request, model);
+    }
+  });
+
+  test("records when a streamed answer began and ended, by the provider's clock", async ({
+    request,
+  }) => {
+    const agent = await createAgent(request, uniqueAgentName('streamed'));
+    await createSkill(request, agent.id, 'streamed_skill');
+    const model = uniqueModelName('streamed');
+
+    try {
+      const response = await request.post(CHAT_COMPLETIONS_PATH, {
+        headers: {
+          'sa-config': saConfig(agent.name, 'streamed_skill', { model }),
+        },
+        data: chatBody('is anyone there', true),
+      });
+      expect(response.status()).toBe(200);
+      // The row completes once the stream has been read to its end.
+      await response.text();
+
+      const completed = async () =>
+        (
+          (await request
+            .get(`${LOGS_PATH}?agent_id=${agent.id}`)
+            .then((r) => r.json())) as StreamedRow[]
+        ).find((log) => log.end_time !== null);
+      await expect
+        .poll(completed, {
+          timeout: 15_000,
+          message: 'the request was never logged',
+        })
+        .toBeDefined();
+      const log = (await completed()) as StreamedRow;
+
+      // The first token is stamped as the provider's first chunk arrives, so
+      // it falls after the provider was asked and before its answer ended.
+      const provider = log.ai_provider_request_log;
+      expect(log.first_token_time).toBeGreaterThanOrEqual(provider.start_time);
+      expect(provider.end_time).toBeGreaterThanOrEqual(log.first_token_time);
+      expect(provider.end_time).toBeLessThanOrEqual(log.end_time);
     } finally {
       await stubReset(request, model);
     }

--- a/e2e/contract/optimizer.spec.ts
+++ b/e2e/contract/optimizer.spec.ts
@@ -14,6 +14,7 @@ import {
   parseSSE,
   STUB_URL,
   saConfig,
+  stubDelay,
   stubReply,
   stubRequests,
   stubReset,
@@ -1303,6 +1304,48 @@ test.describe('response review', () => {
     expect((await stubRequests(request, reviewerModel)).length).toBe(
       reviewsBefore + 1,
     );
+  });
+
+  test("keeps the reviewer's time out of the provider's own timing", async ({
+    request,
+  }) => {
+    // The reviewer takes its time; the model it reviews answers at once.
+    await stubReply(request, reviewerModel, allow);
+    await stubDelay(request, reviewerModel, 1500);
+    try {
+      const response = await ask(request, 'how long did that take?');
+      expect(response.status()).toBe(200);
+
+      await expect
+        .poll(
+          async () =>
+            (
+              await logMentioning(
+                request,
+                reviewedSkillId,
+                'how long did that take?',
+              )
+            )?.end_time,
+        )
+        .toEqual(expect.any(Number));
+      const log = (await logMentioning(
+        request,
+        reviewedSkillId,
+        'how long did that take?',
+      )) as LoggedRequest;
+      const provider = log.ai_provider_request_log as {
+        start_time: number;
+        end_time: number;
+      };
+
+      // The row waited for the review; the provider's own span did not, and
+      // that span is what the latency evaluation scores the model on.
+      expect(log.duration ?? 0).toBeGreaterThanOrEqual(1500);
+      expect(provider.end_time - provider.start_time).toBeLessThan(1500);
+      expect(provider.start_time).toBeGreaterThanOrEqual(log.start_time);
+    } finally {
+      await stubDelay(request, reviewerModel, 0);
+    }
   });
 
   test('does not review the review, even when the reviewers point at each other', async ({

--- a/e2e/contract/optimizer.spec.ts
+++ b/e2e/contract/optimizer.spec.ts
@@ -407,6 +407,51 @@ test.describe('skill routing', () => {
       .toBe('embedding');
   });
 
+  test('shows the request on the agent before routing has picked a skill', async ({
+    request,
+  }) => {
+    // Routing embeds the request first. The stub holds that embedding, so
+    // the row has to be there without it.
+    await stubDelay(request, stub.embeddingModel, 3000);
+    const rows = async () =>
+      (await request
+        .get('/v1/super-agents/observability/logs', {
+          params: { agent_id: translate.agent_id },
+        })
+        .then((r) => r.json())) as LoggedRequest[];
+
+    try {
+      const pending = chatToAgent(
+        request,
+        agentName,
+        stub.textModel,
+        'Translate the message. vec(1,0,0,0,0,0,0,0)',
+        'still routing',
+      );
+
+      // Running, and not yet anyone's: a row with no skill.
+      await expect
+        .poll(
+          async () =>
+            (await rows()).find((row) => row.end_time === null)?.skill_id,
+          {
+            timeout: 2500,
+            message: 'the request was not on the agent before routing finished',
+          },
+        )
+        .toBeNull();
+
+      expect((await pending).status()).toBe(200);
+      // The same row, routed and completed.
+      await expect
+        .poll(() => decisionFor(request, translate.id, 'still routing'))
+        .toBe('embedding');
+      expect((await rows()).filter((row) => row.end_time === null)).toEqual([]);
+    } finally {
+      await stubDelay(request, stub.embeddingModel, 0);
+    }
+  });
+
   test('still honours a skill named in the header', async ({ request }) => {
     // A translate-shaped prompt sent to the SQL skill by name: the name wins.
     const response = await chatToAgent(

--- a/e2e/dashboard/agents.spec.ts
+++ b/e2e/dashboard/agents.spec.ts
@@ -10,6 +10,7 @@ import {
   CHAT_COMPLETIONS_PATH,
   chatBody,
   saConfig,
+  stubDelay,
   stubReset,
   uniqueModelName,
 } from '../fixtures/gateway';
@@ -227,6 +228,47 @@ test.describe('response review form', () => {
     } finally {
       await deleteAgent(request, agent.id);
       await deleteAgent(request, guard.id);
+    }
+  });
+});
+
+test.describe('live updates', () => {
+  test('shows a request as running while the provider answers, without a reload', async ({
+    page,
+    request,
+  }) => {
+    // The row is written when the request arrives and announced over the
+    // event stream, so an open logs page draws it before the provider has
+    // answered. The stub holds its answer long enough to look.
+    const name = uniqueAgentName('running-ui');
+    const agent = await createAgent(request, name);
+    const model = uniqueModelName('running-ui');
+
+    try {
+      await createSkill(request, agent.id, 'gateway_skill');
+      await stubDelay(request, model, 4000);
+      await page.goto(`/agents/${name}/logs`);
+      await expect(
+        page.getByRole('heading', { name: 'Logs', exact: true }),
+      ).toBeVisible();
+
+      const pending = request.post(CHAT_COMPLETIONS_PATH, {
+        headers: { 'sa-config': saConfig(name, 'gateway_skill', { model }) },
+        data: chatBody('are you still there'),
+      });
+
+      await expect(page.getByText('running', { exact: true })).toBeVisible({
+        timeout: 3500,
+      });
+
+      expect((await pending).status()).toBe(200);
+      await expect(page.getByText('running', { exact: true })).toHaveCount(0);
+      await expect(
+        page.getByText('200', { exact: true }).first(),
+      ).toBeVisible();
+    } finally {
+      await stubReset(request, model);
+      await deleteAgent(request, agent.id);
     }
   });
 });

--- a/e2e/fixtures/gateway.ts
+++ b/e2e/fixtures/gateway.ts
@@ -114,6 +114,19 @@ export const stubReply = async (
   });
 };
 
+/**
+ * Make every reply for this model wait `ms` before answering -- how a test
+ * tells a slow reviewer from the model it reviews, on a stub that otherwise
+ * answers at once. Zero lifts it.
+ */
+export const stubDelay = async (
+  request: APIRequestContext,
+  model: string,
+  ms: number,
+): Promise<void> => {
+  await request.post(`${STUB_URL}/__control/delay`, { data: { model, ms } });
+};
+
 export const stubReset = async (
   request: APIRequestContext,
   model: string,

--- a/e2e/fixtures/logs.ts
+++ b/e2e/fixtures/logs.ts
@@ -5,7 +5,8 @@ const LOGS_PATH = '/v1/super-agents/observability/logs';
 /** The parts of a log these specs read. */
 export interface LoggedRequest {
   id: string;
-  skill_id: string;
+  /** Null while routing is still picking the skill, and if it never did. */
+  skill_id: string | null;
   /** How a review finds the request it reviewed: the same trace, as a span. */
   trace_id: string | null;
   span_id: string | null;

--- a/e2e/fixtures/logs.ts
+++ b/e2e/fixtures/logs.ts
@@ -16,7 +16,9 @@ export interface LoggedRequest {
     hook: { id: string };
     result: { deny_request: boolean; reason?: string; error?: string };
   }[];
+  start_time: number;
   end_time: number | null;
+  duration: number | null;
   metadata: Record<string, unknown>;
   original_system_prompt: string | null;
   /**
@@ -25,6 +27,13 @@ export interface LoggedRequest {
    */
   ai_provider_request_log: {
     request_body: { messages?: { role: string; content: string }[] };
+    /**
+     * The provider's own span: when it was asked, and when it had answered.
+     * Inside the row's, which also counts the gateway's work around the call.
+     * Absent on a cache hit.
+     */
+    start_time?: number;
+    end_time?: number;
   } | null;
 }
 

--- a/packages/api/scripts/upgrade-dev-db.mjs
+++ b/packages/api/scripts/upgrade-dev-db.mjs
@@ -16,7 +16,9 @@
  * requests that fail before reaching one.
  *
  * SQLite cannot relax NOT NULL with ALTER, so the table is rebuilt: a new
- * table, the rows copied across, then swapped.
+ * table, the rows copied across, then swapped. The same rebuild later
+ * relaxed `skill_id`, once the row moved to before skill routing: until
+ * routing has picked the skill there is none to write.
  *
  * Also the response review columns on `agents`: `reviewer_agent_id`, the
  * agent whose responses another agent reviews before the client sees them,
@@ -73,6 +75,7 @@ const client = createClient({ url: `file:${dbPath}`, concurrency: 1 });
 
 /** Columns the current code expects on `logs`, in the order it creates them. */
 const NULLABLE_NOW = [
+  'skill_id',
   'status',
   'end_time',
   'duration',
@@ -186,7 +189,7 @@ const rebuildLogs = async (columns) => {
   const create = `CREATE TABLE logs_upgraded (
       id TEXT PRIMARY KEY,
       agent_id TEXT NOT NULL,
-      skill_id TEXT NOT NULL,
+      skill_id TEXT,
       cluster_id TEXT,
       method TEXT NOT NULL CHECK (method IN ('GET', 'POST', 'PUT', 'DELETE', 'PATCH')),
       endpoint TEXT NOT NULL,
@@ -222,9 +225,9 @@ const rebuildLogs = async (columns) => {
       FOREIGN KEY (cluster_id) REFERENCES skill_optimization_clusters(id) ON DELETE SET NULL
     )`;
 
-  const carried = columns
-    .map((column) => column.name)
-    .filter((name) => name !== 'error');
+  // Every column the old table has, `error` included when a previous
+  // rebuild added it: leaving one out would drop its values in the copy.
+  const carried = columns.map((column) => column.name);
   const columnList = carried.join(', ');
 
   // Off *before* the transaction opens: inside one it does nothing, and the

--- a/packages/api/src/connectors/evaluations/latency/evaluate-log.test.ts
+++ b/packages/api/src/connectors/evaluations/latency/evaluate-log.test.ts
@@ -4,7 +4,10 @@ import { HttpMethod } from '@api/types/http';
 import { FunctionName } from '@shared/types/api/request';
 import { AIProvider } from '@shared/types/constants';
 import type { SkillOptimizationEvaluation } from '@shared/types/data';
-import type { CompletedLog } from '@shared/types/data/log';
+import type {
+  AIProviderRequestLog,
+  CompletedLog,
+} from '@shared/types/data/log';
 import { EvaluationMethodName } from '@shared/types/evaluations';
 import { CacheMode, CacheStatus } from '@shared/types/middleware/cache';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -254,6 +257,88 @@ describe('Latency - evaluateLog', () => {
       expect(result.score).toBeCloseTo(0.5, 2);
       expect(result.extra_data.latency_ms).toBe(midpoint);
       expect(result.extra_data.has_first_token_time).toBe(false);
+    });
+  });
+
+  describe('Provider timing', () => {
+    // The row spans the whole request: it arrived at 1000 and was answered
+    // at 9000, with the skill chosen, the request embedded and a reviewer
+    // consulted somewhere in between. The provider itself was asked at 6000.
+    const timed = (
+      first_token_time: number | null,
+      provider: Pick<AIProviderRequestLog, 'start_time' | 'end_time'>,
+    ): CompletedLog => ({
+      ...baseLog,
+      start_time: 1000,
+      first_token_time,
+      end_time: 9000,
+      duration: 8000,
+      ai_provider_request_log: {
+        ...(baseLog.ai_provider_request_log as AIProviderRequestLog),
+        ...provider,
+      },
+    });
+
+    it("counts the provider's answer from the moment it was asked, not the request from its arrival", async () => {
+      const result = await evaluateLog(
+        createMockContext(),
+        baseEvaluation,
+        timed(null, { start_time: 6000, end_time: 6250 }),
+        mockStorageConnector,
+      );
+
+      // 250ms, under the 300ms target. The 8000ms the row spans would have
+      // scored the model for the gateway's work around the call.
+      expect(result.score).toBe(1.0);
+      expect(result.extra_data.latency_ms).toBe(250);
+      expect(result.extra_data.measured).toBe('response');
+      expect(result.extra_data.measured_from).toBe('provider');
+      expect(result.display_info[1].content).toContain(
+        'Provider Response Time: 250ms',
+      );
+    });
+
+    it('counts time to first token from the moment the provider was asked', async () => {
+      const result = await evaluateLog(
+        createMockContext(),
+        baseEvaluation,
+        timed(6200, { start_time: 6000, end_time: 7000 }),
+        mockStorageConnector,
+      );
+
+      expect(result.score).toBe(1.0);
+      expect(result.extra_data.latency_ms).toBe(200);
+      expect(result.extra_data.measured).toBe('ttft');
+      expect(result.extra_data.measured_from).toBe('provider');
+    });
+
+    it("measures across the whole request when the log predates the provider's timing", async () => {
+      const result = await evaluateLog(
+        createMockContext(),
+        baseEvaluation,
+        timed(null, {}),
+        mockStorageConnector,
+      );
+
+      expect(result.extra_data.latency_ms).toBe(8000);
+      expect(result.extra_data.measured).toBe('response');
+      expect(result.extra_data.measured_from).toBe('request');
+      expect(result.score).toBeCloseTo(1 - (8000 - 300) / (8787 - 300), 5);
+      expect(result.display_info[1].content).toContain(
+        'Total Response Time: 8000ms',
+      );
+    });
+
+    it("falls back to the request's span when only the provider's start was recorded", async () => {
+      const result = await evaluateLog(
+        createMockContext(),
+        baseEvaluation,
+        timed(null, { start_time: 6000 }),
+        mockStorageConnector,
+      );
+
+      expect(result.extra_data.latency_ms).toBe(8000);
+      expect(result.extra_data.measured_from).toBe('request');
     });
   });
 

--- a/packages/api/src/connectors/evaluations/latency/latency.ts
+++ b/packages/api/src/connectors/evaluations/latency/latency.ts
@@ -10,7 +10,7 @@ const methodConfig: EvaluationMethodDetails = {
   method: EvaluationMethodName.LATENCY,
   name: 'Latency',
   description:
-    'Evaluates time-to-first-token (TTFT) for streaming responses or total duration for non-streaming',
+    "Evaluates the provider's time to first token (TTFT) for streaming responses, or its total response time for non-streaming",
 } as const;
 
 export const latencyEvaluationConnector: EvaluationMethodConnector = {

--- a/packages/api/src/connectors/evaluations/latency/service/evaluate.ts
+++ b/packages/api/src/connectors/evaluations/latency/service/evaluate.ts
@@ -34,20 +34,67 @@ function calculateLatencyScore(
   return 1.0 - position / range;
 }
 
+/** How long the model took, and which span of the log the number came from. */
+interface LatencyMeasurement {
+  latency_ms: number;
+  /** To the first token, or to the whole answer when the request did not stream. */
+  measured: 'ttft' | 'response';
+  /**
+   * `provider` counts from the moment the provider was asked. `request`
+   * counts from the moment the request arrived, which is all a log written
+   * before the gateway recorded the provider's own timing has to offer.
+   */
+  measured_from: 'provider' | 'request';
+}
+
 /**
- * Extract latency from log
+ * How long the model took, read from the log.
  *
- * For streaming requests with first_token_time: Uses TTFT (first_token_time - start_time)
- * Otherwise: Uses total duration as proxy
+ * The provider's own timing is preferred. The log row's `start_time` is when
+ * the request arrived, and everything the gateway did before asking the
+ * provider -- choosing the skill, embedding the request, the input hooks --
+ * sits between the two; its `end_time` likewise waits for the output hooks,
+ * a reviewer among them. None of that is the model's to answer for, and a
+ * score that counted it would move with the gateway's load rather than with
+ * the configuration under test. A log without the provider's timing is
+ * measured across the whole request, as every log once was.
  */
-function extractLatency(log: Log): number | null {
-  // If we have first_token_time, use it for precise TTFT measurement
-  if (log.first_token_time !== null && log.first_token_time !== undefined) {
-    return log.first_token_time - log.start_time;
+function extractLatency(log: Log): LatencyMeasurement | null {
+  const provider = log.ai_provider_request_log;
+  const firstToken = log.first_token_time ?? null;
+
+  if (provider?.start_time !== undefined) {
+    if (firstToken !== null) {
+      return {
+        latency_ms: firstToken - provider.start_time,
+        measured: 'ttft',
+        measured_from: 'provider',
+      };
+    }
+    if (provider.end_time !== undefined) {
+      return {
+        latency_ms: provider.end_time - provider.start_time,
+        measured: 'response',
+        measured_from: 'provider',
+      };
+    }
   }
 
-  // Fallback to duration for non-streaming or if first_token_time wasn't captured
-  return log.duration;
+  if (firstToken !== null) {
+    return {
+      latency_ms: firstToken - log.start_time,
+      measured: 'ttft',
+      measured_from: 'request',
+    };
+  }
+  if (log.duration === null) {
+    return null;
+  }
+  return {
+    latency_ms: log.duration,
+    measured: 'response',
+    measured_from: 'request',
+  };
 }
 
 export function evaluateLog(
@@ -61,10 +108,10 @@ export function evaluateLog(
   try {
     const params = LatencyEvaluationParameters.parse(evaluation.params);
 
-    const latency_ms = extractLatency(log);
+    const measurement = extractLatency(log);
 
     // If we couldn't extract latency, return 0.5 (neutral score)
-    if (latency_ms === null) {
+    if (measurement === null) {
       const execution_time = Date.now() - start_time;
       return Promise.resolve({
         evaluation_id: evaluation.id,
@@ -85,6 +132,8 @@ export function evaluateLog(
       });
     }
 
+    const { latency_ms, measured, measured_from } = measurement;
+
     const score = calculateLatencyScore(
       latency_ms,
       params.target_latency_ms,
@@ -95,9 +144,15 @@ export function evaluateLog(
 
     // Format latency performance for display
     const latencyType =
-      log.first_token_time !== null
+      measured === 'ttft'
         ? 'Time to First Token (TTFT)'
-        : 'Total Response Time';
+        : measured_from === 'provider'
+          ? 'Provider Response Time'
+          : 'Total Response Time';
+    const measuredFrom =
+      measured_from === 'provider'
+        ? 'when the provider was asked'
+        : "when the request arrived (this log predates the provider's own timing)";
 
     const performance =
       latency_ms <= params.target_latency_ms
@@ -115,6 +170,8 @@ export function evaluateLog(
         target_latency_ms: params.target_latency_ms,
         max_latency_ms: params.max_latency_ms,
         has_first_token_time: log.first_token_time !== null,
+        measured,
+        measured_from,
         execution_time,
       },
       display_info: [
@@ -124,7 +181,7 @@ export function evaluateLog(
         },
         {
           label: 'Latency Measurement',
-          content: `${latencyType}: ${latency_ms}ms\nTarget: ${params.target_latency_ms}ms\nMaximum: ${params.max_latency_ms}ms\nScore: ${(score * 100).toFixed(1)}%`,
+          content: `${latencyType}: ${latency_ms}ms\nMeasured from: ${measuredFrom}\nTarget: ${params.target_latency_ms}ms\nMaximum: ${params.max_latency_ms}ms\nScore: ${(score * 100).toFixed(1)}%`,
         },
       ],
       judge_model_name: null,

--- a/packages/api/src/connectors/evaluations/latency/types.ts
+++ b/packages/api/src/connectors/evaluations/latency/types.ts
@@ -1,11 +1,13 @@
 import { z } from 'zod';
 
 /**
- * Parameters for latency evaluation (Time-to-First-Token / TTFT)
+ * Parameters for the latency evaluation.
  *
- * This evaluation measures how quickly the AI provider starts responding.
- * For streaming requests: Uses first_token_time - start_time
- * For non-streaming requests: Uses the full duration as a proxy
+ * It measures how quickly the provider answered, counted from the moment it
+ * was asked: to its first token when the request streamed, and to its whole
+ * answer otherwise. Nothing the gateway did around the call -- choosing the
+ * skill, embedding the request, the hooks, a reviewer -- counts, since none
+ * of it is the model's to answer for.
  *
  * The score is normalized based on target_latency_ms and max_latency_ms:
  * - Responses at or below target_latency_ms score 1.0 (perfect)

--- a/packages/api/src/connectors/libsql/libsql.test.ts
+++ b/packages/api/src/connectors/libsql/libsql.test.ts
@@ -808,6 +808,51 @@ describe('the log row a request opens', () => {
     expect(log.model).toBe('gpt-5.6');
   });
 
+  it('opens with no skill, and takes the one routing picks without reopening', async () => {
+    const { client, c } = await freshDatabase();
+    await seedParents(client);
+
+    // Announced when the request reached its agent, before routing.
+    await libsqlLogsStorageConnector.startLog(c, {
+      ...startParams(REQUEST),
+      skill_id: null,
+    });
+    const [arrived] = await libsqlLogsStorageConnector.getLogs(c, {
+      id: REQUEST,
+    });
+    expect(arrived.skill_id).toBeNull();
+    expect(arrived.end_time).toBeNull();
+
+    // Announced again once routing has picked the skill.
+    await libsqlLogsStorageConnector.startLog(c, startParams(REQUEST));
+    const logs = await libsqlLogsStorageConnector.getLogs(c, {});
+    expect(logs).toHaveLength(1);
+    expect(logs[0].skill_id).toBe(SKILL);
+    expect(logs[0].end_time).toBeNull();
+  });
+
+  it('closes a request that failed before routing picked a skill', async () => {
+    const { client, c } = await freshDatabase();
+    await seedParents(client);
+
+    await libsqlLogsStorageConnector.startLog(c, {
+      ...startParams(REQUEST),
+      skill_id: null,
+    });
+    await libsqlLogsStorageConnector.failLog(c, {
+      id: REQUEST,
+      status: 504,
+      end_time: 4000,
+      duration: 3000,
+      error: 'The arbiter timed out.',
+    });
+
+    const [log] = await libsqlLogsStorageConnector.getLogs(c, { id: REQUEST });
+    expect(log.skill_id).toBeNull();
+    expect(log.status).toBe(504);
+    expect(log.error).toBe('The arbiter timed out.');
+  });
+
   it('is completed by the write at the end, not duplicated', async () => {
     const { client, c } = await freshDatabase();
     await seedParents(client);

--- a/packages/api/src/connectors/libsql/schema.ts
+++ b/packages/api/src/connectors/libsql/schema.ts
@@ -241,7 +241,10 @@ const initialSchema: LibsqlMigration = {
     `CREATE TABLE IF NOT EXISTS logs (
       id TEXT PRIMARY KEY,
       agent_id TEXT NOT NULL,
-      skill_id TEXT NOT NULL,
+      -- Null until routing has picked the skill, and for a request that
+      -- failed before it did: the row is written when the request reaches
+      -- its agent, which is before the skill is known.
+      skill_id TEXT,
       cluster_id TEXT,
       method TEXT NOT NULL CHECK (method IN ('GET', 'POST', 'PUT', 'DELETE', 'PATCH')),
       endpoint TEXT NOT NULL,

--- a/packages/api/src/handlers/handler-utils.ts
+++ b/packages/api/src/handlers/handler-utils.ts
@@ -878,7 +878,8 @@ export async function recursiveOutputHookHandler(
   let response: Response,
     retryCount: number | undefined,
     createdAt: Date,
-    retrySkipped: boolean;
+    retrySkipped: boolean,
+    sentAt: number;
   const requestTimeout = saTarget.request_timeout || null;
 
   const { retry } = saTarget;
@@ -908,6 +909,7 @@ export async function recursiveOutputHookHandler(
     attempt: retryCount,
     createdAt,
     skip: retrySkipped,
+    sentAt,
   } = await retryRequest(
     aiProviderRequestURL,
     options,
@@ -917,6 +919,12 @@ export async function recursiveOutputHookHandler(
     requestHandler,
     retry?.use_retry_after_header || false,
   ));
+
+  // The provider's own span, for the attempt that answered: from here to its
+  // first token, or to its whole answer when nothing streams. The log row's
+  // times span the whole request instead, routing and review included, and
+  // that is the gateway's time rather than the model's.
+  c.set('provider_start_time', sentAt);
 
   // Create callbacks for streaming responses
   const onFirstChunk = isStreamingMode
@@ -930,7 +938,9 @@ export async function recursiveOutputHookHandler(
   if (isStreamingMode) {
     const streamEndPromise = new Promise<void>((resolve) => {
       streamEndResolver = (accumulatedChunks: string) => {
-        c.set('stream_end_time', Date.now());
+        const endTime = Date.now();
+        c.set('stream_end_time', endTime);
+        c.set('provider_end_time', endTime);
         c.set('accumulated_stream_chunks', accumulatedChunks);
         resolve();
       };
@@ -955,6 +965,11 @@ export async function recursiveOutputHookHandler(
     onFirstChunk,
     streamEndResolver,
   );
+
+  if (!isStreamingMode) {
+    // The whole body has been read by now; a stream stamps this as it ends.
+    c.set('provider_end_time', Date.now());
+  }
 
   if (!mappedResponse.ok) {
     const errorBody = await mappedResponse.text();

--- a/packages/api/src/handlers/retry-handler.test.ts
+++ b/packages/api/src/handlers/retry-handler.test.ts
@@ -59,3 +59,33 @@ describe('retryRequest with a provider error', () => {
     expect(body.error.code).toBe('unsupported_value');
   });
 });
+
+describe('retryRequest timing', () => {
+  it('reports when the attempt that answered was sent, not when the first was', async () => {
+    let attempts = 0;
+    const flakyProvider = () => {
+      attempts += 1;
+      return Promise.resolve(
+        attempts === 1
+          ? new Response('{"error":"busy"}', { status: 500 })
+          : new Response('{}', { status: 200 }),
+      );
+    };
+
+    const { response, createdAt, sentAt } = await retryRequest(
+      url,
+      {},
+      1,
+      [500],
+      null,
+      flakyProvider,
+    );
+
+    expect(response.status).toBe(200);
+    expect(attempts).toBe(2);
+    // The retry waits a second before asking again. The failed attempt and
+    // that wait are the provider's unavailability, not its speed, so a
+    // measure of how fast it answered must not start at `createdAt`.
+    expect(sentAt - createdAt.getTime()).toBeGreaterThanOrEqual(900);
+  });
+});

--- a/packages/api/src/handlers/retry-handler.ts
+++ b/packages/api/src/handlers/retry-handler.ts
@@ -71,9 +71,17 @@ export const retryRequest = async (
   attempt: number | undefined;
   createdAt: Date;
   skip: boolean;
+  /**
+   * When the attempt that produced `response` was sent. Earlier attempts and
+   * the waits between them are the provider's unavailability rather than its
+   * speed, so a measure of how fast it answered starts here, not at
+   * `createdAt`.
+   */
+  sentAt: number;
 }> => {
   let lastAttempt: number | undefined;
   const start = new Date();
+  let sentAt = start.getTime();
   let retrySkipped = false;
 
   let remainingRetryTimeout = MAX_RETRY_LIMIT_MS;
@@ -82,6 +90,7 @@ export const retryRequest = async (
     const result = await retry(
       async (bail: (error: Error) => void, attempt: number) => {
         try {
+          sentAt = Date.now();
           let response: Response;
           if (timeout) {
             response = await fetchWithTimeout(
@@ -168,6 +177,7 @@ export const retryRequest = async (
             attempt: lastAttempt,
             createdAt: start,
             skip: retrySkipped,
+            sentAt,
           };
         } catch (error) {
           if (attempt >= retryCount + 1) {
@@ -225,6 +235,7 @@ export const retryRequest = async (
       attempt: lastAttempt,
       createdAt: start,
       skip: retrySkipped,
+      sentAt,
     };
   }
 };

--- a/packages/api/src/middlewares/agent-and-skill.test.ts
+++ b/packages/api/src/middlewares/agent-and-skill.test.ts
@@ -1,4 +1,5 @@
 import { agentAndSkillMiddleware } from '@api/middlewares/agent-and-skill';
+import { markRequestStarted } from '@api/middlewares/logs';
 import type { AppContext } from '@api/types/hono';
 import * as agentsUtils from '@api/utils/super-agents/agents';
 import * as skillRouting from '@api/utils/super-agents/skill-routing';
@@ -15,6 +16,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the utility functions
 vi.mock('@api/utils/super-agents/agents');
+vi.mock('@api/middlewares/logs', () => ({ markRequestStarted: vi.fn() }));
 vi.mock('@api/utils/super-agents/skills');
 // Partially, so `SkillRoutingError` stays the real class for `instanceof`.
 vi.mock('@api/utils/super-agents/skill-routing', async (importOriginal) => ({
@@ -371,6 +373,108 @@ describe('agentAndSkillMiddleware', () => {
         'custom-agent-123',
         'custom-skill-456',
       );
+    });
+  });
+
+  describe('announcing the request', () => {
+    const agent = {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      name: 'test-agent',
+    } as Agent;
+    const skill = {
+      id: '123e4567-e89b-12d3-a456-426614174001',
+      name: 'routed',
+    } as Skill;
+
+    /** A context that remembers what the middleware sets on it. */
+    const statefulContext = (
+      config: Partial<SuperAgentsConfig>,
+    ): AppContext => {
+      const values = new Map<string, unknown>([
+        ['sa_config_pre_processed', { ...mockSuperAgentsConfig, ...config }],
+        ['user_data_storage_connector', mockConnector],
+        ['sa_request_data', { functionName: 'chatComplete' }],
+      ]);
+      return {
+        req: { url: 'http://localhost/v1/chat/completions' },
+        get: (key: string) => values.get(key),
+        set: (key: string, value: unknown) => values.set(key, value),
+        json: (body: unknown, status: number) => ({ body, status }),
+      } as unknown as AppContext;
+    };
+
+    /** Records what each announcement could see of the skill. */
+    const recordAnnouncements = (seen: string[]) => {
+      vi.mocked(markRequestStarted).mockImplementation((c) => {
+        const known = c.get('skill') as Skill | undefined;
+        seen.push(known ? `announced with ${known.name}` : 'announced bare');
+      });
+    };
+
+    beforeEach(() => {
+      vi.mocked(agentsUtils.getAgent).mockResolvedValue(agent);
+      // A named skill is learned from after the answer; not what is under test.
+      vi.mocked(skillRouting.learnSkillIntent).mockResolvedValue(undefined);
+    });
+
+    it('announces the request before routing, and again once the skill is known', async () => {
+      const seen: string[] = [];
+      recordAnnouncements(seen);
+      vi.mocked(skillRouting.routeRequestToSkill).mockImplementation(() => {
+        seen.push('routed');
+        return Promise.resolve({
+          skill,
+          decision: {
+            method: 'embedding',
+            similarity: 0.93,
+            threshold: 0.8,
+            candidates: 2,
+          },
+        });
+      });
+
+      await agentAndSkillMiddleware(
+        statefulContext({ skill_name: undefined }),
+        mockNext,
+      );
+
+      expect(seen).toEqual([
+        'announced bare',
+        'routed',
+        'announced with routed',
+      ]);
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('announces a request that names its skill before looking it up too', async () => {
+      const seen: string[] = [];
+      recordAnnouncements(seen);
+      vi.mocked(skillsUtils.getSkill).mockResolvedValue(skill);
+
+      await agentAndSkillMiddleware(
+        statefulContext({ skill_name: 'routed' }),
+        mockNext,
+      );
+
+      expect(seen).toEqual(['announced bare', 'announced with routed']);
+    });
+
+    it('leaves the bare announcement behind a skill that does not exist, for the failure to close', async () => {
+      const seen: string[] = [];
+      recordAnnouncements(seen);
+      vi.mocked(skillsUtils.getSkill).mockResolvedValue(null);
+
+      const response = await agentAndSkillMiddleware(
+        statefulContext({ skill_name: 'nope' }),
+        mockNext,
+      );
+
+      expect(seen).toEqual(['announced bare']);
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(response).toEqual({
+        body: { error: 'Skill with name nope not found' },
+        status: 404,
+      });
     });
   });
 

--- a/packages/api/src/middlewares/agent-and-skill.ts
+++ b/packages/api/src/middlewares/agent-and-skill.ts
@@ -33,6 +33,12 @@ export const agentAndSkillMiddleware = createMiddleware(
           );
         }
 
+        // Announced now, before the skill is known: routing can be slow
+        // enough to watch, and a request that fails inside it should leave
+        // a row too. Announced again once the skill has been chosen.
+        c.set('agent', agent);
+        markRequestStarted(c);
+
         let skill: Skill | null;
         if (saConfig.skill_name) {
           skill = await getSkill(
@@ -81,12 +87,9 @@ export const agentAndSkillMiddleware = createMiddleware(
           });
         }
 
-        c.set('agent', agent);
         c.set('skill', skill);
 
-        // The first point at which a pending row could say which skill's logs
-        // it belongs in, and still early enough to cover the provider call --
-        // which is nearly all of a request's elapsed time.
+        // Now with the skill, so the row reaches the skill's own logs too.
         markRequestStarted(c);
       }
     }

--- a/packages/api/src/middlewares/logs.test.ts
+++ b/packages/api/src/middlewares/logs.test.ts
@@ -1,5 +1,6 @@
 import {
   logsMiddleware,
+  markRequestStarted,
   truncateOversizedResponseBody,
 } from '@api/middlewares/logs';
 import type {
@@ -7,6 +8,7 @@ import type {
   UserDataStorageConnector,
 } from '@api/types/connector';
 import type { AppContext, AppEnv } from '@api/types/hono';
+import { emitSSEEvent } from '@api/utils/sse-event-manager';
 import type { SkillRoutingDecision } from '@api/utils/super-agents/skill-routing';
 import { FunctionName } from '@shared/types/api/request';
 import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
@@ -78,7 +80,10 @@ const aiProviderLog = {
 
 describe('logsMiddleware', () => {
   let requestData: SuperAgentsRequestData;
-  let logsConnector: { createLog: ReturnType<typeof vi.fn> };
+  let logsConnector: {
+    createLog: ReturnType<typeof vi.fn>;
+    failLog: ReturnType<typeof vi.fn>;
+  };
   let userData: UserDataStorageConnector;
   let app: Hono<AppEnv>;
   /** What the handler under test leaves on the context, beyond the usual. */
@@ -105,6 +110,7 @@ describe('logsMiddleware', () => {
       createLog: vi
         .fn()
         .mockImplementation(async (_c, params) => ({ ...params, id: 'log-1' })),
+      failLog: vi.fn().mockResolvedValue(undefined),
     };
     userData = {
       incrementSkillTotalRequests: vi.fn(),
@@ -183,6 +189,44 @@ describe('logsMiddleware', () => {
     );
   });
 
+  it('closes a request that failed before a provider was asked with the error itself', async () => {
+    app = new Hono<AppEnv>()
+      .use('*', async (c, next) => {
+        c.set('sa_request_data', requestData);
+        c.set('user_data_storage_connector', userData);
+        await next();
+      })
+      .use(
+        '*',
+        logsMiddleware(
+          createFactory<AppEnv>(),
+          () => logsConnector as unknown as LogsStorageConnector,
+        ),
+      )
+      // What the agent-and-skill middleware answers for a skill that does
+      // not exist, having already opened the row.
+      .post('/v1/chat/completions', (c) =>
+        c.json({ error: 'Skill with name nope not found' }, 404),
+      );
+
+    const response = await app.request('/v1/chat/completions', {
+      method: 'POST',
+    });
+    expect(response.status).toBe(404);
+
+    await vi.waitFor(() =>
+      expect(logsConnector.failLog).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          status: 404,
+          // The message, not the JSON it came wrapped in.
+          error: 'Skill with name nope not found',
+        }),
+      ),
+    );
+    expect(logsConnector.createLog).not.toHaveBeenCalled();
+  });
+
   it('records which configuration served the request', async () => {
     app = new Hono<AppEnv>()
       .use('*', async (c, next) => {
@@ -242,6 +286,86 @@ describe('logsMiddleware', () => {
     const log = await storedLog();
     expect(log.metadata).toEqual({});
     expect(log.original_system_prompt).toBe('You are the caller.');
+  });
+});
+
+describe('markRequestStarted', () => {
+  const startLog = vi.fn().mockResolvedValue(undefined);
+
+  /** What the agent-and-skill middleware has on the context when it calls. */
+  const arrived = {
+    log_request_id: 'request-1',
+    log_start_time: 1000,
+    sa_request_data: {
+      functionName: FunctionName.CHAT_COMPLETE,
+      method: HttpMethod.POST,
+      url: 'http://localhost/v1/chat/completions',
+      requestBody: { model: 'gpt-4o', messages: [] },
+    },
+    sa_config_pre_processed: saConfig,
+    agent,
+    logs_storage_connector: { startLog },
+  };
+
+  const context = (values: Record<string, unknown>): AppContext =>
+    ({
+      req: { url: 'http://localhost/v1/chat/completions' },
+      get: (key: string) => values[key],
+    }) as unknown as AppContext;
+
+  beforeEach(() => {
+    startLog.mockClear();
+    vi.mocked(emitSSEEvent).mockClear();
+  });
+
+  it('opens the row with no skill as soon as the agent is known', async () => {
+    markRequestStarted(context(arrived));
+
+    expect(startLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: 'request-1',
+        agent_id: 'agent-1',
+        skill_id: null,
+        start_time: 1000,
+        model: 'gpt-4o',
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(emitSSEEvent).toHaveBeenCalledWith('log:request-started', {
+        log_id: 'request-1',
+        agent_id: 'agent-1',
+        skill_id: null,
+      }),
+    );
+  });
+
+  it('opens the row for a request that named only its agent', () => {
+    // No `skill_name` in the header: routing will pick one. The config
+    // schema the completion write parses with would refuse this.
+    markRequestStarted(
+      context({
+        ...arrived,
+        sa_config_pre_processed: { agent_name: 'helper', trace_id: 'trace-1' },
+      }),
+    );
+
+    expect(startLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        skill_id: null,
+        base_sa_config: { agent_name: 'helper' },
+      }),
+    );
+  });
+
+  it('writes the row again with the skill once routing has picked one', () => {
+    markRequestStarted(context({ ...arrived, skill }));
+
+    expect(startLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'request-1', skill_id: 'skill-1' }),
+    );
   });
 });
 

--- a/packages/api/src/middlewares/logs.test.ts
+++ b/packages/api/src/middlewares/logs.test.ts
@@ -6,7 +6,7 @@ import type {
   LogsStorageConnector,
   UserDataStorageConnector,
 } from '@api/types/connector';
-import type { AppEnv } from '@api/types/hono';
+import type { AppContext, AppEnv } from '@api/types/hono';
 import type { SkillRoutingDecision } from '@api/utils/super-agents/skill-routing';
 import { FunctionName } from '@shared/types/api/request';
 import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
@@ -81,9 +81,14 @@ describe('logsMiddleware', () => {
   let logsConnector: { createLog: ReturnType<typeof vi.fn> };
   let userData: UserDataStorageConnector;
   let app: Hono<AppEnv>;
+  /** What the handler under test leaves on the context, beyond the usual. */
+  let arrange: (c: AppContext) => void;
+  let providerLog: AIProviderRequestLog;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    arrange = () => undefined;
+    providerLog = { ...aiProviderLog };
     requestData = {
       functionName: FunctionName.CHAT_COMPLETE,
       method: HttpMethod.POST,
@@ -126,7 +131,8 @@ describe('logsMiddleware', () => {
         c.set('agent', agent);
         c.set('skill', skill);
         c.set('skill_routing', decision);
-        c.set('ai_provider_log', aiProviderLog);
+        c.set('ai_provider_log', providerLog);
+        arrange(c);
         // The handler splices the arm's prompt into the request it forwards.
         (requestData.requestBody as { messages: unknown[] }).messages[0] = {
           role: 'system',
@@ -160,6 +166,21 @@ describe('logsMiddleware', () => {
 
     const log = await storedLog();
     expect(log.metadata).toEqual({ skill_routing: decision });
+  });
+
+  it('records when a streamed answer ended, which its provider log could not know when written', async () => {
+    arrange = (c) => {
+      // The handler returned while the stream was still running.
+      c.set('stream_end_promise', Promise.resolve());
+      c.set('provider_end_time', 4321);
+    };
+
+    await app.request('/v1/chat/completions', { method: 'POST' });
+
+    const log = await storedLog();
+    expect(log.ai_provider_request_log).toEqual(
+      expect.objectContaining({ end_time: 4321 }),
+    );
   });
 
   it('records which configuration served the request', async () => {

--- a/packages/api/src/middlewares/logs.ts
+++ b/packages/api/src/middlewares/logs.ts
@@ -840,6 +840,12 @@ export const logsMiddleware = (
         await streamEndPromise;
       }
 
+      // A stream's provider log was written before the stream ended; when
+      // the provider finished answering is known only now.
+      if (aiProviderLog.end_time === undefined) {
+        aiProviderLog.end_time = c.get('provider_end_time');
+      }
+
       // For streaming requests, parse accumulated chunks and update the log
       const accumulatedChunks = c.get('accumulated_stream_chunks') as
         | string

--- a/packages/api/src/middlewares/logs.ts
+++ b/packages/api/src/middlewares/logs.ts
@@ -47,6 +47,7 @@ import { stripAgentSkillPath } from '@shared/utils/url';
 import type { MiddlewareHandler } from 'hono';
 import { getRuntimeKey } from 'hono/adapter';
 import type { Factory } from 'hono/factory';
+import { z } from 'zod';
 
 let logId = 0;
 const MAX_RESPONSE_LENGTH = 100000;
@@ -574,6 +575,38 @@ const shouldLogRequest = (url: URL): boolean => {
  * still open is touched, which is what makes this safe to call as a backstop
  * on a path that may already have completed the row.
  */
+/**
+ * The message inside a gateway error body, when it is one -- `{"error":
+ * "..."}` from the middlewares, `{"error":{"message":"..."}}` from the
+ * provider path -- and otherwise the body itself, cut to size. It is what
+ * the dashboard shows beside a failed row.
+ */
+const errorMessageFrom = (body: string): string => {
+  const fallback = body.slice(0, MAX_ERROR_LENGTH);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return fallback;
+  }
+  if (!parsed || typeof parsed !== 'object' || !('error' in parsed)) {
+    return fallback;
+  }
+  const { error: found } = parsed as { error: unknown };
+  if (typeof found === 'string') {
+    return found.slice(0, MAX_ERROR_LENGTH);
+  }
+  if (
+    found &&
+    typeof found === 'object' &&
+    'message' in found &&
+    typeof found.message === 'string'
+  ) {
+    return found.message.slice(0, MAX_ERROR_LENGTH);
+  }
+  return fallback;
+};
+
 const closeFailedRequest = async (
   c: AppContext,
   requestId: string,
@@ -592,7 +625,7 @@ const closeFailedRequest = async (
       message = await c.res
         .clone()
         .text()
-        .then((body) => body.slice(0, MAX_ERROR_LENGTH))
+        .then(errorMessageFrom)
         .catch(() => undefined);
     }
 
@@ -611,16 +644,26 @@ const closeFailedRequest = async (
 };
 
 /**
- * Announce a request that is about to be sent to a provider, so the dashboard
- * can show it as a pending row while it runs.
+ * Announce a request that is on its way to a provider, so the dashboard can
+ * show it as a pending row while it runs.
  *
- * Called from the agent-and-skill middleware rather than from here, because
- * this middleware's own pre-handler section runs before either has been
- * resolved and a pending row has to say which skill's logs it belongs in.
- * That puts skill routing inside the announced request's dead time -- an
- * ordinary lookup, though the arbiter can make it a slow one -- which is the
- * price of knowing the ids.
+ * Called from the agent-and-skill middleware twice: as soon as the agent is
+ * known, with no skill yet, and again once routing has picked one. The row
+ * is upserted, so the second call fills the skill in. Announcing before
+ * routing is what keeps its dead time -- embedding the request, compacting
+ * its prompt, the arbiter -- out of the wait for the row to appear, which is
+ * the row's whole purpose. This middleware's own pre-handler section cannot
+ * do it: it runs before the agent has been resolved.
  */
+/**
+ * The config as the arriving row records it. `skill_name` is optional here,
+ * unlike in `NonPrivateSuperAgentsConfig`: before routing there is none, and
+ * the completion write records the config with the skill routing chose.
+ */
+const ArrivingSuperAgentsConfig = NonPrivateSuperAgentsConfig.extend({
+  skill_name: z.string().optional(),
+});
+
 export const markRequestStarted = (c: AppContext): void => {
   // Nothing about a row that exists to be looked at is worth failing a
   // request over, and this runs on every request the gateway serves.
@@ -658,12 +701,13 @@ export const markRequestStarted = (c: AppContext): void => {
     const startParams: LogStartParams = {
       id: requestId,
       agent_id: c.get('agent').id,
-      skill_id: c.get('skill').id,
+      // Unset until routing has picked one; the second call fills it in.
+      skill_id: (c.get('skill') as Skill | undefined)?.id ?? null,
       method: saRequestData.method,
       endpoint: url.pathname,
       function_name: saRequestData.functionName,
       start_time: c.get('log_start_time') ?? Date.now(),
-      base_sa_config: NonPrivateSuperAgentsConfig.parse(saConfig),
+      base_sa_config: ArrivingSuperAgentsConfig.parse(saConfig),
       model,
       trace_id: saConfig.trace_id ?? undefined,
     };

--- a/packages/api/src/types/hono.ts
+++ b/packages/api/src/types/hono.ts
@@ -75,6 +75,13 @@ export interface AppEnv {
     hook_logs?: HookLog[];
     first_token_time?: number;
     stream_end_time?: number;
+    /**
+     * When the provider was asked, and when it had answered, for the attempt
+     * whose answer is being served; the log row's own times span the whole
+     * request. Set around the provider call, and kept on the provider log.
+     */
+    provider_start_time?: number;
+    provider_end_time?: number;
     stream_end_promise?: Promise<void>;
     accumulated_stream_chunks?: string;
     cache_storage_connector: CacheStorageConnector;

--- a/packages/api/src/types/hono.ts
+++ b/packages/api/src/types/hono.ts
@@ -64,9 +64,9 @@ export interface AppEnv {
     /** Set when the caller named only the agent and the gateway chose the skill. */
     skill_routing?: SkillRoutingDecision;
     /**
-     * Identifies this request to the in-flight registry, so the dashboard can
-     * pair the pending row it drew on arrival with the news that the request
-     * has finished. Set by the logs middleware before the handler runs.
+     * The id of the log row this request opens on arrival and completes at
+     * the end, so that the two writes land on one row. Set by the logs
+     * middleware before the handler runs.
      */
     log_request_id?: string;
     /** When the request arrived, shared by the row opened then and its completion. */

--- a/packages/api/src/utils/super-agents/feedback-reevaluation.ts
+++ b/packages/api/src/utils/super-agents/feedback-reevaluation.ts
@@ -30,17 +30,17 @@ export async function reevaluateLogFromFeedback(
     return;
   }
 
+  // Feedback can only be left on a request that answered, but the row is
+  // fetched by id and the type cannot know that.
+  if (!isCompletedLog(log)) {
+    return;
+  }
+
   const evaluations = await userDataConnector.getSkillOptimizationEvaluations(
     c,
     { agent_id: log.agent_id, skill_id: log.skill_id },
   );
   if (evaluations.length === 0) {
-    return;
-  }
-
-  // Feedback can only be left on a request that answered, but the row is
-  // fetched by id and the type cannot know that.
-  if (!isCompletedLog(log)) {
     return;
   }
 

--- a/packages/api/src/utils/super-agents/responses.test.ts
+++ b/packages/api/src/utils/super-agents/responses.test.ts
@@ -34,6 +34,7 @@ describe('createResponse', () => {
     // Mock context
     mockContext = {
       set: vi.fn(),
+      get: vi.fn(),
     } as unknown as AppContext;
 
     // Mock response
@@ -138,6 +139,45 @@ describe('createResponse', () => {
           cache_status: 'miss',
           cache_mode: CacheMode.DISABLED,
         }),
+      );
+    });
+
+    it('keeps when the provider was asked and answered on the log', async () => {
+      // What the handler left on the context around the provider call.
+      const timing: Record<string, number> = {
+        provider_start_time: 6000,
+        provider_end_time: 6250,
+      };
+      const context = {
+        set: vi.fn(),
+        get: (key: string) => timing[key],
+      } as unknown as AppContext;
+
+      await createResponse(context, mockOptions);
+
+      expect(context.set).toHaveBeenCalledWith(
+        'ai_provider_log',
+        expect.objectContaining({ start_time: 6000, end_time: 6250 }),
+      );
+    });
+
+    it('leaves a cache hit untimed, since it asked no provider', async () => {
+      // Timing left behind by a target tried before the hit.
+      const timing: Record<string, number> = {
+        provider_start_time: 6000,
+        provider_end_time: 6250,
+      };
+      const context = {
+        set: vi.fn(),
+        get: (key: string) => timing[key],
+      } as unknown as AppContext;
+      mockOptions.cacheStatus = 'HIT' as CacheStatus;
+
+      await createResponse(context, mockOptions);
+
+      expect(context.set).toHaveBeenCalledWith(
+        'ai_provider_log',
+        expect.not.objectContaining({ start_time: expect.anything() }),
       );
     });
 

--- a/packages/api/src/utils/super-agents/responses.ts
+++ b/packages/api/src/utils/super-agents/responses.ts
@@ -6,8 +6,8 @@ import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
 import type { SuperAgentsResponseBody } from '@shared/types/api/response';
 import type { AIProvider } from '@shared/types/constants';
 import type { AIProviderRequestLog } from '@shared/types/data';
-import type {
-  CacheSettings,
+import {
+  type CacheSettings,
   CacheStatus,
 } from '@shared/types/middleware/cache';
 
@@ -37,6 +37,22 @@ export interface CreateResponseOptions extends CommonRequestOptions {
   cacheKey?: string;
   responseAlreadyHandled?: boolean;
 }
+
+/**
+ * When the provider was asked and when it had answered, as the handler that
+ * called it left them on the context. A cache hit asked no provider, and any
+ * timing on the context then belongs to a target tried before it.
+ */
+const providerTiming = (
+  c: AppContext,
+  cacheStatus: CacheStatus,
+): Pick<AIProviderRequestLog, 'start_time' | 'end_time'> =>
+  cacheStatus === CacheStatus.HIT || cacheStatus === CacheStatus.SEMANTIC_HIT
+    ? {}
+    : {
+        start_time: c.get('provider_start_time'),
+        end_time: c.get('provider_end_time'),
+      };
 
 export async function createResponse(
   c: AppContext,
@@ -68,6 +84,7 @@ export async function createResponse(
       raw_response_body: '', // Placeholder for streaming responses
       cache_status: options.cacheStatus,
       cache_mode: options.cacheSettings.mode,
+      ...providerTiming(c, options.cacheStatus),
     };
 
     c.set('ai_provider_log', aiProviderLog);
@@ -135,6 +152,7 @@ export async function createResponse(
       raw_response_body: '', // Placeholder for streaming responses
       cache_status: options.cacheStatus,
       cache_mode: options.cacheSettings.mode,
+      ...providerTiming(c, options.cacheStatus),
     };
 
     c.set('ai_provider_log', aiProviderLog);
@@ -165,6 +183,7 @@ export async function createResponse(
     raw_response_body: mappedResponseCloneText,
     cache_status: options.cacheStatus,
     cache_mode: options.cacheSettings.mode,
+    ...providerTiming(c, options.cacheStatus),
   };
 
   c.set('ai_provider_log', aiProviderLog);

--- a/packages/shared/src/types/data/log.ts
+++ b/packages/shared/src/types/data/log.ts
@@ -25,6 +25,17 @@ export const AIProviderRequestLog = z.object({
   raw_response_body: z.string(),
   cache_mode: z.enum(CacheMode),
   cache_status: z.enum(CacheStatus),
+  /**
+   * When the provider was asked, and when it had finished answering, for the
+   * attempt whose answer this log records. The log row's own `start_time` and
+   * `end_time` span the whole request -- choosing the skill, embedding the
+   * request, the hooks, a reviewer -- which is the gateway's time rather than
+   * the model's; a measure of the model reads this pair instead. Absent on a
+   * cache hit, which asked no provider, and on a row written before the
+   * gateway recorded it.
+   */
+  start_time: z.number().optional(),
+  end_time: z.number().optional(),
 });
 
 export type AIProviderRequestLog = z.infer<typeof AIProviderRequestLog>;

--- a/packages/shared/src/types/data/log.ts
+++ b/packages/shared/src/types/data/log.ts
@@ -58,7 +58,12 @@ export const Log = z.object({
   // Base info
   id: z.uuid(),
   agent_id: z.uuid(),
-  skill_id: z.uuid(),
+  /**
+   * Null until routing has picked the skill, and for a request that failed
+   * before it did: the row is written when the request reaches its agent,
+   * which is before the skill is known.
+   */
+  skill_id: z.uuid().nullable(),
   cluster_id: z.uuid().nullable(),
   method: z.enum(HttpMethod),
   endpoint: z.string(),
@@ -135,6 +140,7 @@ export type Log = z.infer<typeof Log>;
  * stated in the types rather than assumed.
  */
 export const CompletedLog = Log.extend({
+  skill_id: z.uuid(),
   status: z.number(),
   end_time: z.number(),
   duration: z.number(),
@@ -148,6 +154,7 @@ export type CompletedLog = z.infer<typeof CompletedLog>;
 
 /** Whether the request this log describes has finished. */
 export const isCompletedLog = (log: Log): log is CompletedLog =>
+  log.skill_id !== null &&
   log.end_time !== null &&
   log.duration !== null &&
   log.status !== null &&
@@ -212,7 +219,8 @@ export type LogsQueryParams = z.infer<typeof LogsQueryParams>;
 export const LogStartParams = z.object({
   id: z.uuid(),
   agent_id: z.uuid(),
-  skill_id: z.uuid(),
+  /** Null when the row opens before routing; written again once it is known. */
+  skill_id: z.uuid().nullable(),
   method: z.enum(HttpMethod),
   endpoint: z.string(),
   function_name: z.enum(FunctionName),

--- a/packages/shared/src/types/sse.ts
+++ b/packages/shared/src/types/sse.ts
@@ -36,6 +36,8 @@ export const SSEEventType = z.enum([
    * A gateway request that has arrived and is still running. The dashboard
    * shows it as a pending row whose duration ticks up, so a request in
    * progress is visible rather than appearing only once it has finished.
+   * Sent as soon as the request reaches its agent, before a skill has been
+   * chosen, and again once one has.
    */
   'log:request-started',
   /** That request has finished; the pending row can go. */
@@ -60,31 +62,6 @@ export const SSEEventType = z.enum([
 ]);
 
 export type SSEEventType = z.infer<typeof SSEEventType>;
-
-/**
- * A gateway request that is currently running.
- *
- * Sent with `log:request-started`, and replayed for everything still in
- * flight when a client connects, so a reload does not lose the pending rows.
- *
- * Elapsed time is sent as a duration rather than as a start timestamp on
- * purpose: the browser's clock and the server's need not agree, and the
- * client only ever has to add its own elapsed time to this.
- */
-export const InFlightRequest = z.object({
-  request_id: z.string(),
-  agent_id: z.string(),
-  skill_id: z.string(),
-  method: z.string(),
-  endpoint: z.string(),
-  function_name: z.string(),
-  /** The model the caller asked for, when the request named one. */
-  model: z.string().nullable(),
-  /** How long it had been running when this was sent. */
-  elapsed_ms: z.number(),
-});
-
-export type InFlightRequest = z.infer<typeof InFlightRequest>;
 
 /**
  * SSE Event Data

--- a/packages/web/src/components/agents/agent-logs-view.tsx
+++ b/packages/web/src/components/agents/agent-logs-view.tsx
@@ -81,7 +81,15 @@ export function AgentLogsView(): ReactElement {
   const getSkillName = (log: Log): string | null =>
     skills.find((skill) => skill.id === log.skill_id)?.name ?? null;
 
-  const renderSkill = (log: Log) => <LogTagBadge value={getSkillName(log)} />;
+  // A running row with no skill is one routing has not placed yet.
+  const renderSkill = (log: Log) => (
+    <LogTagBadge
+      value={getSkillName(log)}
+      missing={
+        log.skill_id === null && log.end_time === null ? 'routing…' : '—'
+      }
+    />
+  );
 
   const renderPartition = (log: Log) => {
     if (!log.cluster_id) {

--- a/packages/web/src/components/agents/agent-recent-logs-card.tsx
+++ b/packages/web/src/components/agents/agent-recent-logs-card.tsx
@@ -89,6 +89,11 @@ export function AgentRecentLogsCard(): ReactElement | null {
                     value={
                       skills.find((skill) => skill.id === log.skill_id)?.name
                     }
+                    missing={
+                      log.skill_id === null && log.end_time === null
+                        ? 'routing…'
+                        : '—'
+                    }
                   />
                 ),
               }}

--- a/scripts/start-stub-provider.mjs
+++ b/scripts/start-stub-provider.mjs
@@ -26,6 +26,7 @@
  *   POST /__control/fence       {model} -- wrap structured output in a fence
  *   POST /__control/reply       {model, content} -- answer with this text instead;
  *                               an array is answered in order, the last one kept
+ *   POST /__control/delay       {model, ms} -- answer that much later; 0 lifts it
  *   POST /__control/reset       {model} -- forget everything for that model
  *
  * Configured with E2E_STUB_PORT (default 3103).
@@ -55,6 +56,8 @@ const failures = new Map();
  * rather than enforcing it.
  */
 const fenced = new Set();
+/** model name -> milliseconds every reply for it waits before answering. */
+const delays = new Map();
 
 const recordFor = (model) => {
   if (!received.has(model)) {
@@ -276,12 +279,24 @@ const server = createServer(async (request, response) => {
     return;
   }
 
+  if (url.pathname === '/__control/delay') {
+    const { model, ms } = JSON.parse((await readBody(request)) || '{}');
+    if (ms > 0) {
+      delays.set(model, Number(ms));
+    } else {
+      delays.delete(model);
+    }
+    sendJson(response, 200, { ok: true });
+    return;
+  }
+
   if (url.pathname === '/__control/reset') {
     const { model } = JSON.parse((await readBody(request)) || '{}');
     received.delete(model);
     failures.delete(model);
     fenced.delete(model);
     canned.delete(model);
+    delays.delete(model);
     sendJson(response, 200, { ok: true });
     return;
   }
@@ -297,6 +312,11 @@ const server = createServer(async (request, response) => {
 
   const model = body?.model ?? '';
   recordFor(model).push(body);
+
+  const delay = delays.get(model);
+  if (delay) {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
 
   const queued = failures.get(model);
   if (queued?.length) {

--- a/supabase/migrations/20250703100411_initial_schema.sql
+++ b/supabase/migrations/20250703100411_initial_schema.sql
@@ -181,7 +181,7 @@ CREATE TABLE IF NOT EXISTS logs (
   -- Base info
   id UUID PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
   agent_id UUID NOT NULL,
-  skill_id UUID NOT NULL,
+  skill_id UUID,
   cluster_id UUID,
   method http_method NOT NULL,
   endpoint TEXT NOT NULL,
@@ -242,6 +242,7 @@ CREATE INDEX idx_logs_cache_status ON logs(cache_status);
 ALTER TABLE logs ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "service_role_full_access" ON logs FOR ALL TO service_role USING (true) WITH CHECK (true);
 
+COMMENT ON COLUMN logs.skill_id IS 'Null until routing has picked the skill, and for a request that failed before it did: the row is written when the request reaches its agent';
 COMMENT ON COLUMN logs.start_time IS 'Timestamp in milliseconds when the request started';
 COMMENT ON COLUMN logs.first_token_time IS 'Timestamp in milliseconds when the first token was received (for streaming responses). NULL for non-streaming requests or if not captured.';
 COMMENT ON COLUMN logs.end_time IS 'Timestamp in milliseconds when the request completed';


### PR DESCRIPTION
## Problem

The latency evaluation scored the log row's span: `first_token_time - start_time` for a stream, `duration` otherwise. Both ends of that span are the gateway's, not the model's.

- `start_time` is stamped when the request arrives, before the skill is chosen. Embedding the request, compacting a long system prompt, the arbiter, the input hooks and the arm pull all sit inside it.
- `end_time` waits for the output hooks, so a reviewer's whole round trip counted too.
- A held stream was the worst case: unstreamed at the provider, it had no first token, so its entire duration, review included, was scored against the model.

So the score moved with the gateway's load and with the reviewer's speed, rather than with the configuration under test.

## Solution

The provider log (`ai_provider_request_log`) now carries a `start_time` and `end_time` of its own: when the attempt that answered was sent, and when its answer was in. The evaluation reads those.

- Streamed request: first token minus the moment the provider was asked.
- Plain request: the provider's whole answer, body fully read.
- Retries: only the attempt that answered counts. The retry handler reports when it was sent, so a 429 and the wait before the retry are treated as availability, not speed.
- Cache hits carry no timing, since no provider was asked.
- Logs written before this change fall back to the whole-request measure, and the result says so in its display text and in `extra_data.measured_from`.

Both fields are optional on the existing JSON column: no migration, on either backend.

## Also: the request shows on its agent before routing

While checking the running row, it turned out it only appeared once skill routing had finished: the row needed a `skill_id`, which was NOT NULL, and routing (embedding, compaction, the arbiter) runs before that point. A request that failed inside routing left no row at all.

- `logs.skill_id` is nullable on both backends. The agent-and-skill middleware announces the request as soon as the agent is looked up, and again once the skill is chosen; the row is an upsert, so the second write fills the skill in.
- The dashboard's skill column reads "routing…" for a running row with no skill.
- A request that fails before a provider is asked (a skill that does not exist, a routing failure) is closed as a failed row on the agent, carrying the error's message rather than the JSON it came wrapped in.
- The dev-database upgrade script (`pnpm db:upgrade`) rebuilds `logs` for the relaxed column. It also now carries every existing column across; it used to leave `error` behind.
- The dead `InFlightRequest` type from the earlier registry design is removed.

## Test notes

- Unit: evaluator prefers the provider's span and falls back for older logs; the retry handler reports the answering attempt's send time; `createResponse` keeps the span on the log and leaves a cache hit untimed; the logs middleware fills a stream's end once the stream has ended.
- e2e: `log-lifecycle` asserts the provider's span sits inside the row's for a plain and a streamed request. `optimizer` holds the reviewer for 1.5s (new `/__control/delay` control on the stub provider) and checks the row's duration grows while the provider's own span does not.
- Added: the API serves the row with no skill while the stub holds the embedding; a skill that does not exist leaves a 404 row with no skill and a plain message; the dashboard draws the running row live without a reload.
- `pnpm typecheck`, `pnpm check`, `pnpm test` (3223), api + contract:libsql + dashboard e2e (84) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jxn4UPg6eyAtWi2J9jE7AC

