### PR TITLE
Route requests on what they ask for, not on who is asking

### DIFF
--- a/packages/api/src/utils/embeddings.test.ts
+++ b/packages/api/src/utils/embeddings.test.ts
@@ -285,5 +285,55 @@ describe('Embeddings Utility', () => {
       // formatter render every tool output as empty for months.
       expect(result).toContain('Tool Call call_123 Output: Weather result');
     });
+
+    it('keeps the end of a long conversation, not its opening', () => {
+      const messages = [
+        { role: ChatCompletionMessageRole.USER, content: 'The opening ask' },
+        ...Array.from({ length: 40 }, (_, i) => ({
+          role: ChatCompletionMessageRole.TOOL,
+          tool_call_id: `call_${i}`,
+          content: 'x'.repeat(900),
+        })),
+        { role: ChatCompletionMessageRole.USER, content: 'What is asked now' },
+      ];
+
+      const result = formatMessagesForEmbedding(messages);
+      expect(result).toContain('User: What is asked now');
+      expect(result).not.toContain('User: The opening ask');
+      expect(result.length).toBeLessThanOrEqual(6000);
+    });
+
+    it('gives two turns of one session different text as they diverge', () => {
+      const prefix = Array.from({ length: 40 }, (_, i) => ({
+        role: ChatCompletionMessageRole.TOOL,
+        tool_call_id: `call_${i}`,
+        content: 'x'.repeat(900),
+      }));
+
+      const earlier = formatMessagesForEmbedding([
+        ...prefix,
+        { role: ChatCompletionMessageRole.USER, content: 'Rename the field' },
+      ]);
+      const later = formatMessagesForEmbedding([
+        ...prefix,
+        { role: ChatCompletionMessageRole.USER, content: 'Rename the field' },
+        { role: ChatCompletionMessageRole.USER, content: 'Now write the docs' },
+      ]);
+
+      expect(earlier).not.toBe(later);
+      expect(later).toContain('User: Now write the docs');
+    });
+
+    it('cuts the newest message when it alone overruns the budget', () => {
+      const messages = [
+        { role: ChatCompletionMessageRole.USER, content: 'Earlier turn' },
+        { role: ChatCompletionMessageRole.USER, content: 'y'.repeat(9000) },
+      ];
+
+      const result = formatMessagesForEmbedding(messages);
+      expect(result.length).toBe(6000);
+      expect(result.startsWith('User: yyy')).toBe(true);
+      expect(result).not.toContain('Earlier turn');
+    });
   });
 });

