### PR TITLE
Show every hook's verdict on a log, and the answer a hook withheld

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,7 +567,11 @@ client told exactly why is a client shown how to rephrase; on an agent,
 itself never reaches the client: it names the reviewer and carries every
 hook's reason, and is read from the log row. A hook that sets
 `response_body_override` has the client receive that body instead
-(`utils/hooks.ts`). Retrying on a 446 (`retry.on_status_codes`) asks the
+(`utils/hooks.ts`). The provider log on the row records what the client
+received, so a hook that withholds or replaces the response keeps the
+response it judged on its own hook log (`response_body`): that is where
+what the model actually wrote survives, and the log page shows it under
+the hook's verdict, beside the verdict of every hook that ran. Retrying on a 446 (`retry.on_status_codes`) asks the
 provider again. The `hook_results` block the handler merges into an allowed
 response does not reach the client either: the body is re-parsed against
 its response schema on the way out, which strips it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -571,7 +571,12 @@ hook's reason, and is read from the log row. A hook that sets
 received, so a hook that withholds or replaces the response keeps the
 response it judged on its own hook log (`response_body`): that is where
 what the model actually wrote survives, and the log page shows it under
-the hook's verdict, beside the verdict of every hook that ran. Retrying on a 446 (`retry.on_status_codes`) asks the
+the hook's verdict, beside the verdict of every hook that ran. A reviewer
+hook there links to the review its verdict came from -- found among the
+trace's logs by the reviewer's name and the hook's own span
+(`utils/reviews.ts`) -- which is also where the answer a log written
+before this kept nothing of can still be read, in what the reviewer was
+sent. Retrying on a 446 (`retry.on_status_codes`) asks the
 provider again. The `hook_results` block the handler merges into an allowed
 response does not reach the client either: the body is re-parsed against
 its response schema on the way out, which strips it.

--- a/e2e/contract/optimizer.spec.ts
+++ b/e2e/contract/optimizer.spec.ts
@@ -1136,6 +1136,71 @@ test.describe('response review', () => {
     expect(body.choices?.[0].message.content).toBe('I cannot share that.');
   });
 
