### PR TITLE
Let an agent say how long it waits for its reviewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,6 +606,15 @@ carries `reviewing_trace_id`, and a request carrying it gets no reviewer hook
 of its own: a review is never reviewed, which is what keeps two agents that
 review each other from looping.
 
+**The client waits for the verdict**, so how long it may wait is the
+reviewed agent's to say: `options.review.timeout_ms`, null meaning
+`DEFAULT_REVIEW_TIMEOUT_MS` -- a minute. It is the reviewed agent's setting
+and not the reviewer's because it is that agent's client that is kept
+waiting, and the same reviewer may be worth a longer wait for one agent than
+another. Past it the review is one the reviewer could not give, which fails
+open unless the agent set `review_fail_closed`; a reviewer whose own model
+thinks for longer than this is never heard from at all.
+
 **Streams are held.** A blocking output hook has to see the whole response
 before the client does, so a stream it would review is served whole -- the
 provider is asked without `stream`, the hooks judge the JSON -- and what they
@@ -661,15 +670,20 @@ The models are columns on `agents` -- `judge_model_id`,
 database does real work for them, keeping a named model from being deleted
 out from under an agent (`ON DELETE SET NULL`, where system settings
 `RESTRICT`) and keeping an embedding model out of a text slot. Everything
-else -- each role's timeout, its reasoning effort, and the judge's token
-budget -- means nothing to the database, so it lives in one `options` JSON
-column typed by `AgentOptions` in `@shared/types/data/agent`. **Null there
-means inherit**, not "send nothing": an agent with no opinion reads exactly
-as the settings say and keeps following them as they change, and a field
-added later reads as inherit on every row written before it. A PATCH sends
-the roles it changes and the connectors merge them over what is stored
-(`mergeAgentOptions`), so changing one timeout cannot clear an effort beside
-it.
+else -- each role's timeout, its reasoning effort, the judge's token budget,
+and the wait the agent allows its reviewer -- means nothing to the database,
+so it lives in one `options` JSON column typed by `AgentOptions` in
+`@shared/types/data/agent`. That last one, `review`, is not a role at all:
+the reviewer is another agent with models of its own, so a timeout is the
+only thing there is to say about it here. Adding a setting like it is a
+change to that schema and the agent form, and to neither backend's.
+
+**Null there means inherit**, not "send nothing": an agent with no opinion
+reads exactly as the settings say and keeps following them as they change,
+and a field added later reads as inherit on every row written before it. A
+PATCH sends the fields it changes and the connectors merge them over what is
+stored (`mergeAgentOptions`), so changing one timeout cannot clear an effort
+beside it.
 
 `resolveRoleModel` (`utils/evaluation-model-resolver.ts`) puts the three
 answers together for a call, and every caller goes through it;

--- a/packages/api/src/middlewares/super-agents-configuration.test.ts
+++ b/packages/api/src/middlewares/super-agents-configuration.test.ts
@@ -8,7 +8,7 @@ import {
   type SuperAgentsConfig,
   SuperAgentsConfigPreProcessed,
 } from '@shared/types/api/request/headers';
-import type { Skill } from '@shared/types/data';
+import { AgentOptions, type Skill } from '@shared/types/data';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@api/utils/embeddings', () => ({
@@ -263,6 +263,7 @@ describe('saConfigurationInjectorMiddleware reviewer', () => {
       reviewer_agent_id: 'agent-2',
       review_fail_closed: true,
       review_expose_reason: false,
+      options: AgentOptions.parse({ review: { timeout_ms: 120_000 } }),
     });
 
     await saConfigurationInjectorMiddleware(c, vi.fn());
@@ -274,7 +275,8 @@ describe('saConfigurationInjectorMiddleware reviewer', () => {
         id: 'reviewer:guard',
         type: 'output',
         hook_provider: 'agent',
-        config: { agent_name: 'guard' },
+        // The wait the reviewed agent allows, since its client waits it out.
+        config: { agent_name: 'guard', timeout_ms: 120_000 },
         await: true,
         fail_closed: true,
       }),

--- a/packages/api/src/utils/super-agents/reviewer.test.ts
+++ b/packages/api/src/utils/super-agents/reviewer.test.ts
@@ -1,6 +1,7 @@
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
 import { reviewerHookFor } from '@api/utils/super-agents/reviewer';