--- a/packages/api/src/utils/embeddings.ts
+++ b/packages/api/src/utils/embeddings.ts
@@ -131,82 +131,123 @@ export function extractMessagesFromRequestData(
 const MAX_TOOL_OUTPUT_LENGTH = 1000;
 const MAX_EMBEDDING_TEXT_LENGTH = 6000;
 
+const MESSAGE_SEPARATOR = '\n\n\n';
+
+/** One message as its line of the embedded text, or '' for nothing to say. */
+function formatMessageForEmbedding(message: ChatCompletionMessage): string {
+  const role = message.role;
+  let content = '';
+
+  if (typeof message.content === 'string') {
+    content += message.content;
+  } else if (Array.isArray(message.content)) {
+    content += message.content
+      .map((item) => {
+        if (typeof item === 'object' && item.text) {
+          return item.text;
+        }
+        return '';
+      })
+      .filter(Boolean)
+      .join(' ');
+  } else if (message.content) {
+    content += String(message.content);
+  }
+
+  // The tool's output is the message's content, capped: the embedding
+  // needs the topic of the output, not the whole of a git diff.
+  if (
+    role === ChatCompletionMessageRole.TOOL ||
+    role === ChatCompletionMessageRole.FUNCTION
+  ) {
+    return `Tool Call ${message.tool_call_id} Output: ${content.slice(
+      0,
+      MAX_TOOL_OUTPUT_LENGTH,
+    )}`;
+  }
+
+  if (message.tool_calls && message.tool_calls.length > 0) {
+    const tools = message.tool_calls
+      .map((tool) => {
+        const parsedTool = tool as {
+          id: string;
+          type: 'mcp_call';
+          function: {
+            name: string;
+            arguments: string;
+          };
+        };
+        return `Tool Call ID: ${parsedTool.id}\nTool Call Name: ${parsedTool.function.name}\nTool Call Arguments: ${parsedTool.function.arguments}`;
+      })
+      .join(', ');
+    return `Assistant Tool Calls:\n${tools}`;
+  }
+
+  // Only include messages with non-empty content after trimming
+  if (!content.trim()) {
+    return '';
+  }
+
+  if (role === ChatCompletionMessageRole.USER) {
+    return `User: ${content}`.trim();
+  }
+  if (role === ChatCompletionMessageRole.ASSISTANT) {
+    return `Assistant: ${content}`.trim();
+  }
+
+  return `${role}: ${content}`.trim();
+}
+
+/**
+ * A conversation as the text whose embedding places the request among its
+ * skill's clusters: the messages it ends with, newest first into the budget,
+ * rendered back in order.
+ *
+ * The tail rather than the head, because a request is asking for whatever it
+ * has arrived at. An agentic session runs for hundreds of turns behind one
+ * unchanging opening, so taking the budget from the front hands every turn of
+ * it the same text -- the same embedding, the same cluster, the same arm --
+ * however far the work has since travelled. `describeRequestIntent` reads the
+ * conversation from the end for the same reason.
+ */
 export function formatMessagesForEmbedding(
   messages: ChatCompletionMessage[],
 ): string {
-  return messages
-    .filter((message) => {
-      // Exclude system and developer messages from embeddings
-      return (
-        message.role !== ChatCompletionMessageRole.SYSTEM &&
-        message.role !== ChatCompletionMessageRole.DEVELOPER
-      );
-    })
-    .map((message) => {
-      const role = message.role;
-      let content = '';
+  const lines: string[] = [];
+  let budget = MAX_EMBEDDING_TEXT_LENGTH;
 
-      if (typeof message.content === 'string') {
-        content += message.content;
-      } else if (Array.isArray(message.content)) {
-        content += message.content
-          .map((item) => {
-            if (typeof item === 'object' && item.text) {
-              return item.text;
-            }
-            return '';
-          })
-          .filter(Boolean)
-          .join(' ');
-      } else if (message.content) {
-        content += String(message.content);
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    // Exclude system and developer messages from embeddings
+    if (
+      message.role === ChatCompletionMessageRole.SYSTEM ||
+      message.role === ChatCompletionMessageRole.DEVELOPER
+    ) {
+      continue;
+    }
+    const line = formatMessageForEmbedding(message);
+    if (!line) {
+      continue;
+    }
+    if (lines.length > 0) {
+      budget -= MESSAGE_SEPARATOR.length;
+    }
+    if (budget <= 0) {
+      break;
+    }
+    // The newest message is worth cutting to fit; an older one that does not
+    // fit whole is left out, so the text never opens mid-sentence.
+    if (line.length > budget) {
+      if (lines.length === 0) {
+        lines.push(line.slice(0, budget));
       }
+      break;
+    }
+    lines.push(line);
+    budget -= line.length;
+  }
 
-      // The tool's output is the message's content, capped: the embedding
-      // needs the topic of the output, not the whole of a git diff.
-      if (
-        role === ChatCompletionMessageRole.TOOL ||
-        role === ChatCompletionMessageRole.FUNCTION
-      ) {
-        return `Tool Call ${message.tool_call_id} Output: ${content.slice(
-          0,
-          MAX_TOOL_OUTPUT_LENGTH,
-        )}`;
-      }
-
-      if (message.tool_calls && message.tool_calls.length > 0) {
-        const tools = message.tool_calls
-          .map((tool) => {
-            const parsedTool = tool as {
-              id: string;
-              type: 'mcp_call';
-              function: {
-                name: string;
-                arguments: string;
-              };
-            };
-            return `Tool Call ID: ${parsedTool.id}\nTool Call Name: ${parsedTool.function.name}\nTool Call Arguments: ${parsedTool.function.arguments}`;
-          })
-          .join(', ');
-        return `Assistant Tool Calls:\n${tools}`;
-      }
-
-      // Only include messages with non-empty content after trimming
-      if (!content.trim()) {
-        return '';
-      }
-
-      if (role === ChatCompletionMessageRole.USER) {
-        return `User: ${content}`.trim();
-      }
-      if (role === ChatCompletionMessageRole.ASSISTANT) {
-        return `Assistant: ${content}`.trim();
-      }
-
-      return `${role}: ${content}`.trim();
-    })
-    .filter(Boolean)
-    .join('\n\n\n');
+  return lines.reverse().join(MESSAGE_SEPARATOR);
 }
 
 export interface TextEmbedding {

--- a/packages/api/src/utils/super-agents/skill-routing.test.ts
+++ b/packages/api/src/utils/super-agents/skill-routing.test.ts
@@ -200,6 +200,7 @@ describe('routeRequestToSkill', () => {
         candidates: 1,
         identity_similarity: null,
         conversation_similarity: null,
+        // Every decision is timed, whichever way it was reached.
       });
       expect(resolveEmbeddingModelConfig).not.toHaveBeenCalled();
       expect(embedText).not.toHaveBeenCalled();
@@ -223,29 +224,33 @@ describe('routeRequestToSkill', () => {
       const sql = skill('s2', 'sql');
       connector.getSkills.mockResolvedValue([translate, sql]);
 
-      const result = await route(manual, chat('You translate text.'));
+      const result = await route(
+        manual,
+        chat('You translate text.', 'translate this'),
+      );
 
       expect(result.skill).toBe(translate);
       expect(result.decision.method).toBe('embedding');
       expect(result.decision.candidates).toBe(2);
       expect(result.decision.similarity).toBeCloseTo(1, 3);
       expect(result.decision.identity_similarity).toBeCloseTo(1, 3);
-      // Nothing had met a conversation yet, so identity alone decided.
-      expect(result.decision.conversation_similarity).toBeNull();
+      expect(result.decision.conversation_similarity).toBeCloseTo(1, 3);
       // The threshold is not consulted when nothing would be created.
       expect(result.decision.threshold).toBeNull();
 
       // Two seeds, then the winner absorbing the request.
       expect(connector.upsertSkillRouting).toHaveBeenCalledTimes(3);
+      // Both halves are seeded: identity from the prompt the skill would be
+      // called with, the conversation from what the skill says it is for.
       expect(connector.upsertSkillRouting).toHaveBeenCalledWith(
         c,
         expect.objectContaining({
           skill_id: 's1',
           centroid: [1, 0, 0.01],
-          conversation_centroid: null,
+          conversation_centroid: [1, 0, 0.01],
           embedding_model_id: MODEL_ID,
           sample_count: 1,
-          conversation_sample_count: 0,
+          conversation_sample_count: 1,
         }),
       );
       expect(connector.upsertSkillRouting).toHaveBeenCalledWith(
@@ -253,18 +258,18 @@ describe('routeRequestToSkill', () => {
         expect.objectContaining({
           skill_id: 's2',
           centroid: [0, 1, 0.01],
+          conversation_centroid: [0, 1, 0.01],
           sample_count: 1,
         }),
       );
-      // The absorb takes the identity into the main centroid and starts the
-      // conversation centroid from the conversation.
+      // The absorb moves both centroids on from their seeds.
       expect(connector.upsertSkillRouting).toHaveBeenLastCalledWith(
         c,
         expect.objectContaining({
           skill_id: 's1',
           sample_count: 2,
-          conversation_centroid: [0, 0, 0.01],
-          conversation_sample_count: 1,
+          conversation_centroid: [1, 0, 0.01],
+          conversation_sample_count: 2,
         }),
       );
     });
@@ -519,7 +524,10 @@ describe('routeRequestToSkill', () => {
       const translate = skill('s1', 'translate');
       connector.getSkills.mockResolvedValue([translate]);
 
-      const result = await route(growing, chat('You translate text.'));
+      const result = await route(
+        growing,
+        chat('You translate text.', 'translate this'),
+      );
 
       expect(result.skill).toBe(translate);
       expect(result.decision.method).toBe('embedding');
@@ -604,8 +612,10 @@ describe('routeRequestToSkill', () => {
         expect.objectContaining({
           skill_id: 's2',
           sample_count: 2,
-          conversation_centroid: [0, 0, 0.01],
-          conversation_sample_count: 1,
+          // On from the seed the description gave it, halfway to the
+          // conversation the arbiter filed here.
+          conversation_centroid: [0, 0.5, 0.01],
+          conversation_sample_count: 2,
         }),
       );
     });
@@ -630,17 +640,53 @@ describe('routeRequestToSkill', () => {
       expect(connector.upsertSkillRouting).toHaveBeenCalledTimes(2);
     });
 
-    it('routes to the closest skill once the agent is at its cap', async () => {
+    it('asks the arbiter at the cap, and honours an existing skill', async () => {
       const capped = { ...growing, max_auto_created_skills: 1 } as Agent;
       const translate = skill('s1', 'translate', 0, true);
-      connector.getSkills.mockResolvedValue([translate, skill('s2', 'sql')]);
+      const sql = skill('s2', 'sql');
+      connector.getSkills.mockResolvedValue([translate, sql]);
+      vi.mocked(arbitrateSkillForRequest).mockResolvedValue({
+        kind: 'existing',
+        skill: sql,
+      });
 
       const result = await route(capped, chat('Draw a picture of a cat.'));
 
+      // The cap stops the agent growing, not its router being corrected.
+      expect(arbitrateSkillForRequest).toHaveBeenCalled();
       expect(createSkillForRequest).not.toHaveBeenCalled();
-      expect(arbitrateSkillForRequest).not.toHaveBeenCalled();
+      expect(result.skill).toBe(sql);
+      expect(result.decision.method).toBe('arbitrated');
+    });
+
+    it('serves new work from the closest skill once at the cap', async () => {
+      const capped = { ...growing, max_auto_created_skills: 1 } as Agent;
+      const translate = skill('s1', 'translate', 0, true);
+      connector.getSkills.mockResolvedValue([translate, skill('s2', 'sql')]);
+      vi.mocked(arbitrateSkillForRequest).mockResolvedValue({ kind: 'new' });
+
+      const result = await route(capped, chat('Draw a picture of a cat.'));
+
+      // A new job with nowhere to go: nothing is created and the closest
+      // skill answers, as it did before the arbiter was asked.
+      expect(createSkillForRequest).not.toHaveBeenCalled();
       expect(result.decision.method).toBe('embedding');
       expect(['s1', 's2']).toContain(result.skill.id);
+    });
+
+    it('takes no creation lease at the cap', async () => {
+      const capped = { ...growing, max_auto_created_skills: 1 } as Agent;
+      connector.getSkills.mockResolvedValue([
+        skill('s1', 'translate', 0, true),
+        skill('s2', 'sql'),
+      ]);
+      vi.mocked(arbitrateSkillForRequest).mockResolvedValue({ kind: 'new' });
+
+      await route(capped, chat('Draw a picture of a cat.'));
+
+      // Nothing is created there, so concurrent requests have no reason to
+      // queue behind one arbiter call.
+      expect(connector.claimSkillCreationLease).not.toHaveBeenCalled();
     });
 
     it('refuses an agent without skills once it is at its cap', async () => {

--- a/packages/api/src/utils/super-agents/skill-routing.ts
+++ b/packages/api/src/utils/super-agents/skill-routing.ts
@@ -51,6 +51,18 @@ const MAX_CENTROID_SAMPLES = 100;
 const IDENTITY_WEIGHT = 0.6;
 const CONVERSATION_WEIGHT = 0.4;
 
+/**
+ * How far a skill's identity similarity has to stand above the next skill's
+ * for identity to have chosen between them.
+ */
+const IDENTITY_SEPARATION = 0.05;
+
+/**
+ * How far above the threshold a decision has to land before the skill it
+ * chose learns from it.
+ */
+const LEARNING_MARGIN = 0.05;
+
 /** What a request with no system prompt, tools or message is filed under. */
 const DEFAULT_INTENT = 'General requests that carry no instructions or tools';
 
@@ -81,13 +93,25 @@ export class SkillRoutingError extends Error {
   }
 }
 
+/** What a skill says it is for: the one text that is its own. */
+export function describeText(skill: Skill): string {
+  return `${skill.name}: ${skill.description}`;
+}
+
 /**
- * What a skill's centroid starts from, before it has served a request: the
- * prompt the gateway created it from, when there is one -- that is what the
- * next request like it will carry -- and otherwise its description.
+ * What a skill's identity centroid starts from, before it has served a
+ * request: the prompt the gateway created it from, when there is one -- that
+ * is what the next request like it will carry -- and otherwise its
+ * description.
+ *
+ * Every skill one caller creates is seeded from that caller's prompt, so
+ * these centroids are alike by construction. That is identity doing its job:
+ * it marks the skills as this caller's. Telling them apart is the
+ * conversation centroid's, which is why that one is seeded from the
+ * description instead.
  */
 export function seedText(skill: Skill): string {
-  return skill.seed_system_prompt || `${skill.name}: ${skill.description}`;
+  return skill.seed_system_prompt || describeText(skill);
 }
 
 /** The running mean after one more sample, capped as described above. */
@@ -150,6 +174,60 @@ export function scoreIntent(
     return null;
   }
   return { score: sum / weight, identity, conversation };
+}
+
+/**
+ * Scores an intent against a whole field of skills at once, so that identity
+ * counts for what it can actually tell apart.
+ *
+ * A skill's identity centroid says which caller a skill belongs to, and an
+ * agent fed by one tool sends the same system prompt with every request: the
+ * skills of that caller then score alike on identity, whatever the request
+ * asks for. Weighted at 0.6 that similarity is a floor under every score --
+ * measured on real traffic, an identity pinned at 0.97 holds a request above
+ * a 0.8 threshold unless its conversation falls under 0.54, which is to say
+ * never. The arbiter, whose whole job is to catch work no skill fits, is
+ * then unreachable, and the skill with the broadest centroid keeps every
+ * request it wins.
+ *
+ * So identity narrows the field and the conversation chooses within it: the
+ * skills within `IDENTITY_SEPARATION` of the best identity are the ones it
+ * could not separate, and among those the score is the conversation alone.
+ * Skills it did separate keep the blend, which is how a second caller's
+ * skills stay marked down. When identity singles one skill out, it has
+ * chosen, and the blend stands for everyone.
+ *
+ * Returns one score per routing, in order, null where there is nothing to
+ * compare.
+ */
+export function scoreIntentAcrossSkills(
+  intent: RequestIntentEmbedding,
+  routings: (SkillRouting | undefined)[],
+): (SkillScore | null)[] {
+  const scores = routings.map((routing) =>
+    routing ? scoreIntent(intent, routing) : null,
+  );
+
+  const identities = scores
+    .map((score) => score?.identity ?? null)
+    .filter((identity): identity is number => identity !== null);
+  if (identities.length === 0) {
+    return scores;
+  }
+
+  const floor = Math.max(...identities) - IDENTITY_SEPARATION;
+  if (identities.filter((identity) => identity >= floor).length < 2) {
+    return scores;
+  }
+
+  return scores.map((score) =>
+    score !== null &&
+    score.identity !== null &&
+    score.conversation !== null &&
+    score.identity >= floor
+      ? { ...score, score: score.conversation }
+      : score,
+  );
 }
 
 /** The absorb-once key for a conversation embedding, per skill. */
@@ -277,17 +355,22 @@ async function tryEmbedIntent(
 
 type RoutingPass =
   | { kind: 'routed'; result: SkillRoutingResult }
-  /** No skill fits, and the agent may create one: what to create it from. */
-  | {
-      kind: 'create';
-      skills: Skill[];
-      intent: RequestIntentEmbedding | null;
-      similarity: number | null;
-      identitySimilarity: number | null;
-      conversationSimilarity: number | null;
-      /** The closest skill anyway, for routing conservatively. */
-      best: Skill | null;
-    };
+  /** No skill fits: what a new one would be made from, if one may be. */
+  | CreatePass;
+
+interface CreatePass {
+  kind: 'create';
+  skills: Skill[];
+  intent: RequestIntentEmbedding | null;
+  similarity: number | null;
+  identitySimilarity: number | null;
+  conversationSimilarity: number | null;
+  /** The closest skill anyway, for routing conservatively. */
+  best: Skill | null;
+  /** False at the agent's cap: the arbiter may still speak, but only to
+   * name a skill that already exists. */
+  canCreate: boolean;
+}
 
 /**
  * One look at the agent's skills: either the skill for the request, or the
@@ -333,6 +416,7 @@ async function routeOnce(
     intent: RequestIntentEmbedding | null,
     score: SkillScore | null,
     best: Skill | null,
+    canCreate = true,
   ): RoutingPass => ({
     kind: 'create',
     skills,
@@ -341,6 +425,7 @@ async function routeOnce(
     identitySimilarity: score?.identity ?? null,
     conversationSimilarity: score?.conversation ?? null,
     best,
+    canCreate,
   });
 
   if (skills.length === 0) {
@@ -397,21 +482,33 @@ async function routeOnce(
       skills
         .filter((skill) => !bySkill.has(skill.id))
         .map(async (skill) => {
-          const seed = await embedIntent(
-            c,
-            connector,
-            seedText(skill),
-            embeddingConfig.modelId,
-            agent,
-          );
+          // Both halves from the start: a skill whose conversation centroid
+          // is null is scored on identity alone, and identity is what the
+          // skills of one caller share.
+          const [seed, described] = await Promise.all([
+            embedIntent(
+              c,
+              connector,
+              seedText(skill),
+              embeddingConfig.modelId,
+              agent,
+            ),
+            embedIntent(
+              c,
+              connector,
+              describeText(skill),
+              embeddingConfig.modelId,
+              agent,
+            ),
+          ]);
           const routing = await connector.upsertSkillRouting(c, {
             skill_id: skill.id,
             agent_id: agent.id,
             centroid: seed.embedding,
-            conversation_centroid: null,
+            conversation_centroid: described.embedding,
             embedding_model_id: embeddingConfig.modelId,
             sample_count: 1,
-            conversation_sample_count: 0,
+            conversation_sample_count: 1,
           });
           bySkill.set(skill.id, routing);
         }),
@@ -425,52 +522,65 @@ async function routeOnce(
       embeddingConfig.modelId,
     );
 
+    const inOrder = skills.map((skill) => bySkill.get(skill.id));
+    const scores = scoreIntentAcrossSkills(intent, inOrder);
+
     let best: {
       skill: Skill;
       routing: SkillRouting;
       score: SkillScore;
     } | null = null;
-    for (const skill of skills) {
-      const routing = bySkill.get(skill.id);
-      if (!routing) {
-        continue;
-      }
-      const score = scoreIntent(intent, routing);
-      if (!score) {
-        continue;
+    skills.forEach((skill, i) => {
+      const routing = inOrder[i];
+      const score = scores[i];
+      if (!routing || !score) {
+        return;
       }
       if (!best || score.score > best.score.score) {
         best = { skill, routing, score };
       }
-    }
+    });
     if (!best) {
       throw new RequestEmbeddingError('No skill has a routing centroid');
     }
+    const chosen: {
+      skill: Skill;
+      routing: SkillRouting;
+      score: SkillScore;
+    } = best;
 
-    if (autoCreate && best.score.score < agent.skill_match_threshold) {
-      if (underCap) {
-        return create(intent, best.score, best.skill);
-      }
-      warn(
-        `[SKILL_ROUTING] Agent ${agent.name} is at its cap of ${agent.max_auto_created_skills} auto-created skills; routing to ${best.skill.name} at similarity ${best.score.score.toFixed(2)}`,
+    if (autoCreate && chosen.score.score < agent.skill_match_threshold) {
+      // Asked even at the cap. The arbiter cannot make a skill there, but its
+      // existing-skill verdict is the one way a request the centroids misfile
+      // reaches the skill it belongs to, and the cap is on how many skills an
+      // agent has rather than on whether its router may be corrected.
+      return create(intent, chosen.score, chosen.skill, underCap);
+    }
+
+    // Learn from the decision, so skills follow their traffic -- but only
+    // from decisions that were not close calls. A skill that takes in every
+    // request it barely won broadens until it is the nearest centroid to
+    // everything the agent is sent, and the agent collapses onto it; the
+    // narrow skills it swallowed never get another chance, because only the
+    // winner ever learns. Requests that name their skill teach it whatever
+    // its traffic is (`learnSkillIntent`), and so does an arbitrated verdict,
+    // so nothing here is the only way a skill can follow its work.
+    if (chosen.score.score >= agent.skill_match_threshold + LEARNING_MARGIN) {
+      await absorbIntent(
+        c,
+        connector,
+        agent.id,
+        chosen.skill.id,
+        chosen.routing,
+        intent,
       );
     }
 
-    // Learn from the decision, so skills follow their traffic.
-    await absorbIntent(
-      c,
-      connector,
-      agent.id,
-      best.skill.id,
-      best.routing,
-      intent,
-    );
-
     return routed(
-      best.skill,
+      chosen.skill,
       decide(
         'embedding',
-        best.score,
+        chosen.score,
         autoCreate ? agent.skill_match_threshold : null,
       ),
     );
@@ -525,41 +635,34 @@ export async function routeRequestToSkill(
     return first.result;
   }
 
-  // The arbiter is asked under the lease, so the lease has to outlast its
-  // budget -- one attempt and the client's one retry -- on top of creation.
   const settings = await connector.getSystemSettings(c);
-  const leaseMs =
-    SKILL_CREATION_LEASE_MS + 2 * skillArbiterTimeoutMs(agent, settings);
 
-  const underLease = async (): Promise<SkillRoutingResult> => {
-    const again = await routeOnce(c, connector, agent, requestIntent);
-    if (again.kind === 'routed') {
-      return again.result;
-    }
-
+  const settle = async (pass: CreatePass): Promise<SkillRoutingResult> => {
     const decision = (method: SkillRoutingMethod): SkillRoutingDecision => ({
       method,
-      similarity: again.similarity,
+      similarity: pass.similarity,
       threshold: agent.skill_match_threshold,
-      candidates: again.skills.length,
-      identity_similarity: again.identitySimilarity,
-      conversation_similarity: again.conversationSimilarity,
+      candidates: pass.skills.length,
+      identity_similarity: pass.identitySimilarity,
+      conversation_similarity: pass.conversationSimilarity,
     });
 
     // An agent with skills gets the arbiter's judgment before a new one is
     // made; an agent without any gets its first skill straight away.
-    if (again.skills.length > 0 && requestIntent) {
+    if (pass.skills.length > 0 && requestIntent) {
       const verdict = await arbitrateSkillForRequest(
         c,
         connector,
         agent,
-        again.skills,
+        pass.skills,
         requestIntent,
         settings,
       );
       if (verdict.kind === 'existing') {
-        // Teach the router, so the next such request needs no arbiter.
-        if (again.intent) {
+        // Teach the router, so the next such request needs no arbiter. A
+        // verdict is worth learning from where a close call is not: a model
+        // read the request and named the skill.
+        if (pass.intent) {
           const [routing] = await connector.getSkillRoutings(c, {
             skill_id: verdict.skill.id,
           });
@@ -568,10 +671,10 @@ export async function routeRequestToSkill(
             connector,
             agent.id,
             verdict.skill.id,
-            routing?.embedding_model_id === again.intent.modelId
+            routing?.embedding_model_id === pass.intent.modelId
               ? routing
               : undefined,
-            again.intent,
+            pass.intent,
           );
         }
         return { skill: verdict.skill, decision: decision('arbitrated') };
@@ -579,7 +682,18 @@ export async function routeRequestToSkill(
       if (verdict.kind === 'unavailable') {
         // The conservative side: the closest skill, and nothing created.
         return {
-          skill: again.best ?? mostUsed(again.skills),
+          skill: pass.best ?? mostUsed(pass.skills),
+          decision: decision('embedding'),
+        };
+      }
+      if (!pass.canCreate) {
+        // New work, and nowhere to put it: the agent is at its cap. The
+        // closest skill serves it, as it did before the arbiter was asked.
+        warn(
+          `[SKILL_ROUTING] Agent ${agent.name} is at its cap of ${agent.max_auto_created_skills} auto-created skills; routing to ${(pass.best ?? mostUsed(pass.skills)).name}`,
+        );
+        return {
+          skill: pass.best ?? mostUsed(pass.skills),
           decision: decision('embedding'),
         };
       }
@@ -592,11 +706,30 @@ export async function routeRequestToSkill(
         agent,
         saRequestData,
         requestIntent ? intentText(requestIntent) : DEFAULT_INTENT,
-        again.intent,
-        again.skills,
+        pass.intent,
+        pass.skills,
       ),
       decision: decision('created'),
     };
+  };
+
+  // At the cap nothing is created, so there is nothing to serialise and no
+  // reason to make concurrent requests queue behind one arbiter call.
+  if (!first.canCreate) {
+    return settle(first);
+  }
+
+  // The arbiter is asked under the lease, so the lease has to outlast its
+  // budget -- one attempt and the client's one retry -- on top of creation.
+  const leaseMs =
+    SKILL_CREATION_LEASE_MS + 2 * skillArbiterTimeoutMs(agent, settings);
+
+  const underLease = async (): Promise<SkillRoutingResult> => {
+    const again = await routeOnce(c, connector, agent, requestIntent);
+    if (again.kind === 'routed') {
+      return again.result;
+    }
+    return settle(again);
   };
 
   return withSkillCreationLease(c, connector, agent, underLease, leaseMs);


### PR DESCRIPTION
Two defects, found from a misrouted log and confirmed against a real database. Both send requests to the wrong place; they are independent mechanisms, so the branch carries one commit each.

## 1. The cluster embedding read the conversation's opening

A request is placed among its skill's clusters by the embedding of its conversation, and the cluster decides which arms it draws from — so a wrong cluster is a wrong arm and a wrong system prompt.

`formatMessagesForEmbedding` rendered every message in order and left `embedText` to cut the result at 6000 characters, so the embedding was of the conversation's **opening**. An agentic session runs for hundreds of turns behind an opening that never changes, so every turn embedded the same text.

```
134 logs → 9 distinct embeddings, 118 of them byte-identical
clusters:  1: 113   2: 15   3: 5
```

The turn that prompted this was 240 messages into a session whose first 15 messages were all the embedding ever saw.

**Fix:** fill the budget from the end — whole messages, newest first, rendered back in order; only the newest is cut when it alone overruns. The per-message tool-output cap is unchanged and `embedText`'s slice stays as the last guard. Skill *routing* was already immune (`describeRequestIntent` reads from the end), which is the precedent this follows.

Verified on four consecutive logged requests that previously produced byte-identical text: they now produce four distinct texts, each about what that turn was doing.

## 2. Identity held every request above the threshold

An agent fed by one tool is sent the same system prompt with every request, so its skills score alike on identity — pinned at **0.971–0.975 across thirty consecutive requests**. Weighted at 0.6 that is a floor of 0.585 under every score, and a request could only fall below a 0.8 threshold with a conversation similarity under 0.54. The arbiter, whose whole job is to catch work that fits no skill, was unreachable. That agent's traffic went from six skills sharing it to one skill taking 126 of 143 requests in a day.

**Fix:** identity narrows the field and the conversation chooses within it. Skills within `IDENTITY_SEPARATION` of the best identity are the ones identity could not separate, and among those the score is the conversation alone; skills it did separate keep the 0.6/0.4 blend, so a second caller's skills stay marked down. Where identity singles one skill out, the blend stands.

Three changes fall out of it:

- **Both centroids are seeded.** Every skill the gateway creates for one caller is seeded from that caller's prompt — two pairs on the agent above are byte-identical — so the identity centroid cannot tell them apart, and a skill whose conversation centroid is null is scored on identity alone. The conversation centroid now starts from the skill's own description, the one text that is its own.
- **A skill learns only from decisions that were not close calls.** One that absorbs every request it barely won broadens until it is nearest to everything: the skill above beat every other on the conversation half, 0.810 to 0.669, for a request about running an end-to-end test. Named requests still teach a skill, and so does an arbitrated verdict, so this is not a skill's only way to follow its work.
- **The arbiter is asked at the agent's cap.** It cannot make a skill there, but its existing-skill verdict is the one way a request the centroids misfile reaches the skill it belongs to, and the cap is on how many skills an agent has rather than on whether its router may be corrected. Nothing is created under it, so it takes no creation lease.

## Notes

Stored log embeddings and drifted centroids are left as they are. `autoClusterSkill` reads only the logs after a skill's last clustering, and the centroids follow new traffic, so both recover on their own; an agent already collapsed onto one skill may want its `skill_routing` rows deleted to re-seed them.

## Test notes

Seven tests added across `embeddings.test.ts` and `skill-routing.test.ts`, four updated where the routing contract deliberately changed. Full suite: 218 files, 3312 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQ34DnR3kZemZ9Zipv86Dd