+  test('keeps what the model wrote on the log when the reviewer withholds or replaces it', async ({
+    request,
+  }) => {
+    // The provider log records what the client was given -- the 446, or the
+    // replacement -- so the answer the reviewer objected to is kept on the
+    // reviewer's own hook log, which is where the dashboard reads it.
+    await stubReply(request, reviewerModel, deny);
+    const denied = await ask(request, 'keep the withheld answer');
+    expect(denied.status()).toBe(446);
+
+    await expect
+      .poll(() =>
+        logMentioning(request, reviewedSkillId, 'keep the withheld answer'),
+      )
+      .toBeDefined();
+    const withheld = await logMentioning(
+      request,
+      reviewedSkillId,
+      'keep the withheld answer',
+    );
+    expect(withheld?.hook_logs).toHaveLength(1);
+    expect(withheld?.hook_logs?.[0].result.deny_request).toBe(true);
+    expect(withheld?.hook_logs?.[0].result.reason).toBe('Leaks a credential.');
+    expect(
+      withheld?.hook_logs?.[0].response_body?.choices?.[0].message.content,
+    ).toBe('echo: keep the withheld answer');
+
+    await stubReply(request, reviewerModel, replace);
+    const replaced = await ask(request, 'keep the replaced answer');
+    expect(replaced.status()).toBe(200);
+
+    await expect
+      .poll(() =>
+        logMentioning(request, reviewedSkillId, 'keep the replaced answer'),
+      )
+      .toBeDefined();
+    const kept = await logMentioning(
+      request,
+      reviewedSkillId,
+      'keep the replaced answer',
+    );
+    expect(
+      kept?.hook_logs?.[0].response_body?.choices?.[0].message.content,
+    ).toBe('echo: keep the replaced answer');
+    expect(
+      kept?.hook_logs?.[0].result.response_body_override?.choices?.[0].message
+        .content,
+    ).toBe('I cannot share that.');
+
+    // An allowed answer is on the provider log already, and not kept twice.
+    await stubReply(request, reviewerModel, allow);
+    const allowed = await ask(request, 'keep nothing twice');
+    expect(allowed.status()).toBe(200);
+    await expect
+      .poll(() => logMentioning(request, reviewedSkillId, 'keep nothing twice'))
+      .toBeDefined();
+    const plain = await logMentioning(
+      request,
+      reviewedSkillId,
+      'keep nothing twice',
+    );
+    expect(plain?.hook_logs?.[0].result.deny_request).toBe(false);
+    expect(plain?.hook_logs?.[0].response_body).toBeUndefined();
+  });
+
   test('holds a stream until the review is done', async ({ request }) => {
     await stubReply(request, reviewerModel, allow);
 

--- a/e2e/dashboard/agents.spec.ts
+++ b/e2e/dashboard/agents.spec.ts
@@ -274,6 +274,61 @@ test.describe('live updates', () => {
 });
 
 test.describe('log page', () => {
+  test('shows every hook that judged the request, and the answer one withheld', async ({
+    page,
+    request,
+  }) => {
+    // A hook whose reviewer does not exist cannot run; failing closed, it
+    // withholds the answer. The page has to say so, and show the answer
+    // the model wrote, which the client never received.
+    const name = uniqueAgentName('hooked-page');
+    const agent = await createAgent(request, name);
+    const model = uniqueModelName('hooked');
+
+    try {
+      await createSkill(request, agent.id, 'gateway_skill');
+      const config = {
+        ...(JSON.parse(saConfig(name, 'gateway_skill', { model })) as Record<
+          string,
+          unknown
+        >),
+        hooks: [
+          {
+            id: 'reviewer:absent',
+            type: 'output',
+            hook_provider: 'agent',
+            config: { agent_name: `${name}-absent` },
+            fail_closed: true,
+          },
+        ],
+      };
+      const withheld = await request.post(CHAT_COMPLETIONS_PATH, {
+        headers: { 'sa-config': JSON.stringify(config) },
+        data: chatBody('say something withheld'),
+      });
+      expect(withheld.status()).toBe(446);
+
+      await page.goto(`/agents/${name}/logs`);
+      await page.getByText('Chat Complete').first().click();
+      await expect(page).toHaveURL(/\/logs\/[0-9a-f-]+$/);
+
+      const hooks = page.getByRole('region', { name: 'Hooks' });
+      await expect(hooks.getByText('reviewer:absent')).toBeVisible();
+      await expect(hooks.getByText('Denied', { exact: true })).toBeVisible();
+      await expect(hooks.getByText(/fails closed/)).toBeVisible();
+      await expect(
+        page.getByText('What the model wrote, withheld from the client'),
+      ).toBeVisible();
+      await expect(
+        page.getByText('echo: say something withheld').first(),
+      ).toBeVisible();
+      await expect(page.getByText('446', { exact: true })).toBeVisible();
+    } finally {
+      await stubReset(request, model);
+      await deleteAgent(request, agent.id);
+    }
+  });
+
   test('survives back and forward, which restore it around a destroyed editor', async ({
     page,
     request,

--- a/e2e/fixtures/logs.ts
+++ b/e2e/fixtures/logs.ts
@@ -15,7 +15,14 @@ export interface LoggedRequest {
   /** What each hook made of the request; a reviewer's verdict lands here. */
   hook_logs?: {
     hook: { id: string };
-    result: { deny_request: boolean; reason?: string; error?: string };
+    result: {
+      deny_request: boolean;
+      reason?: string;
+      error?: string;
+      response_body_override?: { choices?: { message: { content: string } }[] };
+    };
+    /** The response the hook withheld or replaced; absent when it allowed it. */
+    response_body?: { choices?: { message: { content: string } }[] };
   }[];
   start_time: number;
   end_time: number | null;

--- a/packages/api/src/middlewares/hooks.test.ts
+++ b/packages/api/src/middlewares/hooks.test.ts
@@ -267,6 +267,91 @@ describe('executeHooks logging', () => {
       expect(log.cache_status).toBe(CacheStatus.MISS);
       expect(log.duration).toBe(log.end_time - log.start_time);
       expect(log.result.reason).toBe('Fine.');
+      // An allowed response is on the provider log; it is not written twice.
+      expect(log.response_body).toBeUndefined();
     }
+  });
+
+  it('keeps the response a hook withheld on its log, since the client never sees it', async () => {
+    const connector: HooksConnector = {
+      name: HookProvider.AGENT,
+      executeHook: vi.fn().mockResolvedValue(verdict(true)),
+    };
+    const c = context([hook()], [connector]);
+
+    const [log] = await executeHooks(
+      c,
+      HookType.OUTPUT_HOOK,
+      200,
+      false,
+      requestData,
+      responseBody,
+    );
+
+    expect(log.response_body).toEqual(responseBody);
+  });
+
+  it('keeps the response a hook replaced, beside what it put in its place', async () => {
+    const replacement = { id: 'r', choices: [{ text: 'redacted' }] };
+    const connector: HooksConnector = {
+      name: HookProvider.AGENT,
+      executeHook: vi.fn().mockResolvedValue({
+        ...verdict(false),
+        response_body_override: replacement,
+      }),
+    };
+    const c = context([hook()], [connector]);
+
+    const [log] = await executeHooks(
+      c,
+      HookType.OUTPUT_HOOK,
+      200,
+      false,
+      requestData,
+      responseBody,
+    );
+
+    expect(log.response_body).toEqual(responseBody);
+    expect(log.result.response_body_override).toEqual(replacement);
+  });
+
+  it('keeps a withheld response when the hook failed closed, too', async () => {
+    const connector: HooksConnector = {
+      name: HookProvider.AGENT,
+      executeHook: vi.fn().mockRejectedValue(new Error('Reviewer unreachable')),
+    };
+    const c = context([hook({ fail_closed: true })], [connector]);
+
+    const [log] = await executeHooks(
+      c,
+      HookType.OUTPUT_HOOK,
+      200,
+      false,
+      requestData,
+      responseBody,
+    );
+
+    expect(log.result.deny_request).toBe(true);
+    expect(log.result.error).toBe('Reviewer unreachable');
+    expect(log.response_body).toEqual(responseBody);
+  });
+
+  it('keeps nothing on an input hook log: the request is on the provider log', async () => {
+    const connector: HooksConnector = {
+      name: HookProvider.AGENT,
+      executeHook: vi.fn().mockResolvedValue(verdict(true)),
+    };
+    const c = context([hook({ type: HookType.INPUT_HOOK })], [connector]);
+
+    const [log] = await executeHooks(
+      c,
+      HookType.INPUT_HOOK,
+      null,
+      false,
+      requestData,
+    );
+
+    expect(log.result.deny_request).toBe(true);
+    expect(log.response_body).toBeUndefined();
   });
 });

--- a/packages/api/src/middlewares/hooks.ts
+++ b/packages/api/src/middlewares/hooks.ts
@@ -74,6 +74,24 @@ async function executeHookByProvider(
   }
 }
 
+/**
+ * The response an output hook judged, when the client is not given it --
+ * withheld, or replaced with the hook's own text. The provider log records
+ * what the client received, so without this what the model actually wrote
+ * would be gone. An allowed response is on the provider log already, and is
+ * not written twice.
+ */
+const judgedResponse = (
+  hookType: HookType,
+  result: HookResult,
+  saResponseBody?: SuperAgentsResponseBody,
+): Pick<HookLog, 'response_body'> =>
+  hookType === HookType.OUTPUT_HOOK &&
+  saResponseBody !== undefined &&
+  (result.deny_request || result.response_body_override !== undefined)
+    ? { response_body: saResponseBody as Record<string, unknown> }
+    : {};
+
 function shouldSkipHook(
   hook: Hook,
   fn: FunctionName,
@@ -213,6 +231,7 @@ export async function executeHooks(
           trace_id: saConfig.trace_id,
           hook: hook,
           result: hookResult,
+          ...judgedResponse(hookType, hookResult, saResponseBody),
           start_time: startTime,
           end_time: endTime,
           duration: duration,

--- a/packages/api/src/utils/hooks.ts
+++ b/packages/api/src/utils/hooks.ts
@@ -7,6 +7,7 @@ import type { SuperAgentsResponseBody } from '@shared/types/api/response/body';
 import type { HookLog } from '@shared/types/data';
 
 import {
+  HOOK_DENIED_STATUS,
   type HookDenialResponseBody,
   HookType,
 } from '@shared/types/middleware/hooks';
@@ -59,7 +60,7 @@ export function hookDenialBody(denial: HookLog): HookDenialResponseBody {
 
 const denialResponse = (denial: HookLog): Response =>
   new Response(JSON.stringify(hookDenialBody(denial)), {
-    status: 446,
+    status: HOOK_DENIED_STATUS,
     headers: { 'content-type': 'application/json' },
   });
 

--- a/packages/shared/src/types/data/log.ts
+++ b/packages/shared/src/types/data/log.ts
@@ -45,6 +45,14 @@ export const HookLog = z.object({
   hook: Hook,
   result: HookResult,
   request_body: z.record(z.string(), z.unknown()).optional(),
+  /**
+   * The response an output hook judged, kept when the client was not given
+   * it: denied, or replaced with the hook's own text (which is
+   * `result.response_body_override`). The provider log records what the
+   * client received, so this is where what the model actually wrote
+   * survives. Absent when the hook allowed the response, which is on the
+   * provider log already.
+   */
   response_body: z.record(z.string(), z.unknown()).optional(),
   start_time: z.number(),
   end_time: z.number(),

--- a/packages/shared/src/types/middleware/hooks.ts
+++ b/packages/shared/src/types/middleware/hooks.ts
@@ -103,6 +103,17 @@ export const HookResult = z.object({
 export type HookResult = z.infer<typeof HookResult>;
 
 /**
+ * The status a denial is answered with. Not a registered HTTP status: it is
+ * the convention of the gateways this one descends from, chosen over 403 or
+ * 400 because SDKs read those as a key without permission or a malformed
+ * request, neither of which is true, while an unregistered 4xx is treated
+ * as a generic client error -- surfaced, not retried -- and can be named in
+ * `retry.on_status_codes` without also retrying real bad requests. A 200
+ * would be parsed as an answer, and an agent would act on the error text.
+ */
+export const HOOK_DENIED_STATUS = 446;
+
+/**
  * The body of the 446 a denial becomes. Its `error` is shaped like every
  * other gateway error, so a client SDK surfaces `message` as it would any
  * failure. The hook's own account of why appears -- in `reason`, and at the

--- a/packages/web/src/components/agents/skills/logs/components/hook-results.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/hook-results.test.tsx
@@ -1,0 +1,233 @@
+import type { HookLog } from '@shared/types/data/log';
+import { CacheMode, CacheStatus } from '@shared/types/middleware/cache';
+import {
+  type Hook,
+  HookProvider,
+  type HookResult,
+  HookType,
+} from '@shared/types/middleware/hooks';
+import { render, screen } from '@testing-library/react';
+import {
+  describeHookLog,
+  describeHookProvider,
+  HookResults,
+} from '@web/components/agents/skills/logs/components/hook-results';
+import { describe, expect, it } from 'vitest';
+
+const hookLog = (
+  result: Partial<HookResult> = {},
+  hook: Partial<Hook> = {},
+  extra: Partial<HookLog> = {},
+): HookLog => ({
+  trace_id: 'ses_1',
+  hook: {
+    id: 'reviewer:system-safety',
+    type: HookType.OUTPUT_HOOK,
+    hook_provider: HookProvider.AGENT,
+    config: { agent_name: 'system-safety' },
+    await: true,
+    cache_mode: CacheMode.DISABLED,
+    fail_closed: false,
+    expose_reason: false,
+    ...hook,
+  },
+  result: {
+    deny_request: false,
+    request_body_override: undefined,
+    response_body_override: undefined,
+    skipped: false,
+    ...result,
+  },
+  start_time: 1_000,
+  end_time: 8_142,
+  duration: 7_142,
+  cache_status: CacheStatus.MISS,
+  ...extra,
+});
+
+describe('describeHookLog', () => {
+  it('reads an allowed response as allowed', () => {
+    expect(describeHookLog(hookLog({ reason: 'Fine.' }))).toEqual({
+      verdict: 'allowed',
+      label: 'Allowed',
+      failure: null,
+    });
+  });
+
+  it('reads a denial as denied', () => {
+    expect(describeHookLog(hookLog({ deny_request: true }))).toEqual({
+      verdict: 'denied',
+      label: 'Denied',
+      failure: null,
+    });
+  });
+
+  it('tells a replacement and a rewrite from a denial', () => {
+    expect(
+      describeHookLog(
+        hookLog({
+          response_body_override: {
+            choices: [],
+          } as unknown as HookResult['response_body_override'],
+        }),
+      ).verdict,
+    ).toBe('replaced');
+    expect(
+      describeHookLog(
+        hookLog(
+          {
+            request_body_override: {
+              messages: [],
+            } as unknown as HookResult['request_body_override'],
+          },
+          { type: HookType.INPUT_HOOK },
+        ),
+      ).verdict,
+    ).toBe('rewrote');
+  });
+
+  it('reads a hook that could not run by what its failure did', () => {
+    const open = describeHookLog(hookLog({ error: 'Reviewer unreachable' }));
+    expect(open.verdict).toBe('failed');
+    expect(open.failure).toContain('went through unreviewed');
+
+    const closed = describeHookLog(
+      hookLog({ error: 'Reviewer unreachable', deny_request: true }),
+    );
+    expect(closed.verdict).toBe('denied');
+    expect(closed.failure).toContain('the response was withheld');
+  });
+
+  it('reads a skipped hook as skipped, whatever else it says', () => {
+    expect(
+      describeHookLog(hookLog({ skipped: true, deny_request: true })).verdict,
+    ).toBe('skipped');
+  });
+});
+
+describe('describeHookProvider', () => {
+  it('names the reviewer agent, and its skill when one was named', () => {
+    expect(describeHookProvider(hookLog().hook)).toBe('agent system-safety');
+    expect(
+      describeHookProvider(
+        hookLog({}, { config: { agent_name: 'guard', skill_name: 'policy' } })
+          .hook,
+      ),
+    ).toBe('agent guard / policy');
+  });
+
+  it('names an endpoint and a model by what they are', () => {
+    expect(
+      describeHookProvider(
+        hookLog(
+          {},
+          {
+            hook_provider: HookProvider.HTTP,
+            config: {
+              method: 'POST',
+              url: 'https://guard.example/check',
+            } as unknown as Hook['config'],
+          },
+        ).hook,
+      ),
+    ).toBe('POST https://guard.example/check');
+    expect(
+      describeHookProvider(
+        hookLog(
+          {},
+          {
+            hook_provider: HookProvider.LLM,
+            config: {
+              model: 'gpt-5.6-sol',
+              provider: 'openai',
+            } as unknown as Hook['config'],
+          },
+        ).hook,
+      ),
+    ).toBe('openai/gpt-5.6-sol');
+  });
+});
+
+describe('HookResults', () => {
+  it('shows a denial with its reason, who denied it, and how long it took', () => {
+    render(
+      <HookResults
+        hookLogs={[
+          hookLog(
+            { deny_request: true, reason: 'About to run gh pr checkout.' },
+            { expose_reason: true },
+          ),
+        ]}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Hooks' });
+    expect(panel).toHaveTextContent('Denied');
+    expect(panel).toHaveTextContent('reviewer:system-safety');
+    expect(panel).toHaveTextContent('on the response');
+    expect(panel).toHaveTextContent('agent system-safety');
+    expect(panel).toHaveTextContent('7.1s');
+    expect(panel).toHaveTextContent('About to run gh pr checkout.');
+    expect(panel).toHaveTextContent('The client was told this reason.');
+  });
+
+  it('says when the reason was kept from the client', () => {
+    render(
+      <HookResults
+        hookLogs={[hookLog({ deny_request: true, reason: 'Leaks a secret.' })]}
+      />,
+    );
+
+    expect(screen.getByRole('region', { name: 'Hooks' })).toHaveTextContent(
+      'The client was told which hook withheld it, not why.',
+    );
+  });
+
+  it('shows an allowed response as allowed, so every hook that ran is seen', () => {
+    render(
+      <HookResults
+        hookLogs={[
+          hookLog({ reason: 'Nothing to object to.' }),
+          hookLog({ skipped: true }, { id: 'gate', type: HookType.INPUT_HOOK }),
+        ]}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Hooks' });
+    expect(panel).toHaveTextContent('Allowed');
+    expect(panel).toHaveTextContent('Nothing to object to.');
+    expect(panel).toHaveTextContent('Skipped');
+    expect(panel).toHaveTextContent('gate');
+    expect(panel).toHaveTextContent('on the request');
+  });
+
+  it('shows the error of a hook that could not run, and what that did', () => {
+    render(
+      <HookResults
+        hookLogs={[
+          hookLog(
+            { error: 'The reviewer "guard" did not answer with a verdict' },
+            { fail_closed: false },
+          ),
+        ]}
+      />,
+    );
+
+    const panel = screen.getByRole('region', { name: 'Hooks' });
+    expect(panel).toHaveTextContent('Could not run');
+    expect(panel).toHaveTextContent(
+      'The reviewer "guard" did not answer with a verdict',
+    );
+    expect(panel).toHaveTextContent('went through unreviewed');
+  });
+
+  it('marks a verdict served from the cache', () => {
+    render(
+      <HookResults
+        hookLogs={[hookLog({}, {}, { cache_status: CacheStatus.HIT })]}
+      />,
+    );
+
+    expect(screen.getByText('cached verdict')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/agents/skills/logs/components/hook-results.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/hook-results.test.tsx
@@ -1,4 +1,4 @@
-import type { HookLog } from '@shared/types/data/log';
+import type { HookLog, Log } from '@shared/types/data/log';
 import { CacheMode, CacheStatus } from '@shared/types/middleware/cache';
 import {
   type Hook,
@@ -6,13 +6,13 @@ import {
   type HookResult,
   HookType,
 } from '@shared/types/middleware/hooks';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import {
   describeHookLog,
   describeHookProvider,
   HookResults,
 } from '@web/components/agents/skills/logs/components/hook-results';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 const hookLog = (
   result: Partial<HookResult> = {},
@@ -219,6 +219,66 @@ describe('HookResults', () => {
       'The reviewer "guard" did not answer with a verdict',
     );
     expect(panel).toHaveTextContent('went through unreviewed');
+  });
+
+  it('links a reviewer hook to the review its verdict came from', () => {
+    const review = { id: 'review-1' } as Log;
+    const onOpenReview = vi.fn();
+    render(
+      <HookResults
+        hookLogs={[hookLog({ deny_request: true })]}
+        reviewOf={() => review}
+        onOpenReview={onOpenReview}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Open the review/ }));
+
+    expect(onOpenReview).toHaveBeenCalledWith(review, 'system-safety');
+  });
+
+  it('offers no link when the review is not known', () => {
+    render(
+      <HookResults
+        hookLogs={[hookLog({ deny_request: true })]}
+        reviewOf={() => undefined}
+        onOpenReview={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /Open the review/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('says when a withheld answer was not kept, and where it can still be read', () => {
+    const denied = hookLog({ deny_request: true });
+    const { rerender } = render(
+      <HookResults
+        hookLogs={[denied]}
+        reviewOf={() => ({ id: 'r' }) as Log}
+        onOpenReview={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('region', { name: 'Hooks' })).toHaveTextContent(
+      'What the model wrote was not kept on this log, which predates that; the review shows what the reviewer was sent.',
+    );
+
+    // Kept on the log: nothing to apologise for.
+    rerender(
+      <HookResults
+        hookLogs={[
+          hookLog(
+            { deny_request: true },
+            {},
+            { response_body: { choices: [] } },
+          ),
+        ]}
+      />,
+    );
+    expect(screen.getByRole('region', { name: 'Hooks' })).not.toHaveTextContent(
+      'was not kept',
+    );
   });
 
   it('marks a verdict served from the cache', () => {

--- a/packages/web/src/components/agents/skills/logs/components/hook-results.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/hook-results.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { HookLog } from '@shared/types/data/log';
+import type { HookLog, Log } from '@shared/types/data/log';
 import { CacheStatus } from '@shared/types/middleware/cache';
 import {
   type Hook,
@@ -8,7 +8,9 @@ import {
   HookType,
 } from '@shared/types/middleware/hooks';
 import { Badge } from '@web/components/ui/badge';
+import { Button } from '@web/components/ui/button';
 import { formatDuration } from '@web/utils/time';
+import { ArrowUpRightIcon } from 'lucide-react';
 import type { ReactElement } from 'react';
 
 /** What a hook made of the request or the response, in a word. */
@@ -113,15 +115,32 @@ function reasonAudience(log: HookLog, outcome: HookOutcome): string | null {
 }
 
 /**
+ * Whether the answer this hook withheld or replaced was lost: a log written
+ * before the gateway kept it on the hook log has only the review to show
+ * what the model wrote.
+ */
+const judgedResponseLost = (log: HookLog, outcome: HookOutcome): boolean =>
+  log.hook.type === HookType.OUTPUT_HOOK &&
+  (outcome.verdict === 'denied' || outcome.verdict === 'replaced') &&
+  log.response_body === undefined;
+
+/**
  * Every hook that judged the request, with its verdict, however it went:
  * a request that was allowed through shows who allowed it and why, just as
  * a withheld one shows who withheld it. The response a hook withheld or
- * replaced is drawn with the conversation, not here.
+ * replaced is drawn with the conversation, not here. A reviewer hook links
+ * to the review its verdict came from, where what the reviewer was shown
+ * and said can be read in full.
  */
 export function HookResults({
   hookLogs,
+  reviewOf,
+  onOpenReview,
 }: {
   hookLogs: HookLog[];
+  /** The review a reviewer hook's verdict came from, when it is known. */
+  reviewOf?: (log: HookLog) => Log | undefined;
+  onOpenReview?: (review: Log, reviewerName: string) => void;
 }): ReactElement {
   return (
     <section
@@ -134,6 +153,14 @@ export function HookResults({
       {hookLogs.map((log) => {
         const outcome = describeHookLog(log);
         const audience = reasonAudience(log, outcome);
+        const review = reviewOf?.(log);
+        const reviewer =
+          'agent_name' in log.hook.config ? log.hook.config.agent_name : null;
+        const lost = judgedResponseLost(log, outcome)
+          ? review
+            ? 'What the model wrote was not kept on this log, which predates that; the review shows what the reviewer was sent.'
+            : 'What the model wrote was not kept on this log, which predates that.'
+          : null;
         return (
           <div
             key={`${log.hook.type}-${log.hook.id}-${log.start_time}`}
@@ -165,6 +192,17 @@ export function HookResults({
                   cached verdict
                 </Badge>
               )}
+              {review && reviewer && onOpenReview && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs ml-auto"
+                  onClick={() => onOpenReview(review, reviewer)}
+                >
+                  Open the review
+                  <ArrowUpRightIcon className="h-3 w-3" />
+                </Button>
+              )}
             </div>
             {log.result.reason && (
               <p className="text-sm whitespace-pre-wrap leading-relaxed">
@@ -176,9 +214,9 @@ export function HookResults({
                 {log.result.error}
               </p>
             )}
-            {(outcome.failure || audience) && (
+            {(outcome.failure || audience || lost) && (
               <p className="text-xs text-muted-foreground">
-                {[outcome.failure, audience].filter(Boolean).join(' ')}
+                {[outcome.failure, audience, lost].filter(Boolean).join(' ')}
               </p>
             )}
           </div>

--- a/packages/web/src/components/agents/skills/logs/components/hook-results.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/hook-results.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import type { HookLog } from '@shared/types/data/log';
+import { CacheStatus } from '@shared/types/middleware/cache';
+import {
+  type Hook,
+  HookProvider,
+  HookType,
+} from '@shared/types/middleware/hooks';
+import { Badge } from '@web/components/ui/badge';
+import { formatDuration } from '@web/utils/time';
+import type { ReactElement } from 'react';
+
+/** What a hook made of the request or the response, in a word. */
+export type HookVerdict =
+  | 'allowed'
+  | 'denied'
+  | 'replaced'
+  | 'rewrote'
+  | 'skipped'
+  | 'failed';
+
+export interface HookOutcome {
+  verdict: HookVerdict;
+  /** The verdict as it is shown. */
+  label: string;
+  /**
+   * What the failure meant, when the hook could not run: the request went
+   * through unreviewed, or was withheld for it. Null for a hook that ran.
+   */
+  failure: string | null;
+}
+
+/**
+ * A hook log read as an outcome. A hook that could not run is a different
+ * kind of news from one that objected, so its error is reported as such,
+ * with what the failure did to the request -- which depends on whether the
+ * hook fails open or closed.
+ */
+export function describeHookLog(log: HookLog): HookOutcome {
+  const { hook, result } = log;
+  const subject = hook.type === HookType.INPUT_HOOK ? 'request' : 'response';
+  if (result.skipped) {
+    return { verdict: 'skipped', label: 'Skipped', failure: null };
+  }
+  if (result.error !== undefined) {
+    return result.deny_request
+      ? {
+          verdict: 'denied',
+          label: 'Denied',
+          failure: `The hook could not run and fails closed, so the ${subject} was withheld.`,
+        }
+      : {
+          verdict: 'failed',
+          label: 'Could not run',
+          failure: `The hook fails open, so the ${subject} went through unreviewed.`,
+        };
+  }
+  if (result.deny_request) {
+    return { verdict: 'denied', label: 'Denied', failure: null };
+  }
+  if (result.response_body_override !== undefined) {
+    return { verdict: 'replaced', label: 'Replaced', failure: null };
+  }
+  if (result.request_body_override !== undefined) {
+    return { verdict: 'rewrote', label: 'Rewrote the request', failure: null };
+  }
+  return { verdict: 'allowed', label: 'Allowed', failure: null };
+}
+
+/** Who the hook asked: the reviewer agent, the endpoint, or the model. */
+export function describeHookProvider(hook: Hook): string {
+  const config = hook.config;
+  switch (hook.hook_provider) {
+    case HookProvider.AGENT:
+      if ('agent_name' in config) {
+        return config.skill_name
+          ? `agent ${config.agent_name} / ${config.skill_name}`
+          : `agent ${config.agent_name}`;
+      }
+      return 'agent';
+    case HookProvider.HTTP:
+      return 'url' in config ? `${config.method} ${config.url}` : 'http';
+    case HookProvider.LLM:
+      return 'model' in config ? `${config.provider}/${config.model}` : 'llm';
+    default:
+      return hook.hook_provider;
+  }
+}
+
+const VERDICT_VARIANT: Record<
+  HookVerdict,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  allowed: 'outline',
+  denied: 'destructive',
+  replaced: 'secondary',
+  rewrote: 'secondary',
+  skipped: 'outline',
+  failed: 'secondary',
+};
+
+/**
+ * What the hook's reason did: a denial's reason reaches the client only
+ * where the hook exposes it, and the difference is worth seeing here, since
+ * this panel is where the reason is read either way.
+ */
+function reasonAudience(log: HookLog, outcome: HookOutcome): string | null {
+  if (outcome.verdict !== 'denied') return null;
+  return log.hook.expose_reason
+    ? 'The client was told this reason.'
+    : 'The client was told which hook withheld it, not why.';
+}
+
+/**
+ * Every hook that judged the request, with its verdict, however it went:
+ * a request that was allowed through shows who allowed it and why, just as
+ * a withheld one shows who withheld it. The response a hook withheld or
+ * replaced is drawn with the conversation, not here.
+ */
+export function HookResults({
+  hookLogs,
+}: {
+  hookLogs: HookLog[];
+}): ReactElement {
+  return (
+    <section
+      aria-label="Hooks"
+      className="px-4 py-3 space-y-2 bg-muted/30 border-b"
+    >
+      <div className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        Hooks
+      </div>
+      {hookLogs.map((log) => {
+        const outcome = describeHookLog(log);
+        const audience = reasonAudience(log, outcome);
+        return (
+          <div
+            key={`${log.hook.type}-${log.hook.id}-${log.start_time}`}
+            className="bg-background rounded-md border px-3 py-2 space-y-1"
+          >
+            <div className="flex flex-row flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+              <Badge
+                variant={VERDICT_VARIANT[outcome.verdict]}
+                className="h-5 px-2 py-0 text-xs"
+              >
+                {outcome.label}
+              </Badge>
+              <span className="font-mono">{log.hook.id}</span>
+              <span className="text-muted-foreground">
+                {log.hook.type === HookType.INPUT_HOOK
+                  ? 'on the request'
+                  : 'on the response'}
+              </span>
+              <span className="text-muted-foreground">·</span>
+              <span className="text-muted-foreground">
+                {describeHookProvider(log.hook)}
+              </span>
+              <span className="text-muted-foreground">·</span>
+              <span className="font-mono tabular-nums text-muted-foreground">
+                {formatDuration(log.duration)}
+              </span>
+              {log.cache_status === CacheStatus.HIT && (
+                <Badge variant="outline" className="h-5 px-2 py-0 text-xs">
+                  cached verdict
+                </Badge>
+              )}
+            </div>
+            {log.result.reason && (
+              <p className="text-sm whitespace-pre-wrap leading-relaxed">
+                {log.result.reason}
+              </p>
+            )}
+            {log.result.error !== undefined && (
+              <p className="text-sm text-destructive whitespace-pre-wrap leading-relaxed">
+                {log.result.error}
+              </p>
+            )}
+            {(outcome.failure || audience) && (
+              <p className="text-xs text-muted-foreground">
+                {[outcome.failure, audience].filter(Boolean).join(' ')}
+              </p>
+            )}
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/packages/web/src/components/agents/skills/logs/components/session-map.test.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/session-map.test.tsx
@@ -1,9 +1,6 @@
 import type { Log } from '@shared/types/data/log';
 import { fireEvent, render, screen } from '@testing-library/react';
-import {
-  formatDuration,
-  SessionMap,
-} from '@web/components/agents/skills/logs/components/session-map';
+import { SessionMap } from '@web/components/agents/skills/logs/components/session-map';
 import { describe, expect, it, vi } from 'vitest';
 
 const log = (id: string, start_time: number, extra: Partial<Log> = {}): Log =>
@@ -115,15 +112,5 @@ describe('SessionMap', () => {
     expect(screen.getByText('3+ requests')).toBeInTheDocument();
     // With the window cut, a position would be a guess
     expect(screen.queryByText(/of 3/)).not.toBeInTheDocument();
-  });
-});
-
-describe('formatDuration', () => {
-  it('reads as a request, or as a whole session', () => {
-    expect(formatDuration(320)).toBe('320ms');
-    expect(formatDuration(16_771)).toBe('16.8s');
-    expect(formatDuration(252_000)).toBe('4m 12s');
-    expect(formatDuration(240_000)).toBe('4m');
-    expect(formatDuration(5_400_000)).toBe('1h 30m');
   });
 });

--- a/packages/web/src/components/agents/skills/logs/components/session-map.tsx
+++ b/packages/web/src/components/agents/skills/logs/components/session-map.tsx
@@ -2,25 +2,11 @@
 
 import type { Log } from '@shared/types/data/log';
 import { Button } from '@web/components/ui/button';
-import { formatClockTime } from '@web/utils/time';
+import { formatClockTime, formatDuration } from '@web/utils/time';
 import { cn } from '@web/utils/ui/utils';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import type { ReactElement } from 'react';
 import { useEffect, useRef } from 'react';
-
-/** A length of time, in the unit a reader would say: a request's, or a session's */
-export function formatDuration(ms: number): string {
-  if (ms < 1_000) return `${Math.round(ms)}ms`;
-  if (ms < 60_000) return `${(ms / 1_000).toFixed(1)}s`;
-  if (ms < 3_600_000) {
-    const minutes = Math.floor(ms / 60_000);
-    const seconds = Math.round((ms % 60_000) / 1_000);
-    return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
-  }
-  const hours = Math.floor(ms / 3_600_000);
-  const minutes = Math.floor((ms % 3_600_000) / 60_000);
-  return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
-}
 
 /** The score a request has to reach to count as good; the logs table's line too */
 const GOOD_SCORE = 0.7;

--- a/packages/web/src/components/agents/skills/logs/log-details-view.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-details-view.tsx
@@ -4,10 +4,16 @@ import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
 import { type AIProvider, PrettyAIProvider } from '@shared/types/constants';
 import type { Log } from '@shared/types/data/log';
 import { EvaluationMethodName } from '@shared/types/evaluations';
+import { HOOK_DENIED_STATUS } from '@shared/types/middleware/hooks';
 import { produceSuperAgentsRequestData } from '@shared/utils/sa-request-data';
 import { extractSystemPrompt } from '@shared/utils/system-prompt';
+import { LogStatusBadge } from '@web/components/agents/log-cells';
 import { CompletionViewer } from '@web/components/agents/skills/logs/components/completion-viewer';
 import { GenericViewer } from '@web/components/agents/skills/logs/components/generic-viewer';
+import {
+  describeHookLog,
+  HookResults,
+} from '@web/components/agents/skills/logs/components/hook-results';
 import { MessagesView } from '@web/components/agents/skills/logs/components/messages-view';
 import { SessionMap } from '@web/components/agents/skills/logs/components/session-map';
 import { LogFeedback } from '@web/components/agents/skills/logs/log-feedback';
@@ -36,7 +42,7 @@ import {
   describeSystemPromptOrigin,
   readServedConfiguration,
 } from '@web/utils/system-prompt-origin';
-import { formatLogTimestamp } from '@web/utils/time';
+import { formatDuration, formatLogTimestamp } from '@web/utils/time';
 import {
   AlertTriangle,
   ArrowLeftIcon,
@@ -228,6 +234,45 @@ export function LogDetailsView(): ReactElement {
     }
   }, [selectedLog]);
 
+  // How long the provider itself took, when the gateway recorded it: the
+  // rest of the request's time was routing, hooks and review.
+  const providerSpan = useMemo(() => {
+    const provider = selectedLog?.ai_provider_request_log;
+    return provider?.start_time !== undefined && provider.end_time !== undefined
+      ? formatDuration(provider.end_time - provider.start_time)
+      : null;
+  }, [selectedLog?.ai_provider_request_log]);
+
+  // What the model wrote when the client did not receive it. A hook keeps
+  // the response it withheld or replaced on its own log, since the provider
+  // log records what the client was given; drawn with the conversation, as
+  // the answer it was.
+  const judgedResponses = useMemo(() => {
+    const provider = selectedLog?.ai_provider_request_log;
+    if (!selectedLog || !provider) return [];
+    return selectedLog.hook_logs.flatMap((hookLog) => {
+      if (!hookLog.response_body) return [];
+      try {
+        return [
+          {
+            hookLog,
+            outcome: describeHookLog(hookLog),
+            saRequestData: produceSuperAgentsRequestData(
+              provider.method,
+              provider.request_url,
+              {},
+              provider.request_body,
+              hookLog.response_body,
+            ),
+          },
+        ];
+      } catch (error) {
+        console.error('Failed to parse the response a hook judged:', error);
+        return [];
+      }
+    });
+  }, [selectedLog]);
+
   // The prompt the client sent. Only worth a panel of its own when it differs
   // from what reached the provider; otherwise it is the system message below.
   const originalSystemPrompt = useMemo(() => {
@@ -376,6 +421,39 @@ export function LogDetailsView(): ReactElement {
                   {formatLogTimestamp(selectedLog.start_time)}
                 </span>
               </HeaderItem>
+              <HeaderSeparator />
+              <HeaderItem
+                label="Status:"
+                title={
+                  selectedLog.status === HOOK_DENIED_STATUS
+                    ? 'The response was withheld by a hook'
+                    : undefined
+                }
+              >
+                <LogStatusBadge log={selectedLog} />
+              </HeaderItem>
+              {selectedLog.duration !== null && (
+                <>
+                  <HeaderSeparator />
+                  <HeaderItem
+                    label="Took:"
+                    title={
+                      providerSpan
+                        ? `The provider itself took ${providerSpan}; the rest was routing, hooks and review`
+                        : undefined
+                    }
+                  >
+                    <span className="font-mono tabular-nums">
+                      {formatDuration(selectedLog.duration)}
+                    </span>
+                    {providerSpan && (
+                      <span className="text-muted-foreground">
+                        (provider {providerSpan})
+                      </span>
+                    )}
+                  </HeaderItem>
+                </>
+              )}
               {logSkillName && selectedAgent && (
                 <>
                   <HeaderSeparator />
@@ -622,6 +700,9 @@ export function LogDetailsView(): ReactElement {
               })}
             </div>
           )}
+          {selectedLog.hook_logs.length > 0 && (
+            <HookResults hookLogs={selectedLog.hook_logs} />
+          )}
           <CardContent className="flex flex-row p-0 h-full relative overflow-hidden">
             {selectedLog.trace_id && session.logs.length > 1 && (
               <SessionMap
@@ -687,6 +768,38 @@ export function LogDetailsView(): ReactElement {
                     }
                   />
                 )}
+                {selectedLog &&
+                  judgedResponses.map(
+                    ({ hookLog, outcome, saRequestData: judged }) => (
+                      <div
+                        key={`${hookLog.hook.id}-${hookLog.start_time}`}
+                        className="flex flex-col gap-2"
+                        data-testid="judged-response"
+                      >
+                        <div className="flex flex-row flex-wrap items-center justify-end gap-2 text-xs text-muted-foreground">
+                          <span>
+                            {outcome.verdict === 'replaced'
+                              ? 'What the model wrote, before the hook replaced it'
+                              : 'What the model wrote, withheld from the client'}
+                          </span>
+                          <Badge
+                            variant={
+                              outcome.verdict === 'replaced'
+                                ? 'secondary'
+                                : 'destructive'
+                            }
+                            className={HEADER_BADGE}
+                          >
+                            {outcome.label} by {hookLog.hook.id}
+                          </Badge>
+                        </div>
+                        <CompletionViewer
+                          logId={`${selectedLog.id}-${hookLog.hook.id}`}
+                          saRequestData={judged}
+                        />
+                      </div>
+                    ),
+                  )}
                 {selectedLog &&
                   saRequestData &&
                   selectedLog.ai_provider_request_log?.response_body &&

--- a/packages/web/src/components/agents/skills/logs/log-details-view.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-details-view.tsx
@@ -26,6 +26,7 @@ import { Separator } from '@web/components/ui/separator';
 import { Skeleton } from '@web/components/ui/skeleton';
 import { useLogSession } from '@web/hooks/use-log-session';
 import { usePinnedToBottom } from '@web/hooks/use-pinned-to-bottom';
+import { useReviewsOf } from '@web/hooks/use-reviews';
 import { useSmartBack } from '@web/hooks/use-smart-back';
 import { useAgents } from '@web/providers/agents';
 import { useLogs } from '@web/providers/logs';
@@ -34,6 +35,7 @@ import { useSkillOptimizationClusters } from '@web/providers/skill-optimization-
 import { useSkillOptimizationEvaluationRuns } from '@web/providers/skill-optimization-evaluation-runs';
 import { useSkills } from '@web/providers/skills';
 import { createSkillAvatar } from '@web/utils/avatars';
+import { reviewOf } from '@web/utils/reviews';
 import {
   describeSkillRouting,
   readSkillRouting,
@@ -100,8 +102,11 @@ export function LogDetailsView(): ReactElement {
   const { skills, setQueryParams: setSkillQueryParams } = useSkills();
   const { selectedLog, newerLog, olderLog, isLoading, setAgentId, setSkillId } =
     useLogs();
-  const { replaceToLogDetail, navigateToSkillDashboard } = useNavigation();
+  const { replaceToLogDetail, navigateToLogDetail, navigateToSkillDashboard } =
+    useNavigation();
   const session = useLogSession(selectedLog);
+  // The reviews a reviewer hook's verdicts came from, under their agents
+  const reviews = useReviewsOf(selectedLog);
   const { clusters, setSkillId: setClustersSkillId } =
     useSkillOptimizationClusters();
   const {
@@ -701,7 +706,13 @@ export function LogDetailsView(): ReactElement {
             </div>
           )}
           {selectedLog.hook_logs.length > 0 && (
-            <HookResults hookLogs={selectedLog.hook_logs} />
+            <HookResults
+              hookLogs={selectedLog.hook_logs}
+              reviewOf={(hookLog) => reviewOf(hookLog, reviews)}
+              onOpenReview={(review, reviewer) =>
+                navigateToLogDetail(reviewer, review.id)
+              }
+            />
           )}
           <CardContent className="flex flex-row p-0 h-full relative overflow-hidden">
             {selectedLog.trace_id && session.logs.length > 1 && (

--- a/packages/web/src/hooks/use-reviews.ts
+++ b/packages/web/src/hooks/use-reviews.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { type Log, LogsQueryParams } from '@shared/types/data/log';
+import { HookProvider } from '@shared/types/middleware/hooks';
+import { useQuery } from '@tanstack/react-query';
+import { queryLogs } from '@web/api/v1/super-agents/observability/logs';
+import { logsQueryKeys } from '@web/providers/logs';
+import { reviewsAmong } from '@web/utils/reviews';
+
+/** More reviews than a request has hooks to ask for. */
+const REVIEWS_WINDOW = 50;
+
+/**
+ * The reviews of a log: the requests its reviewer hooks sent, which are
+ * logs of their own under the reviewers' agents. They share the reviewed
+ * request's trace and start within its span, so that is what is asked
+ * for -- across agents, since the reviewer is never the reviewed agent --
+ * and only for a log that had a reviewer hook at all.
+ */
+export function useReviewsOf(log: Log | undefined): Log[] {
+  const reviewed =
+    !!log?.trace_id &&
+    log.hook_logs.some(
+      (hookLog) => hookLog.hook.hook_provider === HookProvider.AGENT,
+    );
+  const { data = [] } = useQuery({
+    queryKey: [
+      ...logsQueryKeys.all,
+      'reviews',
+      log?.trace_id,
+      log?.id,
+      log?.end_time,
+    ] as const,
+    queryFn: async () => {
+      if (!log?.trace_id) return [];
+      const rows = await queryLogs(
+        LogsQueryParams.parse({
+          trace_id: log.trace_id,
+          after: String(log.start_time),
+          ...(log.end_time !== null ? { before: String(log.end_time) } : {}),
+          order: 'asc',
+          limit: String(REVIEWS_WINDOW),
+        }),
+      );
+      return reviewsAmong(rows);
+    },
+    enabled: reviewed,
+  });
+  return data;
+}

--- a/packages/web/src/utils/reviews.test.ts
+++ b/packages/web/src/utils/reviews.test.ts
@@ -1,0 +1,87 @@
+import type { HookLog, Log } from '@shared/types/data/log';
+import { CacheMode, CacheStatus } from '@shared/types/middleware/cache';
+import {
+  type Hook,
+  HookProvider,
+  HookType,
+} from '@shared/types/middleware/hooks';
+import { reviewOf, reviewsAmong } from '@web/utils/reviews';
+import { describe, expect, it } from 'vitest';
+
+const hookLog = (hook: Partial<Hook> = {}, extra: Partial<HookLog> = {}) =>
+  ({
+    trace_id: 'ses_1',
+    hook: {
+      id: 'reviewer:guard',
+      type: HookType.OUTPUT_HOOK,
+      hook_provider: HookProvider.AGENT,
+      config: { agent_name: 'guard' },
+      await: true,
+      cache_mode: CacheMode.DISABLED,
+      fail_closed: false,
+      expose_reason: false,
+      ...hook,
+    },
+    result: {
+      deny_request: true,
+      request_body_override: undefined,
+      response_body_override: undefined,
+      skipped: false,
+    },
+    start_time: 1_000,
+    end_time: 8_000,
+    duration: 7_000,
+    cache_status: CacheStatus.MISS,
+    ...extra,
+  }) as HookLog;
+
+const review = (id: string, start_time: number, agent_name = 'guard') =>
+  ({
+    id,
+    start_time,
+    span_name: 'review',
+    base_sa_config: { agent_name },
+  }) as unknown as Log;
+
+describe('reviewOf', () => {
+  it('finds the review the reviewer answered while the hook ran', () => {
+    const reviews = [review('earlier', 500), review('mine', 1_200)];
+
+    expect(reviewOf(hookLog(), reviews)?.id).toBe('mine');
+  });
+
+  it('tells the reviews of two reviewer agents apart', () => {
+    const reviews = [review('theirs', 1_100, 'other'), review('mine', 1_200)];
+
+    expect(reviewOf(hookLog(), reviews)?.id).toBe('mine');
+    expect(
+      reviewOf(hookLog({ config: { agent_name: 'other' } }), reviews)?.id,
+    ).toBe('theirs');
+  });
+
+  it('links nothing rather than guess between two that fit', () => {
+    const reviews = [review('one', 1_100), review('two', 1_200)];
+
+    expect(reviewOf(hookLog(), reviews)).toBeUndefined();
+  });
+
+  it('links nothing for a hook that is not a reviewer agent', () => {
+    const http = hookLog({
+      hook_provider: HookProvider.HTTP,
+      config: { method: 'POST', url: 'https://guard' } as Hook['config'],
+    });
+
+    expect(reviewOf(http, [review('mine', 1_200)])).toBeUndefined();
+  });
+});
+
+describe('reviewsAmong', () => {
+  it('keeps the reviews of a trace and drops the rest', () => {
+    const logs = [
+      review('r', 1_200),
+      { id: 'q', span_name: null } as unknown as Log,
+    ];
+
+    expect(reviewsAmong(logs).map((log) => log.id)).toEqual(['r']);
+  });
+});

--- a/packages/web/src/utils/reviews.ts
+++ b/packages/web/src/utils/reviews.ts
@@ -1,0 +1,38 @@
+import type { HookLog, Log } from '@shared/types/data/log';
+import { HookProvider } from '@shared/types/middleware/hooks';
+
+/** The span a review is logged under: what the agent hook names its request. */
+export const REVIEW_SPAN = 'review';
+
+/** The reviews among a trace's logs. */
+export const reviewsAmong = (logs: Log[]): Log[] =>
+  logs.filter((log) => log.span_name === REVIEW_SPAN);
+
+/**
+ * The review a reviewer hook's verdict came from, among the reviews of the
+ * request: the one its reviewer agent answered while the hook was running.
+ *
+ * A review is a log of its own under the reviewer's agent, sharing the
+ * reviewed request's trace, so the reviewer is read off the request the
+ * review was sent as. The window matters because a request can be
+ * reviewed by several agents, and a session by the same one many times.
+ * No review that fits, or more than one, links nothing rather than the
+ * wrong one.
+ */
+export function reviewOf(hookLog: HookLog, reviews: Log[]): Log | undefined {
+  const { hook } = hookLog;
+  if (
+    hook.hook_provider !== HookProvider.AGENT ||
+    !('agent_name' in hook.config)
+  ) {
+    return undefined;
+  }
+  const reviewer = hook.config.agent_name;
+  const fitting = reviews.filter(
+    (review) =>
+      review.base_sa_config.agent_name === reviewer &&
+      review.start_time >= hookLog.start_time &&
+      review.start_time <= hookLog.end_time,
+  );
+  return fitting.length === 1 ? fitting[0] : undefined;
+}

--- a/packages/web/src/utils/time.test.ts
+++ b/packages/web/src/utils/time.test.ts
@@ -1,4 +1,8 @@
-import { formatClockTime, formatLogTimestamp } from '@web/utils/time';
+import {
+  formatClockTime,
+  formatDuration,
+  formatLogTimestamp,
+} from '@web/utils/time';
 import { describe, expect, it } from 'vitest';
 
 // Built in local time, so the expectation holds in any timezone
@@ -16,5 +20,15 @@ describe('formatClockTime', () => {
   it('writes the time of day alone', () => {
     expect(formatClockTime(evening)).toBe('8:50:14 PM');
     expect(formatClockTime(morning)).toBe('12:05:09 AM');
+  });
+});
+
+describe('formatDuration', () => {
+  it('reads as a request, or as a whole session', () => {
+    expect(formatDuration(320)).toBe('320ms');
+    expect(formatDuration(16_771)).toBe('16.8s');
+    expect(formatDuration(252_000)).toBe('4m 12s');
+    expect(formatDuration(240_000)).toBe('4m');
+    expect(formatDuration(5_400_000)).toBe('1h 30m');
   });
 });

--- a/packages/web/src/utils/time.ts
+++ b/packages/web/src/utils/time.ts
@@ -16,3 +16,20 @@ export function formatLogTimestamp(ms: number): string {
 export function formatClockTime(ms: number): string {
   return format(new Date(ms), 'h:mm:ss a');
 }
+
+/**
+ * A length of time, in the unit a reader would say: a request's, a hook's,
+ * or a whole session's.
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1_000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1_000).toFixed(1)}s`;
+  if (ms < 3_600_000) {
+    const minutes = Math.floor(ms / 60_000);
+    const seconds = Math.round((ms % 60_000) / 1_000);
+    return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(ms / 3_600_000);
+  const minutes = Math.floor((ms % 3_600_000) / 60_000);
+  return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
+}


### PR DESCRIPTION
## Problem

A request the reviewer denied was answered with a 446, and that was all the log kept of it. The provider log recorded the denial body the client received, so what the model had actually written was overwritten. The log page showed neither the reviewer's verdict nor the withheld answer, and no status or duration either: opening the log of a blocked request gave the conversation and nothing after it.

## Solution

- **The hook log keeps the response it withheld or replaced.** `HookLog.response_body` existed in the schema and nothing filled it. Now an output hook that denies, fails closed, or replaces the response keeps the response it judged there, since the provider log is what the client was given. An allowed response is on the provider log already and is not written twice. A replacement's own text is where it always was, in `result.response_body_override`.
- **The log page shows every hook that ran.** A Hooks panel under the header lists each hook with its verdict (Allowed, Denied, Replaced, Rewrote the request, Skipped, Could not run), the reason in the hook's words, its provider (the reviewer agent and skill, or the endpoint, or the model), how long it took, and whether the verdict came from the cache. A denial says whether the client was told the reason. A hook that could not run says what its failure did: withheld, or through unreviewed.
- **The answer the model wrote is drawn with the conversation**, labelled with the hook that withheld or replaced it, so a denied tool call or reply can be read as it would have been served.
- **The header gains the status and the time the request took**, with the provider's own span beside it when the gateway recorded one.
- `HOOK_DENIED_STATUS` names the 446 with why it is that and not 403 or 200. `formatDuration` moves to the time utilities.

## Tests

- Unit: hooks middleware keeps the judged response on denial, failed-closed denial and replacement, and not on an allowed response or an input hook; `describeHookLog`, `describeHookProvider` and the panel.
- e2e contract (both backends): the row of a denied request keeps `echo: ...` on its hook log, a replaced one keeps both the original and the replacement, an allowed one keeps nothing twice.
- e2e dashboard: a fail-closed hook naming a missing reviewer withholds the answer; the page shows the hook, Denied, the fails-closed note, the withheld answer and the 446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jxn4UPg6eyAtWi2J9jE7AC
