### PR TITLE
Say what a request is while it is still running

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,15 +358,41 @@ Database management:
 
 A gateway request is written to `logs` when it reaches its agent, before a
 skill is chosen, and completed by an upsert under the same id when it
-finishes (`markRequestStarted` in `middlewares/logs.ts`, called from the
-agent-and-skill middleware). Until routing has picked the skill the row's
-`skill_id` is null -- the column is nullable for exactly this -- and the
-middleware writes the row again once it has, so the skill's own logs pick it
-up. A request that fails before a provider answers, routing included, is
-closed as a failed row with its status and an `error`, which is how the
-failures that used to leave no trace are seen. The dashboard learns of both
-ends over the event stream (`log:request-started`, `log:request-settled`)
-and draws a running row until the completion lands.
+finishes (`markRequestStarted` in `middlewares/logs.ts`). Until routing has
+picked the skill the row's `skill_id` is null -- the column is nullable for
+exactly this -- and the row is written again once it has, so the skill's own
+logs pick it up. A request that fails before a provider answers, routing
+included, is closed as a failed row with its status and an `error`, which is
+how the failures that used to leave no trace are seen. The dashboard learns
+of both ends over the event stream (`log:request-started`,
+`log:request-settled`) and draws a running row until the completion lands.
+
+**The row says what the request is, not only that there is one.** It opens
+with `request_body` -- the body the caller sent -- and
+`original_system_prompt`, so a request still in flight has a conversation to
+read; `ai_provider_request_log` is what finally reached the provider, and is
+null until it answers. It is written a third time from
+`saConfigurationInjectorMiddleware`, once a configuration has been pulled:
+`cluster_id`, the provider and model that will answer, and
+`served_system_prompt`, the prompt that configuration rendered. `metadata`
+carries what the gateway has decided so far in the shape the completion
+write uses -- `skill_routing` from the second write, `served_configuration`
+from the third -- so a running row reads like a finished one. `exchangeOf`
+(`@web/utils/log-exchange`) is what the log page renders from: the provider
+exchange when there is one, the client's own request until then.
+
+Each write names only what it knows, so a later one fills in without erasing
+an earlier one's columns, and they are **chained** through the context's
+`log_row_write`: none is awaited by the request, and an earlier, emptier
+write landing last would put a running row back on top of a finished one.
+What closes the row -- the completion write and `closeFailedRequest` --
+waits on that chain for the same reason.
+
+`skill_routing.duration_ms` is how long choosing the skill took, measured
+around `routeRequestToSkill`. The client waits for all of it before the
+provider is asked, so the routing strip reports it and `utils/log-trace.ts`
+cuts it out of the head of the request's first gap, which would otherwise
+draw a model call as undifferentiated gateway time.
 
 ## Coding Style & Naming Conventions
 