+import { AgentOptions } from '@shared/types/data';
 import { HookProvider, HookType } from '@shared/types/middleware/hooks';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -16,6 +17,7 @@ const agent = {
   reviewer_agent_id: 'agent-2',
   review_fail_closed: false,
   review_expose_reason: false,
+  options: AgentOptions.parse({}),
 };
 const guard = { id: 'agent-2', name: 'guard' };
 
@@ -33,6 +35,19 @@ describe('reviewerHookFor', () => {
       fail_closed: false,
       expose_reason: false,
     });
+  });
+
+  it('bounds the review by the agent timeout when it has one', async () => {
+    const hook = await reviewerHookFor(
+      c,
+      connector([guard]),
+      {
+        ...agent,
+        options: AgentOptions.parse({ review: { timeout_ms: 5000 } }),
+      },
+      {},
+    );
+    expect(hook?.config).toEqual({ agent_name: 'guard', timeout_ms: 5000 });
   });
 
   it('carries the agent choice to fail closed', async () => {

--- a/packages/api/src/utils/super-agents/reviewer.ts
+++ b/packages/api/src/utils/super-agents/reviewer.ts
@@ -21,7 +21,10 @@ export const reviewerHookId = (reviewer: Pick<Agent, 'name'>): string =>
  *
  * Configured on the agent and added here, server-side, rather than read from
  * the client's `sa-config`: a review a client could leave out of its header
- * would review nothing.
+ * would review nothing. The agent's own `options.review.timeout_ms` bounds
+ * it -- the reviewed agent's, not the reviewer's, because it is the reviewed
+ * agent's client that waits -- and null leaves it at
+ * `DEFAULT_REVIEW_TIMEOUT_MS`.
  */
 export async function reviewerHookFor(
   c: AppContext,
@@ -34,6 +37,7 @@ export async function reviewerHookFor(
         | 'reviewer_agent_id'
         | 'review_fail_closed'
         | 'review_expose_reason'
+        | 'options'
       >
     | undefined,
   config: Pick<SuperAgentsConfigPreProcessed, 'reviewing_trace_id'>,
@@ -55,11 +59,15 @@ export async function reviewerHookFor(
     );
     return null;
   }
+  const timeoutMs = agent.options.review.timeout_ms;
   return {
     id: reviewerHookId(reviewer),
     type: HookType.OUTPUT_HOOK,
     hook_provider: HookProvider.AGENT,
-    config: { agent_name: reviewer.name },
+    config: {
+      agent_name: reviewer.name,
+      ...(timeoutMs === null ? {} : { timeout_ms: timeoutMs }),
+    },
     await: true,
     cache_mode: CacheMode.DISABLED,
     fail_closed: agent.review_fail_closed,

--- a/packages/shared/src/types/data/agent.test.ts
+++ b/packages/shared/src/types/data/agent.test.ts
@@ -733,6 +733,26 @@ describe('automatic skill settings', () => {
     ).toBe(30_000);
   });
 
+  it('carries the reviewer timeout beside the roles, and inherits by default', () => {
+    // The reviewer is another agent, so the only thing to say about it here
+    // is how long the client waits for its verdict.
+    expect(AgentOptions.parse({}).review.timeout_ms).toBeNull();
+
+    const merged = mergeAgentOptions(
+      AgentOptions.parse({ review: { timeout_ms: 120_000 } }),
+      { judge: { timeout_ms: 45_000 } },
+    );
+    expect(merged.review.timeout_ms).toBe(120_000);
+    expect(
+      mergeAgentOptions(merged, { review: { timeout_ms: null } }).review
+        .timeout_ms,
+    ).toBeNull();
+
+    expect(() =>
+      AgentUpdateParams.parse({ options: { review: { timeout_ms: 500 } } }),
+    ).toThrow();
+  });
+
   it('keep the threshold between 0 and 1 and the cap a whole, non-negative number', () => {
     expect(() =>
       AgentCreateParams.parse({ ...minimal, skill_match_threshold: 1.5 }),

--- a/packages/shared/src/types/data/agent.ts
+++ b/packages/shared/src/types/data/agent.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { ReasoningEffort } from '../api/routes/shared/thinking';
 import {
-  type InternalRole,
   MAX_INTERNAL_TIMEOUT_MS,
   MIN_INTERNAL_TIMEOUT_MS,
 } from './system-settings';
@@ -58,6 +57,13 @@ export const AgentOptions = z
       .prefault({}),
     skill_arbiter: textRole(),
     intent_compaction: textRole(),
+    /**
+     * How long this agent's reviewer may take, the client waiting throughout.
+     * Not a model the agent names -- the reviewer is another agent, with its
+     * own skill and its own models -- so time is the only thing to say about
+     * it here. Null is `DEFAULT_REVIEW_TIMEOUT_MS`.
+     */
+    review: z.object({ timeout_ms: TimeoutOverride }).prefault({}),
   })
   .prefault({});
 export type AgentOptions = z.infer<typeof AgentOptions>;
@@ -84,10 +90,11 @@ export const AgentOptionsUpdate = z.object({
     .optional(),
   skill_arbiter: textRoleUpdate(),
   intent_compaction: textRoleUpdate(),
+  review: z.object({ timeout_ms: TimeoutValue.optional() }).optional(),
 });
 export type AgentOptionsUpdate = z.infer<typeof AgentOptionsUpdate>;
 
-function mergeRole<R extends InternalRole>(
+function mergeRole<R extends keyof AgentOptions>(
   current: AgentOptions,
   update: AgentOptionsUpdate,
   role: R,
@@ -120,6 +127,7 @@ export function mergeAgentOptions(
     judge: mergeRole(current, update, 'judge'),
     skill_arbiter: mergeRole(current, update, 'skill_arbiter'),
     intent_compaction: mergeRole(current, update, 'intent_compaction'),
+    review: mergeRole(current, update, 'review'),
   };
 }
 
@@ -155,8 +163,9 @@ export const Agent = z.object({
   skill_arbiter_model_id: z.uuid().nullable(),
   intent_compaction_model_id: z.uuid().nullable(),
 
-  /** How long each of those may take and how hard it may think, where the
-   * agent has an opinion. Null inherits the system setting. */
+  /** How long each of those may take and how hard it may think, plus how
+   * long the agent's reviewer may take, where the agent has an opinion.
+   * Null inherits. */
   options: AgentOptions,
 
   /** Another agent that reviews every response before the client receives

--- a/packages/web/src/components/agents/edit-agent-view.test.tsx
+++ b/packages/web/src/components/agents/edit-agent-view.test.tsx
@@ -719,6 +719,69 @@ describe('EditAgentView', () => {
       });
     });
 
+    it('cannot set the review timeout without a reviewer', () => {
+      renderEditAgentView();
+      expect(screen.getByLabelText('Review timeout (seconds)')).toBeDisabled();
+    });
+
+    it('saves how long the client waits for the verdict', async () => {
+      vi.mocked(useAgents).mockReturnValue({
+        ...vi.mocked(useAgents)(),
+        agents: [mockAgent, guard],
+        selectedAgent: {
+          ...mockAgent,
+          reviewer_agent_id: 'agent-2',
+          options: AgentOptions.parse({ review: { timeout_ms: 90_000 } }),
+        },
+      });
+      renderEditAgentView();
+
+      // Milliseconds on the row, seconds on the page.
+      const timeout = screen.getByLabelText('Review timeout (seconds)');
+      expect(timeout).toHaveValue(90);
+
+      fireEvent.change(timeout, { target: { value: '180' } });
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateAgent).toHaveBeenCalledWith(
+          'agent-1',
+          expect.objectContaining({
+            options: expect.objectContaining({
+              review: { timeout_ms: 180_000 },
+            }),
+          }),
+        );
+      });
+    });
+
+    it('leaves the review to its default when the field is empty', async () => {
+      vi.mocked(useAgents).mockReturnValue({
+        ...vi.mocked(useAgents)(),
+        agents: [mockAgent, guard],
+        selectedAgent: {
+          ...mockAgent,
+          reviewer_agent_id: 'agent-2',
+          options: AgentOptions.parse({ review: { timeout_ms: 90_000 } }),
+        },
+      });
+      renderEditAgentView();
+
+      fireEvent.change(screen.getByLabelText('Review timeout (seconds)'), {
+        target: { value: '' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateAgent).toHaveBeenCalledWith(
+          'agent-1',
+          expect.objectContaining({
+            options: expect.objectContaining({ review: { timeout_ms: null } }),
+          }),
+        );
+      });
+    });
+
     it('saves the choice to explain denials', async () => {
       vi.mocked(useAgents).mockReturnValue({
         ...vi.mocked(useAgents)(),

--- a/packages/web/src/components/agents/edit-agent-view.tsx
+++ b/packages/web/src/components/agents/edit-agent-view.tsx
@@ -77,17 +77,24 @@ const selectChange =
     onChange(value === none ? null : value);
   };
 
+/** A timeout the form holds in seconds, or null to inherit. */
+const TimeoutSecondsSchema = z
+  .number({ error: 'Enter a whole number of seconds, or leave it empty' })
+  .int('Must be a whole number of seconds')
+  .min(MIN_TIMEOUT_SECONDS, `Must be at least ${MIN_TIMEOUT_SECONDS}`)
+  .max(MAX_TIMEOUT_SECONDS, `Must be at most ${MAX_TIMEOUT_SECONDS}`)
+  .nullable();
+
 /** One role's overrides, as the form holds them: seconds, not milliseconds. */
 const RoleFormSchema = z.object({
   model_id: z.string().nullable(),
-  timeout_seconds: z
-    .number({ error: 'Enter a whole number of seconds, or leave it empty' })
-    .int('Must be a whole number of seconds')
-    .min(MIN_TIMEOUT_SECONDS, `Must be at least ${MIN_TIMEOUT_SECONDS}`)
-    .max(MAX_TIMEOUT_SECONDS, `Must be at most ${MAX_TIMEOUT_SECONDS}`)
-    .nullable(),
+  timeout_seconds: TimeoutSecondsSchema,
   reasoning_effort: z.enum(ReasoningEffort).nullable(),
 });
+
+/** Seconds as the API takes them; null stays null, meaning inherit. */
+const millisecondsOf = (seconds: number | null): number | null =>
+  seconds === null ? null : seconds * 1000;
 
 /** What each role is called on the page, and what it is for. */
 const ROLE_LABELS: Record<InternalRole, { name: string; detail: string }> = {
@@ -147,6 +154,7 @@ const EditAgentFormSchema = z
       .nullable(),
     // Null means responses go unreviewed.
     reviewer_agent_id: z.string().nullable(),
+    review_timeout_seconds: TimeoutSecondsSchema,
     review_fail_closed: z.boolean(),
     review_expose_reason: z.boolean(),
   })
@@ -181,7 +189,7 @@ const rolesOf = (agent: Agent): EditAgentFormData['roles'] =>
     }),
   ) as EditAgentFormData['roles'];
 
-/** The form's roles as the API takes them: model columns, and one patch. */
+/** The form's overrides as the API takes them: model columns, and one patch. */
 function roleUpdates(data: EditAgentFormData): AgentUpdateParams {
   const models = Object.fromEntries(
     INTERNAL_ROLES.map((role) => [
@@ -192,8 +200,7 @@ function roleUpdates(data: EditAgentFormData): AgentUpdateParams {
   const options = Object.fromEntries(
     INTERNAL_ROLES.map((role) => {
       const { timeout_seconds, reasoning_effort } = data.roles[role];
-      const timeout_ms =
-        timeout_seconds === null ? null : timeout_seconds * 1000;
+      const timeout_ms = millisecondsOf(timeout_seconds);
       return [
         role,
         role === 'embedding'
@@ -208,7 +215,15 @@ function roleUpdates(data: EditAgentFormData): AgentUpdateParams {
       ];
     }),
   );
-  return { ...models, options } as AgentUpdateParams;
+  return {
+    ...models,
+    options: {
+      ...options,
+      // Not one of the roles: the reviewer is another agent with models of
+      // its own, so all the reviewed agent says is how long it may take.
+      review: { timeout_ms: millisecondsOf(data.review_timeout_seconds) },
+    },
+  } as AgentUpdateParams;
 }
 
 export function EditAgentView(): React.ReactElement {
@@ -276,6 +291,7 @@ export function EditAgentView(): React.ReactElement {
       roles: blankRoles(),
       judge_max_tokens: null,
       reviewer_agent_id: null,
+      review_timeout_seconds: null,
       review_fail_closed: false,
       review_expose_reason: false,
     },
@@ -292,6 +308,10 @@ export function EditAgentView(): React.ReactElement {
         roles: rolesOf(selectedAgent),
         judge_max_tokens: selectedAgent.options.judge.max_tokens,
         reviewer_agent_id: selectedAgent.reviewer_agent_id,
+        review_timeout_seconds:
+          selectedAgent.options.review.timeout_ms === null
+            ? null
+            : selectedAgent.options.review.timeout_ms / 1000,
         review_fail_closed: selectedAgent.review_fail_closed,
         review_expose_reason: selectedAgent.review_expose_reason,
       });
@@ -758,6 +778,45 @@ export function EditAgentView(): React.ReactElement {
                             ))}
                           </SelectContent>
                         </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="review_timeout_seconds"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Review timeout (seconds)</FormLabel>
+                        <FormDescription>
+                          How long the client waits for the verdict. Past it the
+                          review counts as one the reviewer could not give, so a
+                          response is delivered unless the agent fails closed.
+                          Empty is a minute.
+                        </FormDescription>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            step="1"
+                            min={MIN_TIMEOUT_SECONDS}
+                            max={MAX_TIMEOUT_SECONDS}
+                            placeholder="60"
+                            name={field.name}
+                            value={field.value ?? ''}
+                            onBlur={field.onBlur}
+                            onChange={(e) =>
+                              field.onChange(
+                                e.target.value === ''
+                                  ? null
+                                  : e.target.valueAsNumber,
+                              )
+                            }
+                            disabled={
+                              isUpdating ||
+                              form.watch('reviewer_agent_id') === null
+                            }
+                          />
+                        </FormControl>
                         <FormMessage />
                       </FormItem>
                     )}


### PR DESCRIPTION
## Problem

A reviewer that takes longer than a minute is never heard from. The review is an ordinary gateway request, and the client that makes it is bounded by `DEFAULT_REVIEW_TIMEOUT_MS` — 60s. `HookAgentProviderConfig` has carried a `timeout_ms` all along and `connectors/hooks/agent.ts` reads it, but `reviewerHookFor` never set it, so there was nowhere to say otherwise.

Past the timeout the response is delivered unreviewed, or withheld where the agent fails closed, on a verdict that was on its way. A reviewer whose own model thinks before it answers hits this every time.

## Solution

The reviewed agent says how long its client waits, in `options.review.timeout_ms`.

The reviewed agent's setting and not the reviewer's, for the reason `review_fail_closed` and `review_expose_reason` are its: it is that agent's client that is kept waiting, and the same reviewer can be worth a longer wait for one agent than another. Null is the minute it was.

`review` is not one of the six internal roles — the reviewer is another agent, with its own skill and its own models, so a timeout is the only thing there is to say about it here.

**Nothing to migrate.** `options` is the JSON column the agent's model settings already live in, `AgentOptions` prefaults the new key, and null on a row written before the field existed reads as inherit — which is what those rows already had. No schema change on either backend, and no `dev.db` upgrade.

## In the app

"Review timeout (seconds)" sits under "Reviewer agent" in Response review, disabled without a reviewer like the two switches beside it, placeholder `60`, bounded by the shared 1s–600s. Its description says what running out means, since that consequence — the response going through unreviewed, or being withheld — is what someone raising the number is trying to avoid.

Nothing else bounds the hooks path, so this setting is the only thing between a client and an unbounded wait on a slow reviewer.

## Test notes

`pnpm check` and `pnpm typecheck` clean; 3307 unit tests pass.

New coverage:
- the hook config carries the agent's timeout, and omits it when the agent has none (`reviewer.test.ts`)
- it survives the injector middleware onto `sa_config.hooks` (`super-agents-configuration.test.ts`)
- it defaults to inherit, a patch to another role cannot clear it, and a sub-second timeout is refused (`agent.test.ts`)
- the form round-trips 90s → 180s and empties back to inherit, and the field is disabled without a reviewer (`edit-agent-view.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnbWquRbXe4fARsWL5e1mc