--- a/e2e/contract/log-lifecycle.spec.ts
+++ b/e2e/contract/log-lifecycle.spec.ts
@@ -106,6 +106,8 @@ test.describe('the log row a request opens', () => {
         .then((r) => r.json())) as {
         status: number | null;
         end_time: number | null;
+        skill_id: string | null;
+        request_body: { messages?: { content: string }[] } | null;
       }[];
 
     try {
@@ -124,7 +126,16 @@ test.describe('the log row a request opens', () => {
           message: 'the request was never shown as running',
         })
         .toEqual([null]);
-      expect((await rows())[0].status).toBeNull();
+      const [open] = await rows();
+      expect(open.status).toBeNull();
+      // And it carries the request itself, which is the only account of what
+      // is being asked until the provider answers. The dashboard renders the
+      // conversation from this; a row with the client's body dropped in
+      // transit -- JSONB one side, TEXT the other -- would draw an empty card.
+      expect(open.request_body?.messages?.[0].content).toBe(
+        'are you still there',
+      );
+      expect(open.skill_id).not.toBeNull();
 
       const response = await pending;
       expect(response.status()).toBe(200);

--- a/packages/api/scripts/upgrade-dev-db.mjs
+++ b/packages/api/scripts/upgrade-dev-db.mjs
@@ -20,6 +20,13 @@
  * relaxed `skill_id`, once the row moved to before skill routing: until
  * routing has picked the skill there is none to write.
  *
+ * Also two columns on `logs` for what a request is before a provider has
+ * answered it: `request_body`, the body the caller sent, and
+ * `served_system_prompt`, the prompt the pulled configuration rendered.
+ * Both are additive, so an ALTER each suffices; the `logs_with_eval_scores`
+ * view is `SELECT l.*`, which SQLite expands when the view is queried
+ * rather than when it was created, so it picks them up untouched.
+ *
  * Also the response review columns on `agents`: `reviewer_agent_id`, the
  * agent whose responses another agent reviews before the client sees them,
  * `review_fail_closed`, whether a response it could not judge is withheld,
@@ -85,6 +92,15 @@ const NULLABLE_NOW = [
   'cache_status',
 ];
 
+/**
+ * Columns added to `logs` since the initial schema, as `schema.ts` spells
+ * them. Additive and nullable, so an ALTER apiece is the whole upgrade.
+ */
+const LOG_COLUMNS = [
+  { name: 'request_body', definition: 'TEXT', after: [] },
+  { name: 'served_system_prompt', definition: 'TEXT', after: [] },
+];
+
 const columnsOf = async (table) => {
   const result = await client.execute(`PRAGMA table_info(${table})`);
   return result.rows.map((row) => ({
@@ -110,8 +126,15 @@ const main = async () => {
   const missingReviewColumns = REVIEW_COLUMNS.filter(
     ({ name }) => !agentColumns.some((column) => column.name === name),
   );
+  const missingLogColumns = LOG_COLUMNS.filter(
+    ({ name }) => !columns.some((column) => column.name === name),
+  );
 
-  if (!needsLogsRebuild && missingReviewColumns.length === 0) {
+  if (
+    !needsLogsRebuild &&
+    missingReviewColumns.length === 0 &&
+    missingLogColumns.length === 0
+  ) {
     console.log('Already up to date; nothing to do.');
     await refreshFingerprints();
     return;
@@ -125,10 +148,19 @@ const main = async () => {
   }
 
   for (const column of missingReviewColumns) {
-    await addReviewColumn(column);
+    await addColumn('agents', column);
   }
   if (needsLogsRebuild) {
     await rebuildLogs(columns);
+  }
+
+  // Re-read: a rebuild builds the current shape, so what is still missing
+  // afterwards is only what the rebuild did not cover.
+  const rebuilt = await columnsOf('logs');
+  for (const column of LOG_COLUMNS) {
+    if (!rebuilt.some(({ name }) => name === column.name)) {
+      await addColumn('logs', column);
+    }
   }
 
   await refreshFingerprints();
@@ -158,13 +190,13 @@ const REVIEW_COLUMNS = [
   },
 ];
 
-const addReviewColumn = async ({ name, definition, after }) => {
-  console.log(`Adding \`agents.${name}\`...`);
-  await client.execute(`ALTER TABLE agents ADD COLUMN ${name} ${definition}`);
+const addColumn = async (table, { name, definition, after }) => {
+  console.log(`Adding \`${table}.${name}\`...`);
+  await client.execute(`ALTER TABLE ${table} ADD COLUMN ${name} ${definition}`);
   for (const sql of after) {
     await client.execute(sql);
   }
-  console.log(`Added \`agents.${name}\`.`);
+  console.log(`Added \`${table}.${name}\`.`);
 };
 
 /** `columns` are the current `logs` columns, from `columnsOf`. */
@@ -197,6 +229,7 @@ const rebuildLogs = async (columns) => {
       start_time INTEGER NOT NULL,
       first_token_time INTEGER,
       base_sa_config TEXT NOT NULL,
+      request_body TEXT,
       status INTEGER,
       end_time INTEGER,
       duration INTEGER,
@@ -207,6 +240,7 @@ const rebuildLogs = async (columns) => {
       metadata TEXT NOT NULL,
       embedding TEXT DEFAULT NULL,
       original_system_prompt TEXT,
+      served_system_prompt TEXT,
       cache_status TEXT CHECK (
         cache_status IS NULL OR
         cache_status IN ('HIT', 'SEMANTIC_HIT', 'MISS', 'SEMANTIC_MISS', 'REFRESH', 'DISABLED')

--- a/packages/api/src/connectors/evaluations/argument-correctness/evaluate-log.test.ts
+++ b/packages/api/src/connectors/evaluations/argument-correctness/evaluate-log.test.ts
@@ -119,7 +119,9 @@ describe('Argument Correctness - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {
@@ -245,7 +247,9 @@ describe('Argument Correctness - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {

--- a/packages/api/src/connectors/evaluations/conversation-completeness/evaluate-log.test.ts
+++ b/packages/api/src/connectors/evaluations/conversation-completeness/evaluate-log.test.ts
@@ -113,7 +113,9 @@ describe('Conversation Completeness - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {
@@ -247,7 +249,9 @@ describe('Conversation Completeness - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {
@@ -444,7 +448,9 @@ describe('Conversation Completeness - agentic logs', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {
@@ -555,7 +561,9 @@ describe('Conversation Completeness - meta-conversation logs', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {

--- a/packages/api/src/connectors/evaluations/knowledge-retention/evaluate-log.test.ts
+++ b/packages/api/src/connectors/evaluations/knowledge-retention/evaluate-log.test.ts
@@ -114,7 +114,9 @@ describe('Knowledge Retention - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {
@@ -256,7 +258,9 @@ describe('Knowledge Retention - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {
@@ -383,7 +387,9 @@ describe('Knowledge Retention - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {

--- a/packages/api/src/connectors/evaluations/latency/evaluate-log.test.ts
+++ b/packages/api/src/connectors/evaluations/latency/evaluate-log.test.ts
@@ -46,7 +46,9 @@ describe('Latency - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {

--- a/packages/api/src/connectors/evaluations/role-adherence/evaluate-log.test.ts
+++ b/packages/api/src/connectors/evaluations/role-adherence/evaluate-log.test.ts
@@ -114,7 +114,9 @@ describe('Role Adherence - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {
@@ -253,7 +255,9 @@ describe('Role Adherence - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {

--- a/packages/api/src/connectors/evaluations/task-completion/evaluate-log.test.ts
+++ b/packages/api/src/connectors/evaluations/task-completion/evaluate-log.test.ts
@@ -127,7 +127,9 @@ describe('Task Completion - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {
@@ -261,7 +263,9 @@ describe('Task Completion - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {
@@ -479,7 +483,9 @@ describe('Task Completion - agentic logs', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {

--- a/packages/api/src/connectors/evaluations/turn-relevancy/evaluate-log.test.ts
+++ b/packages/api/src/connectors/evaluations/turn-relevancy/evaluate-log.test.ts
@@ -112,7 +112,9 @@ describe('Turn Relevancy - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {
@@ -232,7 +234,9 @@ describe('Turn Relevancy - evaluateLog', () => {
       app_id: null,
       external_user_id: null,
       external_user_human_name: null,
+      request_body: null,
       original_system_prompt: null,
+      served_system_prompt: null,
       user_metadata: null,
       metadata: {},
       ai_provider_request_log: {

--- a/packages/api/src/connectors/libsql/logs.ts
+++ b/packages/api/src/connectors/libsql/logs.ts
@@ -96,8 +96,8 @@ export const libsqlLogsStorageConnector: LogsStorageConnector = {
     c: AppContext,
     startParams: LogStartParams,
   ): Promise<void> => {
-    const { base_sa_config, ...rest } = startParams as LogStartParams &
-      Record<string, unknown>;
+    const { base_sa_config, request_body, metadata, ...rest } =
+      startParams as LogStartParams & Record<string, unknown>;
 
     await insertInto(
       getLibsqlClient(c),
@@ -105,9 +105,12 @@ export const libsqlLogsStorageConnector: LogsStorageConnector = {
       {
         ...asColumns(rest),
         base_sa_config: toJsonColumn(base_sa_config),
-        // NOT NULL with nothing to put in them yet.
+        request_body:
+          request_body === undefined ? undefined : toJsonColumn(request_body),
+        // NOT NULL, and nothing to put in `hook_logs` until the hooks have
+        // run. `metadata` carries whatever the gateway has decided so far.
         hook_logs: toJsonColumn([]),
-        metadata: toJsonColumn({}),
+        metadata: toJsonColumn(metadata ?? {}),
       },
       z.array(Log),
       // A retried request could reuse an id; completing the row beats failing.

--- a/packages/api/src/connectors/libsql/query.ts
+++ b/packages/api/src/connectors/libsql/query.ts
@@ -21,6 +21,7 @@ const JSON_COLUMNS: Record<string, string[]> = {
   tools: ['raw_data'],
   logs: [
     'base_sa_config',
+    'request_body',
     'ai_provider_request_log',
     'hook_logs',
     'metadata',

--- a/packages/api/src/connectors/libsql/schema.ts
+++ b/packages/api/src/connectors/libsql/schema.ts
@@ -295,6 +295,11 @@ const initialSchema: LibsqlMigration = {
       start_time INTEGER NOT NULL,
       first_token_time INTEGER,
       base_sa_config TEXT NOT NULL,
+      -- The body the caller sent, recorded when the row opens: the only
+      -- account of a request that is still running, or that failed before a
+      -- provider answered. ai_provider_request_log holds the body that
+      -- finally reached the provider.
+      request_body TEXT,
       -- Null while the request is still running. The row is written when the
       -- request arrives rather than when it finishes, so that work in
       -- progress is visible and a request that fails before reaching a
@@ -310,6 +315,10 @@ const initialSchema: LibsqlMigration = {
       metadata TEXT NOT NULL,
       embedding TEXT DEFAULT NULL,
       original_system_prompt TEXT,
+      -- The prompt the gateway chose, written as soon as the configuration
+      -- serving the request is pulled -- before the provider is asked, so
+      -- that a request still in flight can be read.
+      served_system_prompt TEXT,
       cache_status TEXT CHECK (
         cache_status IS NULL OR
         cache_status IN ('HIT', 'SEMANTIC_HIT', 'MISS', 'SEMANTIC_MISS', 'REFRESH', 'DISABLED')

--- a/packages/api/src/connectors/supabase/supabase.ts
+++ b/packages/api/src/connectors/supabase/supabase.ts
@@ -1504,9 +1504,10 @@ export const supabaseLogsStorageConnector: LogsStorageConnector = {
       'logs',
       {
         ...startParams,
-        // NOT NULL with nothing to put in them yet.
+        // NOT NULL, and nothing to put in `hook_logs` until the hooks have
+        // run. `metadata` carries whatever the gateway has decided so far.
         hook_logs: [],
-        metadata: {},
+        metadata: startParams.metadata ?? {},
       },
       null,
       // A retried request could reuse an id; completing the row beats failing.

--- a/packages/api/src/middlewares/logs.test.ts
+++ b/packages/api/src/middlewares/logs.test.ts
@@ -88,11 +88,14 @@ describe('logsMiddleware', () => {
   let app: Hono<AppEnv>;
   /** What the handler under test leaves on the context, beyond the usual. */
   let arrange: (c: AppContext) => void;
+  /** What happens once the handler has answered, before the row is closed. */
+  let settle: (c: AppContext) => void;
   let providerLog: AIProviderRequestLog;
 
   beforeEach(() => {
     vi.clearAllMocks();
     arrange = () => undefined;
+    settle = () => undefined;
     providerLog = { ...aiProviderLog };
     requestData = {
       functionName: FunctionName.CHAT_COMPLETE,
@@ -132,6 +135,10 @@ describe('logsMiddleware', () => {
           () => logsConnector as unknown as LogsStorageConnector,
         ),
       )
+      .use('*', async (c, next) => {
+        await next();
+        settle(c);
+      })
       .post('/v1/chat/completions', (c) => {
         c.set('sa_config', saConfig);
         c.set('agent', agent);
@@ -165,6 +172,44 @@ describe('logsMiddleware', () => {
     expect(log.original_system_prompt).toBe('You are the caller.');
     expect(log.skill_id).toBe('skill-1');
     expect(log.agent_id).toBe('agent-1');
+  });
+
+  it('closes a failed request whose answer is read while its row is still being written', async () => {
+    // The failure's message is read off the response the client is being
+    // given, and the row it closes may still be being written. Waiting for
+    // that write before taking the copy is waiting long enough for the body
+    // to be consumed -- and a clone of a consumed body throws, which used to
+    // lose the failure altogether rather than merely lose its message.
+    arrange = (c) => {
+      // No provider was reached, so the row is closed as a failure.
+      c.set('ai_provider_log', undefined);
+    };
+    settle = (c) => {
+      c.res = new Response(JSON.stringify({ error: 'nothing answered' }), {
+        status: 502,
+        headers: { 'content-type': 'application/json' },
+      });
+      // Still in flight when the request fails...
+      c.set(
+        'log_row_write',
+        new Promise<void>((resolve) => setTimeout(resolve, 20)),
+      );
+      // ...and the client has read the answer before it lands.
+      setTimeout(() => void c.res.text(), 0);
+    };
+
+    const response = await app.request('/v1/chat/completions', {
+      method: 'POST',
+    });
+    expect(response.status).toBe(502);
+
+    await vi.waitFor(() =>
+      expect(logsConnector.failLog).toHaveBeenCalledTimes(1),
+    );
+    expect(logsConnector.failLog.mock.calls[0][1]).toMatchObject({
+      status: 502,
+      error: 'nothing answered',
+    });
   });
 
   it('records how the skill was chosen', async () => {

--- a/packages/api/src/middlewares/logs.test.ts
+++ b/packages/api/src/middlewares/logs.test.ts
@@ -292,6 +292,14 @@ describe('logsMiddleware', () => {
 describe('markRequestStarted', () => {
   const startLog = vi.fn().mockResolvedValue(undefined);
 
+  const clientBody = {
+    model: 'gpt-4o',
+    messages: [
+      { role: 'system', content: 'You are the caller.' },
+      { role: 'user', content: 'Translate this.' },
+    ],
+  };
+
   /** What the agent-and-skill middleware has on the context when it calls. */
   const arrived = {
     log_request_id: 'request-1',
@@ -300,29 +308,45 @@ describe('markRequestStarted', () => {
       functionName: FunctionName.CHAT_COMPLETE,
       method: HttpMethod.POST,
       url: 'http://localhost/v1/chat/completions',
-      requestBody: { model: 'gpt-4o', messages: [] },
+      requestBody: clientBody,
     },
     sa_config_pre_processed: saConfig,
     agent,
     logs_storage_connector: { startLog },
   };
 
-  const context = (values: Record<string, unknown>): AppContext =>
-    ({
+  /**
+   * A context that remembers what is set on it, since the writes chain
+   * through `log_row_write` and each call reads the one before.
+   */
+  const context = (values: Record<string, unknown>): AppContext => {
+    const state = { ...values };
+    return {
       req: { url: 'http://localhost/v1/chat/completions' },
-      get: (key: string) => values[key],
-    }) as unknown as AppContext;
+      get: (key: string) => state[key],
+      set: (key: string, value: unknown) => {
+        state[key] = value;
+      },
+    } as unknown as AppContext;
+  };
+
+  /** Everything the row has been written with, in the order it was written. */
+  const written = async (c: AppContext) => {
+    await c.get('log_row_write');
+    return startLog.mock.calls.map(([, params]) => params);
+  };
 
   beforeEach(() => {
-    startLog.mockClear();
+    startLog.mockReset();
+    startLog.mockResolvedValue(undefined);
     vi.mocked(emitSSEEvent).mockClear();
   });
 
   it('opens the row with no skill as soon as the agent is known', async () => {
-    markRequestStarted(context(arrived));
+    const c = context(arrived);
+    markRequestStarted(c);
 
-    expect(startLog).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(await written(c)).toEqual([
       expect.objectContaining({
         id: 'request-1',
         agent_id: 'agent-1',
@@ -330,42 +354,104 @@ describe('markRequestStarted', () => {
         start_time: 1000,
         model: 'gpt-4o',
       }),
-    );
-    await vi.waitFor(() =>
-      expect(emitSSEEvent).toHaveBeenCalledWith('log:request-started', {
-        log_id: 'request-1',
-        agent_id: 'agent-1',
-        skill_id: null,
-      }),
-    );
+    ]);
+    expect(emitSSEEvent).toHaveBeenCalledWith('log:request-started', {
+      log_id: 'request-1',
+      agent_id: 'agent-1',
+      skill_id: null,
+    });
   });
 
-  it('opens the row for a request that named only its agent', () => {
+  it('records the request the client made, before anything has served it', async () => {
+    // The row is the only account of the request until a provider answers,
+    // so what the caller sent has to be on it from the start.
+    const c = context(arrived);
+    markRequestStarted(c);
+
+    expect((await written(c))[0]).toMatchObject({
+      request_body: clientBody,
+      original_system_prompt: 'You are the caller.',
+      metadata: {},
+    });
+  });
+
+  it('opens the row for a request that named only its agent', async () => {
     // No `skill_name` in the header: routing will pick one. The config
     // schema the completion write parses with would refuse this.
-    markRequestStarted(
-      context({
-        ...arrived,
-        sa_config_pre_processed: { agent_name: 'helper', trace_id: 'trace-1' },
-      }),
-    );
+    const c = context({
+      ...arrived,
+      sa_config_pre_processed: { agent_name: 'helper', trace_id: 'trace-1' },
+    });
+    markRequestStarted(c);
 
-    expect(startLog).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        skill_id: null,
-        base_sa_config: { agent_name: 'helper' },
-      }),
-    );
+    expect((await written(c))[0]).toMatchObject({
+      skill_id: null,
+      base_sa_config: { agent_name: 'helper' },
+    });
   });
 
-  it('writes the row again with the skill once routing has picked one', () => {
-    markRequestStarted(context({ ...arrived, skill }));
+  it('writes the row again with the skill and how it was chosen', async () => {
+    const c = context({ ...arrived, skill, skill_routing: decision });
+    markRequestStarted(c);
 
-    expect(startLog).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ id: 'request-1', skill_id: 'skill-1' }),
+    expect((await written(c))[0]).toMatchObject({
+      id: 'request-1',
+      skill_id: 'skill-1',
+      metadata: { skill_routing: decision },
+    });
+  });
+
+  it('writes the row again with the configuration serving the request', async () => {
+    const c = context({
+      ...arrived,
+      skill,
+      pulled_arm: pulledArm,
+      sa_config: {
+        ...saConfig,
+        targets: [
+          {
+            configuration: {
+              ai_provider: 'openai',
+              model: 'gpt-5.6',
+              system_prompt: 'You translate text.',
+            },
+          },
+        ],
+      },
+    });
+    markRequestStarted(c);
+
+    expect((await written(c))[0]).toMatchObject({
+      cluster_id: 'cluster-1',
+      served_system_prompt: 'You translate text.',
+      ai_provider: 'openai',
+      model: 'gpt-5.6',
+      metadata: { served_configuration: { id: 'arm-1', name: '7' } },
+    });
+  });
+
+  it('lands the writes in the order they were made', async () => {
+    // None of them is awaited by the request, and an earlier, emptier write
+    // landing last would put a row with no skill on top of one with one.
+    const landed: (string | null)[] = [];
+    startLog.mockImplementation(async (_c, params) => {
+      // The first write is made to take longer than the second.
+      await new Promise((resolve) =>
+        setTimeout(resolve, params.skill_id ? 0 : 5),
+      );
+      landed.push(params.skill_id);
+    });
+
+    const c = context(arrived);
+    markRequestStarted(c);
+    (c as unknown as { set: (k: string, v: unknown) => void }).set(
+      'skill',
+      skill,
     );
+    markRequestStarted(c);
+    await c.get('log_row_write');
+
+    expect(landed).toEqual([null, 'skill-1']);
   });
 });
 

--- a/packages/api/src/middlewares/logs.ts
+++ b/packages/api/src/middlewares/logs.ts
@@ -494,6 +494,12 @@ async function processLogs({
 
   await broadcastLog(JSON.stringify(createParams));
 
+  // The writes that opened this row are not awaited by the request, so one
+  // may still be in flight. Letting it land first is what keeps it from
+  // arriving after the completion and putting a running row back on top of
+  // a finished one.
+  await c.get('log_row_write');
+
   // Store the log in the configured logs storage connector
   try {
     const insertedLog = await logsStorageConnector.createLog(c, createParams);
@@ -615,6 +621,12 @@ const closeFailedRequest = async (
   status?: number,
 ): Promise<void> => {
   try {
+    // The writes that opened the row are not awaited by the request. Closing
+    // it before the last of them lands would either be undone by it, or --
+    // if the row does not exist yet -- update nothing and leave the request
+    // running for ever, since `failLog` never creates a row.
+    await c.get('log_row_write');
+
     const endTime = Date.now();
     const responseStatus = status ?? c.res.status;
 
@@ -644,18 +656,6 @@ const closeFailedRequest = async (
 };
 
 /**
- * Announce a request that is on its way to a provider, so the dashboard can
- * show it as a pending row while it runs.
- *
- * Called from the agent-and-skill middleware twice: as soon as the agent is
- * known, with no skill yet, and again once routing has picked one. The row
- * is upserted, so the second call fills the skill in. Announcing before
- * routing is what keeps its dead time -- embedding the request, compacting
- * its prompt, the arbiter -- out of the wait for the row to appear, which is
- * the row's whole purpose. This middleware's own pre-handler section cannot
- * do it: it runs before the agent has been resolved.
- */
-/**
  * The config as the arriving row records it. `skill_name` is optional here,
  * unlike in `NonPrivateSuperAgentsConfig`: before routing there is none, and
  * the completion write records the config with the skill routing chose.
@@ -664,6 +664,47 @@ const ArrivingSuperAgentsConfig = NonPrivateSuperAgentsConfig.extend({
   skill_name: z.string().optional(),
 });
 
+/**
+ * What the gateway has settled about the request so far, in the shape the
+ * completion write uses, so that a row still running reads like a finished
+ * one. Both keys are absent until the step that decides them has run.
+ */
+const metadataSoFar = (c: AppContext): Record<string, unknown> => {
+  const skillRouting = c.get('skill_routing');
+  const pulledArm = c.get('pulled_arm');
+  return {
+    ...(skillRouting ? { skill_routing: skillRouting } : {}),
+    ...(pulledArm
+      ? {
+          served_configuration: {
+            id: pulledArm.id,
+            name: pulledArm.name,
+          } satisfies ServedConfiguration,
+        }
+      : {}),
+  };
+};
+
+/**
+ * Announce a request that is on its way to a provider, so the dashboard can
+ * show what is known about it while it runs.
+ *
+ * Called three times: from the agent-and-skill middleware as soon as the
+ * agent is known, with nothing decided yet, and again once routing has
+ * picked the skill, and from the configuration injector once a
+ * configuration has been pulled for it. The row is upserted and each write
+ * names only what it knows, so a later call fills in without erasing an
+ * earlier one's columns. Announcing before routing is what keeps its dead
+ * time -- embedding the request, compacting its prompt, the arbiter -- out
+ * of the wait for the row to appear, which is the row's whole purpose;
+ * announcing again after each decision is what makes that wait legible
+ * rather than a spinner. This middleware's own pre-handler section cannot
+ * do the first one: it runs before the agent has been resolved.
+ *
+ * The writes are chained rather than merely started, because they overlap:
+ * none is awaited by the request, and one landing out of order would put
+ * the earlier, emptier row on top of the later one.
+ */
 export const markRequestStarted = (c: AppContext): void => {
   // Nothing about a row that exists to be looked at is worth failing a
   // request over, and this runs on every request the gateway serves.
@@ -685,40 +726,54 @@ export const markRequestStarted = (c: AppContext): void => {
 
     const requestBody = (saRequestData as { requestBody?: unknown })
       .requestBody;
-    const model =
+    const clientBody =
       requestBody &&
       typeof requestBody === 'object' &&
-      'model' in requestBody &&
-      typeof requestBody.model === 'string'
-        ? requestBody.model
+      !Array.isArray(requestBody)
+        ? (requestBody as Record<string, unknown>)
+        : undefined;
+    const model =
+      clientBody && typeof clientBody.model === 'string'
+        ? clientBody.model
         : undefined;
 
     // The pre-processed config, not `sa_config`: that one is injected by a
-    // middleware that runs *after* the skill resolves, so at this point it
-    // does not exist yet. Parsing through `NonPrivateSuperAgentsConfig`
-    // strips the targets, which carry the caller's provider keys.
+    // middleware that runs *after* the skill resolves, so on the first two
+    // calls it does not exist yet. Parsing through
+    // `NonPrivateSuperAgentsConfig` strips the targets, which carry the
+    // caller's provider keys.
     const saConfig = c.get('sa_config') ?? c.get('sa_config_pre_processed');
+    // The configuration the request will be sent with, once one has been
+    // pulled. The first target is the one that serves unless it fails, and
+    // the fallbacks would each be a request of their own.
+    const served = c.get('sa_config')?.targets[0]?.configuration;
+    const pulledArm = c.get('pulled_arm');
     const startParams: LogStartParams = {
       id: requestId,
       agent_id: c.get('agent').id,
       // Unset until routing has picked one; the second call fills it in.
       skill_id: (c.get('skill') as Skill | undefined)?.id ?? null,
+      cluster_id: pulledArm?.cluster_id,
       method: saRequestData.method,
       endpoint: url.pathname,
       function_name: saRequestData.functionName,
       start_time: c.get('log_start_time') ?? Date.now(),
       base_sa_config: ArrivingSuperAgentsConfig.parse(saConfig),
-      model,
+      request_body: clientBody,
+      original_system_prompt: extractSystemPrompt(saRequestData) ?? undefined,
+      served_system_prompt: served?.system_prompt ?? undefined,
+      metadata: metadataSoFar(c),
+      ai_provider: served?.ai_provider,
+      model: served?.model ?? model,
       trace_id: saConfig.trace_id ?? undefined,
     };
 
-    // Not awaited: a request must not wait on a write that exists so someone
-    // can watch it. The completion write is an upsert, so whichever of the
-    // two lands first, the row ends up right.
-    void c
-      .get('logs_storage_connector')
-      .startLog(c, startParams)
-      ?.then(() => {
+    // Not awaited by the request: it must not wait on a write that exists so
+    // someone can watch it. What closes the row does wait, so the writes
+    // cannot cross.
+    const written = (c.get('log_row_write') ?? Promise.resolve())
+      .then(() => c.get('logs_storage_connector').startLog(c, startParams))
+      .then(() => {
         emitSSEEvent('log:request-started', {
           log_id: requestId,
           agent_id: startParams.agent_id,
@@ -728,6 +783,7 @@ export const markRequestStarted = (c: AppContext): void => {
       .catch((e: unknown) => {
         warn('[Logs] Could not open the row for a request:', e);
       });
+    c.set('log_row_write', written);
   } catch (e) {
     warn('[Logs] Could not open the row for a request:', e);
   }

--- a/packages/api/src/middlewares/logs.ts
+++ b/packages/api/src/middlewares/logs.ts
@@ -621,6 +621,14 @@ const closeFailedRequest = async (
   status?: number,
 ): Promise<void> => {
   try {
+    const responseStatus = status ?? c.res.status;
+
+    // Taken before anything is awaited, and read after. `c.res` is on its
+    // way to the client, so a clone taken later finds a body already
+    // consumed and throws -- which used to lose the failure entirely, since
+    // nothing below would then run.
+    const answered = reason === undefined ? c.res.clone() : null;
+
     // The writes that opened the row are not awaited by the request. Closing
     // it before the last of them lands would either be undone by it, or --
     // if the row does not exist yet -- update nothing and leave the request
@@ -628,18 +636,15 @@ const closeFailedRequest = async (
     await c.get('log_row_write');
 
     const endTime = Date.now();
-    const responseStatus = status ?? c.res.status;
 
-    let message = reason;
-    if (!message) {
-      // The gateway answers an error as JSON; anything else is not worth
-      // storing, and neither is a body large enough to matter.
-      message = await c.res
-        .clone()
-        .text()
+    // The gateway answers an error as JSON; anything else is not worth
+    // storing, and neither is a body large enough to matter.
+    const message =
+      reason ??
+      (await answered
+        ?.text()
         .then(errorMessageFrom)
-        .catch(() => undefined);
-    }
+        .catch(() => undefined));
 
     await c.get('logs_storage_connector').failLog(c, {
       id: requestId,

--- a/packages/api/src/middlewares/super-agents-configuration.ts
+++ b/packages/api/src/middlewares/super-agents-configuration.ts
@@ -1,3 +1,4 @@
+import { markRequestStarted } from '@api/middlewares/logs';
 import { handleGenerateArms } from '@api/optimization/skill-optimizations';
 import type { UserDataStorageConnector } from '@api/types/connector';
 import type { AppContext } from '@api/types/hono';
@@ -550,6 +551,12 @@ export const saConfigurationInjectorMiddleware = createMiddleware(
         };
 
         c.set('sa_config', saConfig);
+
+        // The row again, now that the request has a configuration: which one
+        // was pulled, the prompt it rendered and the model that will answer.
+        // Until the provider does, this is the only account of what the
+        // request is being sent as.
+        markRequestStarted(c);
       }
     }
     await next();

--- a/packages/api/src/types/hono.ts
+++ b/packages/api/src/types/hono.ts
@@ -71,6 +71,13 @@ export interface AppEnv {
     log_request_id?: string;
     /** When the request arrived, shared by the row opened then and its completion. */
     log_start_time?: number;
+    /**
+     * The last write to that row, so the next one chains onto it. The row is
+     * written several times as the request progresses and none of the writes
+     * is awaited by the request, so without this an earlier, emptier write
+     * could land on top of a later one.
+     */
+    log_row_write?: Promise<void>;
     ai_provider_log?: AIProviderRequestLog;
     hook_logs?: HookLog[];
     first_token_time?: number;

--- a/packages/api/src/utils/super-agents/skill-routing.test.ts
+++ b/packages/api/src/utils/super-agents/skill-routing.test.ts
@@ -201,6 +201,7 @@ describe('routeRequestToSkill', () => {
         identity_similarity: null,
         conversation_similarity: null,
         // Every decision is timed, whichever way it was reached.
+        duration_ms: expect.any(Number),
       });
       expect(resolveEmbeddingModelConfig).not.toHaveBeenCalled();
       expect(embedText).not.toHaveBeenCalled();
@@ -409,6 +410,7 @@ describe('routeRequestToSkill', () => {
         candidates: 0,
         identity_similarity: null,
         conversation_similarity: null,
+        duration_ms: expect.any(Number),
       });
       expect(arbitrateSkillForRequest).not.toHaveBeenCalled();
       expect(createSkillForRequest).toHaveBeenCalledWith(

--- a/packages/api/src/utils/super-agents/skill-routing.ts
+++ b/packages/api/src/utils/super-agents/skill-routing.ts
@@ -629,6 +629,24 @@ export async function routeRequestToSkill(
   agent: Agent,
   saRequestData: SuperAgentsRequestData,
 ): Promise<SkillRoutingResult> {
+  // Timed here rather than at each of the ways out below, so that every
+  // decision carries how long it took to reach -- an embedding on the quick
+  // path, the arbiter and a new skill on the slow one. The client waits for
+  // all of it before the provider is asked, so the log records it.
+  const startedAt = Date.now();
+  const result = await chooseSkill(c, connector, agent, saRequestData);
+  return {
+    ...result,
+    decision: { ...result.decision, duration_ms: Date.now() - startedAt },
+  };
+}
+
+async function chooseSkill(
+  c: AppContext,
+  connector: UserDataStorageConnector,
+  agent: Agent,
+  saRequestData: SuperAgentsRequestData,
+): Promise<SkillRoutingResult> {
   const requestIntent = describeRequestIntent(saRequestData);
   const first = await routeOnce(c, connector, agent, requestIntent);
   if (first.kind === 'routed') {

--- a/packages/shared/src/types/data/log.test.ts
+++ b/packages/shared/src/types/data/log.test.ts
@@ -23,10 +23,12 @@ const base = {
   start_time: 1000,
   first_token_time: null,
   base_sa_config: {},
+  request_body: { model: 'gpt-5.6', messages: [] },
   hook_logs: [],
   metadata: {},
   embedding: null,
   original_system_prompt: null,
+  served_system_prompt: null,
   error: null,
   trace_id: null,
   parent_span_id: null,
@@ -92,6 +94,21 @@ describe('Log', () => {
     };
 
     expect(Log.safeParse(failed).success).toBe(true);
+  });
+
+  it('keeps the request a row that has not answered was opened with', () => {
+    // The row is the only account of a request until the provider answers,
+    // so what the caller sent has to survive it.
+    const log = Log.parse(running);
+
+    expect(log.request_body).toEqual({ model: 'gpt-5.6', messages: [] });
+  });
+
+  it('accepts a row written before the request was recorded', () => {
+    // Every row predating those columns reads them as null.
+    const old = { ...running, request_body: null, served_system_prompt: null };
+
+    expect(Log.safeParse(old).success).toBe(true);
   });
 
   it('still requires what a request has on arrival', () => {

--- a/packages/shared/src/types/data/log.ts
+++ b/packages/shared/src/types/data/log.ts
@@ -79,6 +79,15 @@ export const Log = z.object({
   start_time: z.number(),
   first_token_time: z.number().nullable(),
   base_sa_config: z.record(z.string(), z.unknown()),
+  /**
+   * The body the caller sent, recorded when the row opens. It is what the
+   * request *was*, before a skill was chosen for it or a prompt substituted
+   * into it, which is the only account of a request that is still running or
+   * that failed before a provider answered.
+   * `ai_provider_request_log.request_body` is the body that finally reached
+   * the provider. Null on a row written before the gateway recorded it.
+   */
+  request_body: z.record(z.string(), z.unknown()).nullable(),
 
   /**
    * Everything below is null while the request is still running.
@@ -106,6 +115,15 @@ export const Log = z.object({
    * received. `ai_provider_request_log` holds the body that reached the
    * provider, in which an optimized skill has substituted its own prompt. */
   original_system_prompt: z.string().nullable(),
+  /**
+   * The system prompt the gateway chose for the request, written as soon as
+   * the configuration serving it is pulled -- before the provider is asked,
+   * so that a request still in flight can be read. A finished request
+   * carries it inside `ai_provider_request_log.request_body` too; this is
+   * what a running one has instead. Null when the skill substituted nothing,
+   * and on a row written before the gateway recorded it.
+   */
+  served_system_prompt: z.string().nullable(),
 
   // Cache info
   cache_status: z.enum(CacheStatus).nullable(),
@@ -221,19 +239,37 @@ export const LogsQueryParams = z.object({
 export type LogsQueryParams = z.infer<typeof LogsQueryParams>;
 
 /**
- * The row written when a request arrives, before anything is known about how
- * it went. Completed by `LogCreateParams` under the same `id`.
+ * The row as the request is still being served, written whenever the gateway
+ * learns something worth showing: when the request arrives, once routing has
+ * chosen its skill, and once a configuration has been pulled for it. Each
+ * write names only what it knows, so a later one never erases an earlier
+ * one's columns. Completed by `LogCreateParams` under the same `id`.
  */
 export const LogStartParams = z.object({
   id: z.uuid(),
   agent_id: z.uuid(),
   /** Null when the row opens before routing; written again once it is known. */
   skill_id: z.uuid().nullable(),
+  /** Unset until the optimizer has pulled a configuration. */
+  cluster_id: z.uuid().optional(),
   method: z.enum(HttpMethod),
   endpoint: z.string(),
   function_name: z.enum(FunctionName),
   start_time: z.number(),
   base_sa_config: z.record(z.string(), z.unknown()),
+  /** The body the caller sent, so a request in flight can be read. */
+  request_body: z.record(z.string(), z.unknown()).optional(),
+  original_system_prompt: z.string().optional(),
+  /** The prompt the pulled configuration rendered, once there is one. */
+  served_system_prompt: z.string().optional(),
+  /**
+   * What the gateway has decided so far -- how it routed the request, which
+   * configuration it pulled -- in the shape the completion write uses, so a
+   * running row reads like a finished one.
+   */
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  /** Resolved once a configuration is pulled; the caller's before that. */
+  ai_provider: z.enum(AIProvider).optional(),
   /** What the caller asked for; the arm may resolve something else. */
   model: z.string().optional(),
   trace_id: z.string().optional(),

--- a/packages/shared/src/types/data/skill-routing.ts
+++ b/packages/shared/src/types/data/skill-routing.ts
@@ -79,5 +79,13 @@ export const SkillRoutingDecision = z.object({
   /** The two halves of the score, when both were computed. */
   identity_similarity: z.number().nullable().optional(),
   conversation_similarity: z.number().nullable().optional(),
+  /**
+   * How long choosing took, in milliseconds -- the embeddings, and on a miss
+   * the arbiter and the skill it created. The client waits for all of it
+   * before the provider is even asked, which is why it is worth recording
+   * separately from the request's own duration. Absent on a log written
+   * before the gateway measured it.
+   */
+  duration_ms: z.number().min(0).optional(),
 });
 export type SkillRoutingDecision = z.infer<typeof SkillRoutingDecision>;

--- a/packages/web/src/components/agents/skills/logs/log-details-view.tsx
+++ b/packages/web/src/components/agents/skills/logs/log-details-view.tsx
@@ -42,6 +42,7 @@ import {
   createSkillAvatar,
 } from '@web/utils/avatars';
 import { describeHookLog, summariseHooks } from '@web/utils/hook-outcome';
+import { exchangeOf } from '@web/utils/log-exchange';
 import { outcomeOf } from '@web/utils/log-outcome';
 import { traceOf } from '@web/utils/log-trace';
 import { reviewOf } from '@web/utils/reviews';
@@ -275,27 +276,11 @@ export function LogDetailsView(): ReactElement {
 
   // Derived, not set in an effect, so a log switch never paints a frame of
   // the previous log's messages under the new log's header.
-  const saRequestData = useMemo((): SuperAgentsRequestData | null => {
-    if (!selectedLog) return null;
-    // Still running, or failed before a provider answered: there is no
-    // exchange to render, and the view says so instead.
-    if (!selectedLog.ai_provider_request_log) return null;
-    // A log recorded against a route or body shape this build no longer
-    // knows how to parse should cost us this one view, not the whole
-    // dashboard -- the error boundary above wraps every provider.
-    try {
-      return produceSuperAgentsRequestData(
-        selectedLog.ai_provider_request_log.method,
-        selectedLog.ai_provider_request_log.request_url,
-        {},
-        selectedLog.ai_provider_request_log.request_body,
-        selectedLog.ai_provider_request_log.response_body,
-      );
-    } catch (error) {
-      console.error('Failed to parse the log request data:', error);
-      return null;
-    }
-  }, [selectedLog]);
+  const saRequestData = useMemo(
+    (): SuperAgentsRequestData | null =>
+      selectedLog ? exchangeOf(selectedLog, window.location.origin) : null,
+    [selectedLog],
+  );
 
   // What the model wrote when the client did not receive it. A hook keeps
   // the response it withheld or replaced on its own log, since the provider
@@ -342,6 +327,26 @@ export function LogDetailsView(): ReactElement {
     return original === extractSystemPrompt(saRequestData) ? null : original;
   }, [selectedLog?.original_system_prompt, saRequestData]);
 
+  // The prompt the gateway chose, while the request is still being served,
+  // and where it came from. Once the provider has answered, the conversation
+  // below is the body that was sent and this prompt is its system message;
+  // before that, the conversation is the client's own request, so the prompt
+  // the skill substituted has nowhere else to appear.
+  const selectedSystemPrompt = useMemo(() => {
+    if (!selectedLog || selectedLog.ai_provider_request_log) return null;
+    const prompt = selectedLog.served_system_prompt;
+    if (!prompt || prompt === selectedLog.original_system_prompt) return null;
+    return {
+      prompt,
+      origin: describeSystemPromptOrigin({
+        partition: clusterName,
+        configuration: readServedConfiguration(selectedLog.metadata),
+        clientPrompt: selectedLog.original_system_prompt,
+        sentPrompt: prompt,
+      }),
+    };
+  }, [selectedLog, clusterName]);
+
   // The configuration that served the request, named on the header line
   // beside its partition.
   const servedConfiguration = useMemo(
@@ -353,6 +358,10 @@ export function LogDetailsView(): ReactElement {
   // the optimizer pulled, or the client, when the skill substituted nothing.
   const systemPromptOrigin = useMemo(() => {
     if (!selectedLog) return null;
+    // The badge labels the conversation's system message, which is the
+    // client's own until a provider has answered: nothing has replaced it
+    // yet, and the prompt that will is its own panel above.
+    if (!selectedLog.ai_provider_request_log) return null;
     return describeSystemPromptOrigin({
       partition: clusterName,
       configuration: readServedConfiguration(selectedLog.metadata),
@@ -719,6 +728,37 @@ export function LogDetailsView(): ReactElement {
                         className="text-xs text-muted-foreground"
                       >
                         as sent by the client
+                      </Badge>
+                    </div>
+                  </GenericViewer>
+                )}
+                {selectedLog && selectedSystemPrompt && (
+                  <GenericViewer
+                    path={`${selectedLog.id}-served-system-prompt`}
+                    language={'text'}
+                    defaultValue={selectedSystemPrompt.prompt}
+                    readOnly={true}
+                    onSave={async (): Promise<void> => {
+                      //pass
+                    }}
+                    onSelect={(): void => {
+                      //pass
+                    }}
+                  >
+                    <div className="flex flex-row items-center gap-2">
+                      <div className="text-sm font-normal">
+                        Selected system prompt
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className="text-xs text-muted-foreground"
+                        title={
+                          selectedSystemPrompt.origin?.title ??
+                          'The prompt the gateway chose for this request, in place of the one the client sent'
+                        }
+                      >
+                        {selectedSystemPrompt.origin?.label ??
+                          'chosen by the skill'}
                       </Badge>
                     </div>
                   </GenericViewer>

--- a/packages/web/src/utils/log-exchange.test.ts
+++ b/packages/web/src/utils/log-exchange.test.ts
@@ -1,0 +1,89 @@
+import { FunctionName } from '@shared/types/api/request';
+import { AIProvider } from '@shared/types/constants';
+import type { Log } from '@shared/types/data/log';
+import { HttpMethod } from '@shared/types/http';
+import { CacheMode, CacheStatus } from '@shared/types/middleware/cache';
+import { exchangeOf } from '@web/utils/log-exchange';
+import { describe, expect, it, vi } from 'vitest';
+
+const ORIGIN = 'http://localhost:3000';
+
+const clientBody = {
+  model: 'gpt-4o',
+  messages: [{ role: 'user', content: 'Translate this.' }],
+};
+
+/** A row as it stands between arriving and being answered. */
+const running = (extra: Partial<Log> = {}): Log =>
+  ({
+    id: 'log-1',
+    method: HttpMethod.POST,
+    endpoint: '/v1/chat/completions',
+    function_name: FunctionName.CHAT_COMPLETE,
+    request_body: clientBody,
+    ai_provider_request_log: null,
+    ...extra,
+  }) as Log;
+
+/** The provider exchange a finished row carries. */
+const answered = {
+  provider: AIProvider.OPENAI,
+  function_name: FunctionName.CHAT_COMPLETE,
+  method: HttpMethod.POST,
+  request_url: 'https://api.openai.com/v1/chat/completions',
+  status: 200,
+  request_body: {
+    model: 'gpt-5.6',
+    messages: [{ role: 'system', content: 'You translate text.' }],
+  },
+  response_body: { choices: [{ message: { content: 'Traduis ceci.' } }] },
+  raw_request_body: '{}',
+  raw_response_body: '{}',
+  cache_mode: CacheMode.DISABLED,
+  cache_status: CacheStatus.MISS,
+} as Log['ai_provider_request_log'];
+
+describe('exchangeOf', () => {
+  it('shows the request the client made while it is still running', () => {
+    const data = exchangeOf(running(), ORIGIN);
+
+    expect(data?.functionName).toBe(FunctionName.CHAT_COMPLETE);
+    expect(data?.requestBody).toMatchObject(clientBody);
+    expect(data?.responseBody).toBeUndefined();
+  });
+
+  it('shows it for a request that failed before a provider answered', () => {
+    const data = exchangeOf(
+      running({ status: 502, error: 'connect ECONNREFUSED' }),
+      ORIGIN,
+    );
+
+    expect(data?.requestBody).toMatchObject(clientBody);
+  });
+
+  it('prefers what reached the provider once it has answered', () => {
+    // The prompt an optimized skill substituted is in the sent body, not in
+    // the client's, so a finished log reads from the provider exchange.
+    const data = exchangeOf(
+      running({ ai_provider_request_log: answered }),
+      ORIGIN,
+    );
+
+    expect(data?.requestBody).toMatchObject(answered?.request_body ?? {});
+    expect(data?.responseBody).toMatchObject(answered?.response_body ?? {});
+  });
+
+  it('is null for a row written before the request was recorded', () => {
+    expect(exchangeOf(running({ request_body: null }), ORIGIN)).toBeNull();
+  });
+
+  it('is null, not a throw, for a route this build cannot parse', () => {
+    const noise = vi.spyOn(console, 'error').mockImplementation(() => {
+      // The parse failure is reported, and not worth printing here.
+    });
+
+    expect(exchangeOf(running({ endpoint: '/v1/nowhere' }), ORIGIN)).toBeNull();
+
+    noise.mockRestore();
+  });
+});

--- a/packages/web/src/utils/log-exchange.ts
+++ b/packages/web/src/utils/log-exchange.ts
@@ -1,0 +1,58 @@
+import type { SuperAgentsRequestData } from '@shared/types/api/request/body';
+import type { Log } from '@shared/types/data/log';
+import { produceSuperAgentsRequestData } from '@shared/utils/sa-request-data';
+
+/**
+ * The exchange a log has to show: the request, and the answer when there is
+ * one.
+ *
+ * Once a provider has answered, that is the body the gateway sent and the
+ * body that came back. Until then -- a request still running, or one that
+ * failed before a provider was reached -- it is the request the client made,
+ * recorded when the row opened. That is the whole point of opening the row
+ * early: there is something to read before the answer exists, so a request
+ * in flight shows its own conversation rather than an empty card.
+ *
+ * `origin` is where the request arrived, since the row keeps the path it was
+ * served on rather than a whole URL.
+ *
+ * Null when the row carries neither, and when the route or the body shape is
+ * one this build can no longer parse: that should cost the log its view, not
+ * the dashboard its page.
+ */
+export function exchangeOf(
+  log: Log,
+  origin: string,
+): SuperAgentsRequestData | null {
+  const provider = log.ai_provider_request_log;
+  const sent = provider
+    ? {
+        method: provider.method,
+        url: provider.request_url,
+        requestBody: provider.request_body,
+        responseBody: provider.response_body,
+      }
+    : log.request_body
+      ? {
+          method: log.method,
+          url: new URL(log.endpoint, origin).href,
+          requestBody: log.request_body,
+          responseBody: null,
+        }
+      : null;
+
+  if (!sent) return null;
+
+  try {
+    return produceSuperAgentsRequestData(
+      sent.method,
+      sent.url,
+      {},
+      sent.requestBody,
+      sent.responseBody,
+    );
+  } catch (error) {
+    console.error('Failed to parse the log request data:', error);
+    return null;
+  }
+}

--- a/packages/web/src/utils/log-trace.test.ts
+++ b/packages/web/src/utils/log-trace.test.ts
@@ -55,6 +55,14 @@ const log = (extra: Partial<Log> = {}): Log =>
     ...extra,
   }) as Log;
 
+/** A routing decision, as the log row carries it. */
+const ROUTED = {
+  method: 'embedding',
+  similarity: 0.9,
+  threshold: 0.8,
+  candidates: 3,
+};
+
 /** The provider's own span, as the gateway records it. */
 const provider = (from: number, to: number) =>
   ({ start_time: from, end_time: to }) as Log['ai_provider_request_log'];
@@ -76,7 +84,7 @@ describe('traceOf', () => {
     );
 
     expect(stages?.map((stage) => [stage.label, stage.ms])).toEqual([
-      ['routing', 108_950],
+      ['setup', 108_950],
       ['provider', 7_867],
       ['review', 7_142],
     ]);
@@ -100,10 +108,10 @@ describe('traceOf', () => {
     );
 
     // The gateway's own work is named by where it falls: what ran before
-    // anything else is routing, what runs between two stages is the gateway,
+    // anything else is setup, what runs between two stages is the gateway,
     // and what is left at the end is the response.
     expect(stages?.map((stage) => stage.label)).toEqual([
-      'routing',
+      'setup',
       'check',
       'gateway',
       'provider',
@@ -144,7 +152,7 @@ describe('traceOf', () => {
     );
 
     expect(stages?.map((stage) => [stage.label, stage.ms])).toEqual([
-      ['routing', 1_000],
+      ['setup', 1_000],
       ['provider', 4_000],
       ['response', 4_000],
     ]);
@@ -162,9 +170,44 @@ describe('traceOf', () => {
       }),
     );
 
-    expect(stages?.map((stage) => stage.label)).toEqual([
-      'routing',
-      'provider',
+    expect(stages?.map((stage) => stage.label)).toEqual(['setup', 'provider']);
+  });
+
+  it('splits the head of the first gap into the routing it measured', () => {
+    // Routing is the one piece of the gateway's own work the row times, and
+    // it happens first, so the gap before the provider is cut at it rather
+    // than drawn as one bar that hides a model call inside it.
+    const stages = traceOf(
+      log({
+        metadata: { skill_routing: { ...ROUTED, duration_ms: 3_000 } },
+        ai_provider_request_log: provider(ARRIVED + 4_000, ARRIVED + 9_000),
+        end_time: ARRIVED + 9_000,
+        duration: 9_000,
+      }),
+    );
+
+    expect(stages?.map((stage) => [stage.label, stage.ms])).toEqual([
+      ['routing', 3_000],
+      ['setup', 1_000],
+      ['provider', 5_000],
+    ]);
+  });
+
+  it('gives routing the whole gap when it fills it', () => {
+    // The measurement and the gap come off different clocks, so routing can
+    // read as longer than the gap it sits in; it takes the gap, not more.
+    const stages = traceOf(
+      log({
+        metadata: { skill_routing: { ...ROUTED, duration_ms: 9_000 } },
+        ai_provider_request_log: provider(ARRIVED + 1_000, ARRIVED + 5_000),
+        end_time: ARRIVED + 5_000,
+        duration: 5_000,
+      }),
+    );
+
+    expect(stages?.map((stage) => [stage.label, stage.ms])).toEqual([
+      ['routing', 1_000],
+      ['provider', 4_000],
     ]);
   });
 

--- a/packages/web/src/utils/log-trace.ts
+++ b/packages/web/src/utils/log-trace.ts
@@ -1,5 +1,6 @@
 import type { Log } from '@shared/types/data/log';
 import { HookType } from '@shared/types/middleware/hooks';
+import { readSkillRouting } from '@web/utils/skill-routing';
 
 /**
  * A request's passage through the gateway, read off the row it left.
@@ -85,9 +86,9 @@ function gatewayStage(
 } {
   if (first) {
     return {
-      label: 'routing',
+      label: 'setup',
       detail:
-        "Choosing the skill, embedding the request and the gateway's own setup, before anything else had run.",
+        "Embedding the request, pulling the configuration that served it, and the gateway's own setup, before anything else had run.",
     };
   }
   if (last) {
@@ -131,19 +132,39 @@ export function traceOf(log: Log): TraceStage[] | null {
   const stages: TraceStage[] = [];
   let cursor = start;
 
+  // The one piece of the gateway's own work the row times: choosing the
+  // skill, for a request that named only the agent. It happens at the head
+  // of the first gap, so the gap is split at it rather than drawn as one
+  // bar that hides the model call inside it.
+  const routingMs = readSkillRouting(log.metadata)?.duration_ms ?? null;
+
   known.forEach((span, index) => {
     // Overlapping spans are read as one after another: a hook that started
     // before the previous stage ended keeps only the part that is its own.
     const from = Math.max(span.from, cursor);
     const gap = from - cursor;
-    if (gap >= NOISE_MS) {
-      const where = gatewayStage(stages.length, cursor === start, false);
+    const first = cursor === start;
+    // Only what is left of the gap once routing has had its share; a
+    // measurement longer than the gap it sits in takes the whole of it.
+    const routed = first && routingMs !== null ? Math.min(routingMs, gap) : 0;
+    if (routed > 0) {
+      stages.push({
+        key: `routing-${cursor}`,
+        kind: 'gateway',
+        label: 'routing',
+        detail:
+          'Choosing the skill for a request that named only its agent: embedding it, and on a miss the arbiter and the skill it created.',
+        ms: routed,
+      });
+    }
+    if (gap - routed >= NOISE_MS) {
+      const where = gatewayStage(stages.length, first, false);
       stages.push({
         key: `gateway-${cursor}`,
         kind: 'gateway',
         label: where.label,
         detail: where.detail,
-        ms: gap,
+        ms: gap - routed,
       });
     }
     if (span.to > from) {

--- a/packages/web/src/utils/skill-routing.ts
+++ b/packages/web/src/utils/skill-routing.ts
@@ -2,6 +2,7 @@ import {
   SkillRoutingDecision,
   type SkillRoutingMethod,
 } from '@shared/types/data/skill-routing';
+import { formatDuration } from '@web/utils/time';
 
 /** The routing decision a log carries, if the gateway chose its skill. */
 export function readSkillRouting(
@@ -44,7 +45,7 @@ const METHOD_TITLES: Record<SkillRoutingMethod, string> = {
 
 export interface SkillRoutingDescription {
   label: string;
-  /** Similarity against the threshold, when both were computed. */
+  /** Similarity against the threshold, and how long choosing took. */
   detail: string | null;
   title: string;
 }
@@ -53,7 +54,7 @@ export interface SkillRoutingDescription {
 export function describeSkillRouting(
   decision: SkillRoutingDecision,
 ): SkillRoutingDescription {
-  const { method, similarity, threshold, candidates } = decision;
+  const { method, similarity, threshold, candidates, duration_ms } = decision;
   const percent = (value: number): string => `${Math.round(value * 100)}%`;
   const parts: string[] = [];
   if (similarity !== null) {
@@ -67,6 +68,11 @@ export function describeSkillRouting(
   // label has already said there was only the one.
   if (candidates > 0 && method !== 'only_skill') {
     parts.push(`from ${candidates} skill${candidates === 1 ? '' : 's'}`);
+  }
+  // Time the client spent before the provider was even asked, which on the
+  // paths that call a model is most of what it waited for.
+  if (duration_ms !== undefined) {
+    parts.push(`took ${formatDuration(duration_ms)}`);
   }
   return {
     label: METHOD_LABELS[method],

--- a/supabase/migrations/20250703100411_initial_schema.sql
+++ b/supabase/migrations/20250703100411_initial_schema.sql
@@ -189,6 +189,11 @@ CREATE TABLE IF NOT EXISTS logs (
   start_time BIGINT NOT NULL, -- Timestamp (ms) when request started
   first_token_time BIGINT, -- Timestamp (ms) when first token received (for streaming), NULL for non-streaming
   base_sa_config JSONB NOT NULL,
+  -- The body the caller sent, recorded when the row opens: the only account
+  -- of a request that is still running, or that failed before a provider
+  -- answered. ai_provider_request_log holds the body that finally reached
+  -- the provider.
+  request_body JSONB,
   -- Null while the request is still running. The row is written when the
   -- request arrives rather than when it finishes, so that work in progress is
   -- visible and a request that fails before reaching a provider -- or never
@@ -208,6 +213,10 @@ CREATE TABLE IF NOT EXISTS logs (
   -- received. ai_provider_request_log holds the body that reached the
   -- provider, in which an optimized skill has substituted its own prompt.
   original_system_prompt TEXT,
+  -- The prompt the gateway chose, written as soon as the configuration
+  -- serving the request is pulled -- before the provider is asked, so that a
+  -- request still in flight can be read.
+  served_system_prompt TEXT,
   -- Cache info
   cache_status cache_status_enum,
   -- Why it failed, when it failed before a provider answered. A failure the


### PR DESCRIPTION
## Problem

A row is written when a request arrives, but it said only that a request existed. Opening it in the dashboard gave a header, a clock and an empty card: no messages, no prompt, nothing about which skill took the request or how long that took. Refreshing did not help, because none of it was in the database — the request body first reached a row at completion, inside `ai_provider_request_log`.

So the thing the early row exists for — making the wait legible — was still a spinner, and a request that failed before reaching a provider left a status and nothing to read.

## Solution

**The row carries the request.** Two nullable columns on `logs`, on both backends:

- `request_body` — the body the caller sent, written when the row opens. Until a provider answers this is the only account of what was asked; `ai_provider_request_log.request_body` remains what finally went out.
- `served_system_prompt` — the prompt the pulled configuration rendered, written before the provider is asked.

`metadata` is now written as the request progresses instead of only at the end, so a running row carries `skill_routing` and `served_configuration` in the same shape a finished one uses. The row is written a third time, from `saConfigurationInjectorMiddleware` once a configuration is pulled, adding `cluster_id` and the provider and model that will answer.

**The writes are chained** through a new `log_row_write` context variable. None is awaited by the request, so an earlier, emptier write landing last would put a running row back on top of a finished one. What closes the row waits on that chain — which also fixes a latent bug where `closeFailedRequest` could run before the row existed: `failLog` never creates a row, so such a request stayed open for ever.

**Routing is timed** around `routeRequestToSkill`, and the decision carries `duration_ms`. The client waits for all of it before the provider is asked, so the Routing strip reports it (`sent to the closest match · 91% match, needs 80% · from 3 skills · took 1.2s`) and `log-trace.ts` cuts it out of the head of the request's first gap. That gap was one bar labelled *routing* that actually hid the arbiter's model call inside it; what remains is now named *setup*.

**The page reads through `exchangeOf`** (`@web/utils/log-exchange`): the provider exchange when there is one, the client's own request until then. A request in flight — and one that failed before reaching a provider — shows its conversation, with the prompt the gateway selected in a panel of its own above it, badged with the partition and configuration it came from.

## Migrations

Both columns are nullable and additive, and the migrations are edited in place as the repo does while there are no deployments. `pnpm db:upgrade` grew a step for them: two `ALTER TABLE ... ADD COLUMN`, no table rebuild. Tested on a 2.4 GB copy of a real development database — both columns added, 8456 logs, 617 evaluation runs and 11 feedbacks intact, `logs_with_eval_scores` picks the columns up (SQLite expands `l.*` at query time), no foreign-key violations.

## Test notes

- `pnpm typecheck`, `pnpm check`, `pnpm test` — 3319 passing.
- New: `log-exchange.test.ts` (what the page renders from, running / failed / answered / unrecorded / unparseable), the ordering guarantee and the three writes in `logs.test.ts`, the routing split in `log-trace.test.ts`, and the running row's `request_body` in `e2e/contract/log-lifecycle.spec.ts` — in `contract/` because JSONB and TEXT round-trip that body through two hand-written conversions.
- `pnpm exec playwright test` — 92 passing against the built server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXi8tdtsnXJUJ7Vbe7trSs
